### PR TITLE
[chore] Respond to ANDROID_ARCH environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
 NDK_VER=$(shell grep -E 'NDKABI=[0-9]+' ./mk-luajit.sh | cut -d= -f2)
 
+# Android is kind of bizarre. Sometimes you need specific stuff.
+# Other times you need just `arm` or else…
+# For `x86` and `x86_64` it's all good.
+ifdef ANDROID_ARCH
+	ifeq ($(ANDROID_ARCH), arm)
+		ANDROID_FULL_ARCH?=armeabi-v7a
+	else
+		ANDROID_FULL_ARCH?=$(ANDROID_ARCH)
+	endif
+endif
+ANDROID_FULL_ARCH?=armeabi-v7a
+
 # at least 16 is required to create a build with View.SYSTEM_UI_FLAG_FULLSCREEN
 # and View.SYSTEM_UI_FLAG_LOW_PROFILE
 # however, default to 19 because that's what the nightly build server uses
@@ -9,8 +21,8 @@ apk: local.properties project.properties
 	git submodule init
 	git submodule sync
 	git submodule update
-	./mk-luajit.sh armeabi-v7a
-	ndk-build
+	./mk-luajit.sh $(ANDROID_FULL_ARCH)
+	ndk-build ANDROID_FULL_ARCH=$(ANDROID_FULL_ARCH)
 	ant debug
 
 local.properties project.properties:

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -29,7 +29,7 @@ DEFLATE7_DIR := $(LOCAL_PATH)/compress-deflate7
 PATCH_OUTPUT := $(shell cd $(DEFLATE7_DIR) && patch -N -p1 < ../7zMain.patch)
 lzma_SOURCES := \
         7zStream.c 7zFile.c Ppmd7Dec.c Ppmd7.c Bcj2.c \
-        Bra86.c Bra.c Lzma2Dec.c LzmaDec.c 7zIn.c 7zDec.c \
+        Bra86.c Bra.c CpuArch.c Lzma2Dec.c LzmaDec.c 7zIn.c 7zDec.c \
         7zCrcOpt.c 7zCrc.c 7zBuf2.c 7zBuf.c 7zAlloc.c \
         Util/7z/7zMain.c
 

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -3,5 +3,5 @@
 # since luajit is built separately, build one after the other, each
 # with an according LuaJIT build
 #APP_ABI := armeabi armeabi-v7a
-APP_ABI := armeabi-v7a
-APP_PLATFORM := android-9
+APP_ABI := $(ANDROID_FULL_ARCH)
+APP_PLATFORM := android-$(NDKABI)

--- a/mk-luajit.sh
+++ b/mk-luajit.sh
@@ -17,7 +17,7 @@ DEST=$(cd "$(dirname "$0")" && pwd)/jni/luajit-build/$1
 
 echo "Using NDKABI ${NDKABI}."
 
-NDKVER=$(grep -oP 'r\K([0-9]+)(?=[a-z])' ${NDK}/CHANGELOG.md)
+NDKVER=$(grep -oP 'r\K([0-9]+)(?=[a-z])' ${NDK}/CHANGELOG.md | head -1)
 echo "Detected NDK version ${NDKVER}..."
 if [ "$NDKVER" -lt 11 ]; then
     echo 'NDK not of the right version, please update to NDK version 11 or higher.'


### PR DESCRIPTION
Can create an x86 packages combined with  https://github.com/koreader/koreader-base/pull/544

References https://github.com/koreader/koreader/issues/1815

You'll need to manually `./mk-luajit.sh clean` in between builds
for different architectures for the moment.