### PR TITLE
revert force allocation of one large mcode

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1,6 +1,3 @@
-require("jit.opt").start("sizemcode=512","maxmcode=512")
-for i=1,100 do end  -- Force allocation of the first segment
-
 local ffi = require("ffi")
 ffi.cdef[[
 // logging:


### PR DESCRIPTION
This can be done later with more user customization.