### PR TITLE
adding mimetypes to open more supported files

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -24,6 +24,22 @@
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/pdf" />
+                <data android:mimeType="image/djvu" />
+                <data android:mimeType="image/vnd.djvu" />
+                <data android:mimeType="image/x-djvu". />
+                <data android:mimeType="application/x-cbz" />
+                <data android:mimeType="application/epub+zip" />
+                <data android:mimeType="application/x-fb2" />
+                <data android:mimeType="application/x-mobipocket-ebook" />
+                <data android:mimeType="application/msword" />
+                <data android:mimeType="application/x-chm" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:host="*" />
                 <data android:scheme="file" />


### PR DESCRIPTION
- based on https://github.com/SufficientlySecure/document-viewer/blob/master/document-viewer/src/main/AndroidManifest.xml
- fixes https://github.com/koreader/koreader/issues/3006 for PDFs (tested using the approach written in the issue; I did not build the app by myself, just changed this file in the .apk)
- I added other mimetypes based on the supported file types as written in https://github.com/koreader/koreader/blob/master/README.md but couldn't test them; you might want to add more