### PR TITLE
fix loading dynamic library

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1088,7 +1088,11 @@ function android.deplib_loader(modulename)
         -- try to load dependencies of this module with our dlopen implementation
         if readable(module) then
             android.LOGI("try to load module "..module)
-            if pcall(android.dl.dlopen, module) then return end
+            local ok, err = pcall(android.dl.dlopen, module)
+            if ok then return end
+            if err then
+                android.LOGI("error: " .. err)
+            end
         end
     end
 end
@@ -1168,7 +1172,9 @@ local function run(android_app_state)
 
     -- load the dlopen() implementation
     android.dl = require("dl")
-    android.dl.library_path = "/lib:/system/lib:"..android.nativeLibraryDir..":"..android.dir
+    android.dl.library_path = android.nativeLibraryDir..":"..
+        android.dir..":"..android.dir.."/libs:"..
+        "/lib:/system/lib:/lib/lib?.so:/system/lib/lib?.so"
 
     -- register the dependency lib loader
     table.insert(package.loaders, 3, android.deplib_loader)

--- a/assets/elf.lua
+++ b/assets/elf.lua
@@ -101,6 +101,8 @@ function Elf.open(filename)
     local e = {}
     e.filename = filename
     e.file = assert(io.open(filename, "r"), "cannot open file "..filename)
+    -- should also raise error if 'filename' is a directory
+    assert(e.file:read(0), filename .. " is not a regular file")
     setmetatable(e, Elf)
     return e
 end


### PR DESCRIPTION
There was a bug that when loading `ffi.load("ssl")`
it tried to read "/system/lib/ssl" directory and made dlopen fail.
This patch fixes this by testing if the filename is a regular file.