### PR TITLE
fix loading libandroid on MIUI ROMs

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="org.koreader.launcher"
-      android:versionCode="3"
-      android:versionName="1.3">
+      android:versionCode="4"
+      android:versionName="1.4">
     <uses-sdk android:minSdkVersion="9" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -10,14 +10,14 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <application android:icon="@drawable/icon" android:label="@string/app_name"
         android:hasCode="true" android:debuggable="true"
-        android:largeHeap="true">
+        android:largeHeap="true" android:vmSafeMode="true">
         <activity android:name="org.koreader.launcher.MainActivity"
                 android:label="@string/app_name"
                 android:screenOrientation="portrait"
                 android:launchMode="singleInstance"
                 android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
             <meta-data android:name="android.app.lib_name"
-                    android:value="luajit-launcher" />
+                    android:value="luajit" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/assets/dl.lua
+++ b/assets/dl.lua
@@ -75,10 +75,13 @@ function dl.dlopen(library, load_func)
             -- we do _not_ pass the load_func to the cascaded
             -- calls, so those will always use sys_dlopen()
             for _, needed in pairs(lib:dlneeds()) do
-                -- for android >= 6.0, you can't load system library anymore
-                -- and since we also have our own dl implementation, it's safe
-                -- to skip the stock libdl.
-                if needed ~= "libdl.so" then
+                if needed == "libluajit.so" then
+                    -- load the luajit-launcher libluajit with sys_dlopen
+                    load_func("libluajit.so")
+                elseif needed ~= "libdl.so" then
+                    -- for android >= 6.0, you can't load system library anymore
+                    -- and since we also have our own dl implementation, it's safe
+                    -- to skip the stock libdl.
                     dl.dlopen(needed)
                 end
             end

--- a/assets/install.lua
+++ b/assets/install.lua
@@ -21,9 +21,9 @@ local function install()
     local module = "module"
     local package_name = "koreader%-(.*)%.7z"
     local mgr = A.app.activity.assetManager
-    local asset_dir = ffi.C.AAssetManager_openDir(mgr, module)
+    local asset_dir = A.lib.AAssetManager_openDir(mgr, module)
     assert(asset_dir ~= nil, "could not open module directory in assets")
-    local filename = ffi.C.AAssetDir_getNextFileName(asset_dir)
+    local filename = A.lib.AAssetDir_getNextFileName(asset_dir)
     while filename ~= nil do
         filename = ffi.string(filename)
         A.LOGI(string.format("Check file in asset %s: %s", module, filename))
@@ -38,22 +38,22 @@ local function install()
             local package = A.dir.."/"..filename
             local buffer_size = 4096
             local buf = ffi.new("char[?]", buffer_size)
-            local asset = ffi.C.AAssetManager_open(mgr,
+            local asset = A.lib.AAssetManager_open(mgr,
                             ffi.cast("char*", module.."/"..filename),
                             ffi.C.AASSET_MODE_STREAMING);
             if asset ~= nil then
                 local output = ffi.C.fopen(ffi.cast("char*", package),
                                 ffi.cast("char*", "wb"))
-                local nb_read = ffi.C.AAsset_read(asset, buf,
+                local nb_read = A.lib.AAsset_read(asset, buf,
                                 ffi.new("int", buffer_size))
                 while nb_read > 0 do
                     ffi.C.fwrite(buf, ffi.new("int", nb_read),
                                 ffi.new("int", 1), output)
-                    nb_read = ffi.C.AAsset_read(asset, buf,
+                    nb_read = A.lib.AAsset_read(asset, buf,
                                 ffi.new("int", buffer_size))
                 end
                 ffi.C.fclose(output)
-                ffi.C.AAsset_close(asset)
+                A.lib.AAsset_close(asset)
                 -- unpack to data directory
                 local args = {"7z", "x", package, A.dir}
                 local argv = ffi.new("char*[?]", #args+1)
@@ -67,9 +67,9 @@ local function install()
                 break
             end
         end
-        filename = ffi.string(ffi.C.AAssetDir_getNextFileName(asset_dir))
+        filename = ffi.string(A.lib.AAssetDir_getNextFileName(asset_dir))
     end
-    ffi.C.AAssetDir_close(asset_dir)
+    A.lib.AAssetDir_close(asset_dir)
 end
 
 install()

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -41,7 +41,7 @@ include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE    := luajit-launcher
+LOCAL_MODULE    := luajit
 LOCAL_SRC_FILES := android-main.c
 # remember to add libraries here that you plan to use via FFI:
 LOCAL_LDLIBS    := -lm -llog -landroid

--- a/src/org/koreader/launcher/MainActivity.java
+++ b/src/org/koreader/launcher/MainActivity.java
@@ -22,7 +22,7 @@ public class MainActivity extends NativeActivity {
     }
 
     static {
-        System.loadLibrary("luajit-launcher");
+        System.loadLibrary("luajit");
     }
 
     private static String TAG = "luajit-launcher";
@@ -162,7 +162,7 @@ public class MainActivity extends NativeActivity {
             }
         });
     }
-    
+
     public int getStatusBarHeight() {
 	    Rect rectangle = new Rect();
 		Window window = getWindow();
@@ -170,19 +170,19 @@ public class MainActivity extends NativeActivity {
 		int statusBarHeight = rectangle.top;
 		return statusBarHeight;
 	}
-	
+
 	private Point getSceenSize() {
 		Display display = getWindowManager().getDefaultDisplay();
 		Point size = new Point();
 		display.getSize(size);
 		return size;
 	}
-	
+
 	public int getScreenWidth() {
 		int width = getSceenSize().x;
 		return width;
 	}
-	
+
 	public int getScreenHeight(){
 		int height = getSceenSize().y;
 		return height;


### PR DESCRIPTION
Xiaomi MIUI ROMs won't load libandroid.so to the global namespace. We have to load the library by ourselves.