### PR TITLE
[fix] Normalize Android build

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3,7 +3,7 @@
       package="org.koreader.launcher"
       android:versionCode="3"
       android:versionName="1.3">
-    <uses-sdk android:minSdkVersion="9" />
+    <uses-sdk android:minSdkVersion="14" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 NDK_VER=$(shell grep -E 'NDKABI=[0-9]+' ./mk-luajit.sh | cut -d= -f2)
 
+# required for View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_LOW_PROFILE
+NDKABI_MIN_16=$(shell [ ${NDKABI} -ge 16 ] && echo -n ${NDKABI} || echo -n 16)
+
 apk: local.properties project.properties
 	git submodule init
 	git submodule sync
@@ -9,7 +12,7 @@ apk: local.properties project.properties
 	ant debug
 
 local.properties project.properties:
-	android update project --path . -t android-19
+	android update project --path . -t android-$(NDKABI_MIN_16)
 
 clean:
 	-ndk-build clean

--- a/mk-luajit.sh
+++ b/mk-luajit.sh
@@ -10,7 +10,7 @@ fi
 
 # NDKABI=21  # Android 5.0+
 # NDKABI=19  # Android 4.4+
-NDKABI=9 # Android 4.0+
+NDKABI=${NDKABI:-14} # Android 4.0+
 BUILD_ARCH=linux-$(uname -m)
 DEST=$(cd "$(dirname "$0")" && pwd)/jni/luajit-build/$1
 


### PR DESCRIPTION
There are different numbers all over the place, but I *think* the code points toward Android 4 (platform-14) as an intended target.

Also, by using `NDKABI=${NDKABI:-14}` we allow for environment variable overrides. It only sets the default of 14 if $NDKABI isn't set. This is in the same spirit as https://github.com/koreader/koreader/pull/3064