### PR TITLE
revert to min 9

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3,7 +3,7 @@
       package="org.koreader.launcher"
       android:versionCode="3"
       android:versionName="1.3">
-    <uses-sdk android:minSdkVersion="14" />
+    <uses-sdk android:minSdkVersion="9" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />

--- a/mk-luajit.sh
+++ b/mk-luajit.sh
@@ -10,7 +10,8 @@ fi
 
 # NDKABI=21  # Android 5.0+
 # NDKABI=19  # Android 4.4+
-NDKABI=${NDKABI:-14} # Android 4.0+
+#NDKABI=${NDKABI:-14} # Android 4.0+
+NDKABI=${NDKABI:-9} # Android 2.3+
 BUILD_ARCH=linux-$(uname -m)
 DEST=$(cd "$(dirname "$0")" && pwd)/jni/luajit-build/$1
 


### PR DESCRIPTION
I think the comment in here misled me. Everything builds under ABI 9 so there's no reason to enforce 14.