### PR TITLE
Add android.externalStorage function

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1297,6 +1297,22 @@ local function run(android_app_state)
             return is_charging == 1
         end)
     end
+    android.externalStorage = function()
+        return JNI:context(android.app.activity.vm, function(JNI)
+            local dir = JNI:callObjectMethod(
+                JNI:callStaticObjectMethod(
+                    "android/os/Environment",
+                    "getExternalStorageDirectory",
+                    "()Ljava/io/File;"
+                ),
+                "getAbsolutePath",
+                "()Ljava/lang/String;"
+            )
+            dir = JNI:to_string(dir)
+            android.LOGI("external storage " .. dir)
+            return dir
+        end)
+    end
     android.showProgress = function(title, message)
         android.LOGI("show progress dialog")
         JNI:context(android.app.activity.vm, function(JNI)

--- a/build.xml
+++ b/build.xml
@@ -29,12 +29,12 @@
     <property file="ant.properties" />
 
     <!-- if sdk.dir was not set from one of the property file, then
-         get it from the ANDROID_HOME env var.
+         get it from the ANDROID_SDK_ROOT env var.
          This must be done before we load project.properties since
          the proguard config can use sdk.dir -->
     <property environment="env" />
-    <condition property="sdk.dir" value="${env.ANDROID_HOME}">
-        <isset property="env.ANDROID_HOME" />
+    <condition property="sdk.dir" value="${env.ANDROID_SDK_ROOT}">
+        <isset property="env.ANDROID_SDK_ROOT" />
     </condition>
 
     <!-- The project.properties file is created and updated by the 'android'

--- a/mk-luajit.sh
+++ b/mk-luajit.sh
@@ -1,7 +1,7 @@
 # see http://luajit.org/install.html for details
 # there, a call like one of the following is recommended
 
-if [ "x$NDK" == "x" ]; then
+if [ "x$NDK" = "x" ]; then
 	NDK=/opt/android-ndk
 fi
 if [ ! -d "$NDK" ]; then


### PR DESCRIPTION
/sdcard of my device is not accessible from apps, which may be a bug of my device. But we definitely should use android.os.Environment.getExternalStorage() instead of hardcoded string for data folder.
So this change is to add this function in android-luajit-launcher layer.
One more change in koreader will use this function to replace the hardcoded /sdcard.

This change also contains an update build.xml and mk-luajit.sh to fix several typos.