### PR TITLE
setFullscreenLayout() without delay as well

### DIFF
--- a/src/org/koreader/launcher/MainActivity.java
+++ b/src/org/koreader/launcher/MainActivity.java
@@ -47,7 +47,10 @@ public class MainActivity extends NativeActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        // set fullscreen immediately on general principle
+        setFullscreenLayout();
 
+        // set fullscreen delayed because presumably some devices don't work right otherwise
         final Handler handler = new Handler();
         handler.postDelayed(new Runnable() {
             @Override


### PR DESCRIPTION
Otherwise the bottom part of the screen where the controls were can remain black. The delay seems to have no positive effects in my various VMs.

Also see https://www.mobileread.com/forums/showpost.php?p=3665118&postcount=160