### PR TITLE
Change screenOrientation to sensorPortrait

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:largeHeap="true" android:vmSafeMode="true">
         <activity android:name="org.koreader.launcher.MainActivity"
                 android:label="@string/app_name"
-                android:screenOrientation="portrait"
+                android:screenOrientation="sensorPortrait"
                 android:launchMode="singleInstance"
                 android:theme="@style/Fullscreen">
             <meta-data android:name="android.app.lib_name"


### PR DESCRIPTION
Allows for flipping device orientation: holding it upside-down may be more confortable than the default portrait orientation the maker decided for.

References:
https://stackoverflow.com/questions/582185/android-disable-landscape-mode/582585#582585
https://stackoverflow.com/questions/9801580/screen-orientation-and-values-in-manifest-xml/9801725#9801725
https://developer.android.com/guide/topics/manifest/activity-element.html#screen

Got hold of a cheap tablet on which I tried koreader: koreader was stuck to a single portrait orientation (all the other apps were following 180° device rotation). This default orientation was not confortable (thin side, volume keys, warm area are then at the bottom right corner in my right hand).
I first solved it by using in patch.lua some tricks with:
```
self.bb:setRotation(2) -- in overidden framebuffer_android:init()
Device.input:registerEventAdjustHook(Device.input.adjustTouchMirrorX, Device.screen:getWidth())
Device.input:registerEventAdjustHook(Device.input.adjustTouchMirrorY, Device.screen:getHeight())
```
which was fine enough (except that swiping from the top shows the bottom menu, and swiping from the bottom shows the status bar, inverted :)

This is probably the most proper way to solve my problem (tested with apktool d / edit / apktoll b / sign apk)
However, it may not please trapezists, fakirs and gymnasts if they read while practicing :|
