### PR TITLE
bump minimum target to API14, minimum NDK version to 15 and minimum SDK version to 19.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3,7 +3,7 @@
       package="org.koreader.launcher"
       android:versionCode="4"
       android:versionName="1.4">
-    <uses-sdk android:minSdkVersion="9" />
+    <uses-sdk android:minSdkVersion="14" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
-NDK_VER=$(shell grep -E 'NDKABI=[0-9]+' ./mk-luajit.sh | cut -d= -f2)
+# Supported Android ABIs: armeabi-v7a, x86 and x86_64
 
-# Android is kind of bizarre. Sometimes you need specific stuff.
-# Other times you need just `arm` or else…
-# For `x86` and `x86_64` it's all good.
 ifdef ANDROID_ARCH
 	ifeq ($(ANDROID_ARCH), arm)
 		ANDROID_FULL_ARCH?=armeabi-v7a
@@ -10,12 +7,12 @@ ifdef ANDROID_ARCH
 		ANDROID_FULL_ARCH?=$(ANDROID_ARCH)
 	endif
 endif
+
+# Default is build for arm
 ANDROID_FULL_ARCH?=armeabi-v7a
 
-# at least 16 is required to create a build with View.SYSTEM_UI_FLAG_FULLSCREEN
-# and View.SYSTEM_UI_FLAG_LOW_PROFILE
-# however, default to 19 because that's what the nightly build server uses
-NDKABI_MIN_16=$(shell [ ${NDKABI} -ge 16 ] && echo -n ${NDKABI} || echo -n 19)
+# Minimum SDK API is 19, required to use View.VERSION_CODES.KITKAT
+SDKAPI_MIN=$(shell [ ${NDKABI} -ge 19 ] && echo -n ${NDKABI} || echo -n 19)
 
 apk: local.properties project.properties
 	git submodule init
@@ -27,7 +24,7 @@ apk: local.properties project.properties
         #gradle debug
 
 local.properties project.properties:
-	android update project --path . -t android-$(NDKABI_MIN_16)
+	android update project --path . -t android-$(SDKAPI_MIN}
 
 clean:
 	-ndk-build clean

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1254,31 +1254,41 @@ local function run(android_app_state)
         end)
     end
 
+    android.getProduct = function()
+        return JNI:context(android.app.activity.vm, function(JNI)
+            local product = JNI:callObjectMethod(
+                android.app.activity.clazz,
+                "getProduct",
+                "()Ljava/lang/String;"
+            )
+            return JNI:to_string(product) or "unknown"
+        end)
+    end
+
     android.getScreenWidth = function()
         return JNI:context(android.app.activity.vm, function(JNI)
-            local width = JNI:callIntMethod(
+            return JNI:callIntMethod(
                 android.app.activity.clazz,
                 "getScreenWidth",
                 "()I"
             )
-            android.LOGV("get screen width  " .. width)
-            return width
         end)
     end
+
     android.getScreenHeight = function()
         return JNI:context(android.app.activity.vm, function(JNI)
-            local height = JNI:callIntMethod(
+            return JNI:callIntMethod(
                 android.app.activity.clazz,
                 "getScreenHeight",
                 "()I"
             )
-            android.LOGV("get screen height  " .. height)
-            return height
         end)
     end
+
     android.screen = {}
     android.screen.width = android.getScreenWidth()
     android.screen.height = android.getScreenHeight()
+
     android.getScreenBrightness = function()
         return JNI:context(android.app.activity.vm, function(JNI)
             local str_brightness = JNI.env[0].NewStringUTF(JNI.env, "screen_brightness")
@@ -1297,6 +1307,7 @@ local function run(android_app_state)
             return res
         end)
     end
+
     android.setScreenBrightness = function(brightness)
         android.LOGV("set screen brightness "..brightness)
         JNI:context(android.app.activity.vm, function(JNI)
@@ -1315,28 +1326,27 @@ local function run(android_app_state)
             )
         end)
     end
+
     android.getBatteryLevel = function()
         return JNI:context(android.app.activity.vm, function(JNI)
-            local level = JNI:callIntMethod(
+            return JNI:callIntMethod(
                 android.app.activity.clazz,
                 "getBatteryLevel",
                 "()I"
             )
-            android.LOGV("get battery level " .. level)
-            return level
         end)
     end
+
     android.isCharging = function()
         return JNI:context(android.app.activity.vm, function(JNI)
-            local is_charging = JNI:callIntMethod(
+            return JNI:callIntMethod(
                 android.app.activity.clazz,
                 "isCharging",
                 "()I"
-            )
-            android.LOGV("is charging " .. is_charging)
-            return is_charging == 1
+            ) == 1
         end)
     end
+
     android.externalStorage = function()
         return JNI:context(android.app.activity.vm, function(JNI)
             local dir = JNI:callObjectMethod(
@@ -1353,6 +1363,7 @@ local function run(android_app_state)
             return dir
         end)
     end
+
     android.showProgress = function(title, message)
         android.LOGV("show progress dialog")
         JNI:context(android.app.activity.vm, function(JNI)
@@ -1368,6 +1379,7 @@ local function run(android_app_state)
             JNI.env[0].DeleteLocalRef(JNI.env, message)
         end)
     end
+
     android.dismissProgress = function()
         android.LOGV("dismiss progress dialog")
         JNI:context(android.app.activity.vm, function(JNI)
@@ -1379,17 +1391,17 @@ local function run(android_app_state)
             )
         end)
     end
+
     android.isFullscreen = function()
         return JNI:context(android.app.activity.vm, function(JNI)
-            local fullscreen = JNI:callIntMethod(
+            return JNI:callIntMethod(
                 android.app.activity.clazz,
                 "isFullscreen",
                 "()I"
-            )
-            android.LOGI("is fullscreen = ", fullscreen)
-            return fullscreen == 1
+            ) == 1
         end)
     end
+
     android.setFullscreen = function(fullscreen)
         android.LOGV("setting fullscreen to " .. tostring(fullscreen))
         JNI:context(android.app.activity.vm, function(JNI)
@@ -1421,21 +1433,17 @@ local function run(android_app_state)
                 "getClipboardText",
                 "()Ljava/lang/String;"
             )
-            text = JNI:to_string(text)
-            android.LOGV("clipboard text copied: " .. text)
-            return text
+            return JNI:to_string(text)
         end)
     end
 
     android.hasClipboardText = function()
         return JNI:context(android.app.activity.vm, function(JNI)
-            local hasClipboardText = JNI:callIntMethod(
+            return JNI:callIntMethod(
                 android.app.activity.clazz,
                 "hasClipboardTextIntResultWrapper",
                 "()I"
-            )
-            android.LOGV("Has text in clipboard: ", hasClipboardText)
-            return hasClipboardText == 1
+            ) == 1
         end)
     end
 
@@ -1455,13 +1463,11 @@ local function run(android_app_state)
 
     android.isWifiEnabled = function()
         return JNI:context(android.app.activity.vm, function(JNI)
-            local isWifiEnabled = JNI:callIntMethod(
+            return JNI:callIntMethod(
                 android.app.activity.clazz,
                 "isWifiEnabled",
                 "()I"
-            )
-            android.LOGV("is WifiEnabled =", isWifiEnabled)
-            return isWifiEnabled == 1
+            ) == 1
         end)
     end
 
@@ -1479,13 +1485,11 @@ local function run(android_app_state)
 
     android.getStatusBarHeight = function()
         return JNI:context(android.app.activity.vm, function(JNI)
-            local statusBarHeight = JNI:callIntMethod(
+            return JNI:callIntMethod(
                 android.app.activity.clazz,
                 "getStatusBarHeight",
                 "()I"
             )
-            android.LOGV("get status bar height  " .. statusBarHeight)
-            return statusBarHeight
         end)
     end
 
@@ -1513,9 +1517,9 @@ local function run(android_app_state)
         end
         return process
     end
+
     android.execute = function(...)
         local argv = {...}
-        android.LOGI("run command " .. table.concat(argv, " "))
         return JNI:context(android.app.activity.vm, function(JNI)
             local process = subprocess(JNI, argv)
             local stdout = JNI:callObjectMethod(
@@ -1547,18 +1551,22 @@ local function run(android_app_state)
                 end
             end
             local res = JNI:callIntMethod(process, "waitFor", "()I")
-            android.LOGV("command stdout:" .. out)
-            android.LOGV("command stderr:" .. err)
-            android.LOGI("command res:" .. res)
+
+            if res > 0 then
+                android.LOGW(string.format("command %s returned %d", table.concat(argv, " "), res))
+            else
+                android.LOGI(string.format("command %s returned %d", table.concat(argv, " "), res))
+            end
+            android.LOGV(string.format(" stdout: %s\n stderr: %s", out, err))
             JNI.env[0].DeleteLocalRef(JNI.env, process)
             JNI.env[0].DeleteLocalRef(JNI.env, stdout)
             JNI.env[0].DeleteLocalRef(JNI.env, stderr)
             return res
         end)
     end
+
     android.stdout = function(...)
         local argv = {...}
-        android.LOGI("run command " .. table.concat(argv, " "))
         return JNI:context(android.app.activity.vm, function(JNI)
             local process = subprocess(JNI, argv)
             local stdout = JNI:callObjectMethod(
@@ -1575,22 +1583,21 @@ local function run(android_app_state)
                     break
                 end
             end
-            android.LOGI("command output:" .. out)
             JNI.env[0].DeleteLocalRef(JNI.env, process)
             JNI.env[0].DeleteLocalRef(JNI.env, stdout)
             return out
         end)
     end
+
     os.execute = function(command) -- luacheck: ignore 122
         if command == nil then return -1 end
         local argv = {}
         command:gsub("([^ ]+)", function(arg) table.insert(argv, arg) end)
         return android.execute(unpack(argv))
     end
+
     android.LOGI("Application data directory "..android.dir)
     android.LOGI("Application library directory "..android.nativeLibraryDir)
-    android.LOGI("Screen size "..android.screen.width.."x"..android.screen.height)
-    android.LOGI("Screen brightness "..android.getScreenBrightness())
 
     -- register the "android" module (ourself)
     package.loaded.android = android

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1265,6 +1265,18 @@ local function run(android_app_state)
         end)
     end
 
+    android.getVersion =  function()
+        return JNI:context(android.app.activity.vm, function(JNI)
+            local version = JNI:callObjectMethod(
+                android.app.activity.clazz,
+                "getVersion",
+                "()Ljava/lang/String;"
+            )
+            return JNI:to_string(version) or ""
+        end)
+    end
+
+
     android.getScreenWidth = function()
         return JNI:context(android.app.activity.vm, function(JNI)
             return JNI:callIntMethod(

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1300,6 +1300,7 @@ local function run(android_app_state)
     android.screen = {}
     android.screen.width = android.getScreenWidth()
     android.screen.height = android.getScreenHeight()
+    android.LOGV("Screen size "..android.screen.width.."x"..android.screen.height)
 
     android.getScreenBrightness = function()
         return JNI:context(android.app.activity.vm, function(JNI)

--- a/jni/android-main.c
+++ b/jni/android-main.c
@@ -29,8 +29,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "luajit-2.1/lualib.h"
 #include "luajit-2.1/lauxlib.h"
 
-#define  LOGI(...)  __android_log_print(ANDROID_LOG_INFO,"luajit-launcher",__VA_ARGS__)
 #define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR,"luajit-launcher",__VA_ARGS__)
+#define  LOGV(...)  __android_log_print(ANDROID_LOG_VERBOSE,"luajit-launcher",__VA_ARGS__)
 #define  LOADER_ASSET "android.lua"
 
 
@@ -43,11 +43,11 @@ static void handle_cmd(struct android_app* app, int32_t cmd) {
         case APP_CMD_INIT_WINDOW:
             // The window is being shown, get it ready.
             window_ready = 1;
-            LOGI("App window ready.");
+            LOGV("App window ready.");
             break;
         case APP_CMD_GAINED_FOCUS:
             gained_focus = 1;
-            LOGI("App gained focus.");
+            LOGV("App gained focus.");
             break;
     }
 }
@@ -61,7 +61,7 @@ void android_main(struct android_app* state) {
 
     // wait until everything is initialized before launching LuaJIT assets
     state->onAppCmd = handle_cmd;
-    LOGI("Waiting for app ready...");
+    LOGV("Waiting for app ready...");
     int events;
     struct android_poll_source* source;
     // we block forever waiting for events.
@@ -79,7 +79,7 @@ void android_main(struct android_app* state) {
         }
     }
 
-    LOGI("Launching LuaJIT assets...");
+    LOGV("Launching LuaJIT assets...");
     luaCode = AAssetManager_open(state->activity->assetManager, LOADER_ASSET, AASSET_MODE_BUFFER);
     if (luaCode == NULL) {
         LOGE("error loading loader asset");

--- a/mk-luajit.sh
+++ b/mk-luajit.sh
@@ -4,8 +4,8 @@
 
 # NDKABI=21  # Android 5.0+
 # NDKABI=19  # Android 4.4+
-#NDKABI=${NDKABI:-14} # Android 4.0+
-NDKABI=${NDKABI:-9} # Android 2.3+
+NDKABI=${NDKABI:-14} # Android 4.0+
+#NDKABI=${NDKABI:-9} # Android 2.3+
 DEST=$(cd "$(dirname "$0")" && pwd)/jni/luajit-build/$1
 # might be linux-x86_64 or darwin-x86-64
 HOST_ARCH="*"
@@ -21,8 +21,8 @@ function check_NDK() {
 
     NDKVER=$(grep -oP 'r\K([0-9]+)(?=[a-z])' ${NDK}/CHANGELOG.md | head -1)
     echo "Detected NDK version ${NDKVER}..."
-    if [ "$NDKVER" -lt 11 ]; then
-        echo 'NDK not of the right version, please update to NDK version 11 or higher.'
+    if [ "$NDKVER" -lt 15 ]; then
+        echo 'NDK not of the right version, please update to NDK version 15 or higher.'
         exit 1
     fi
 }

--- a/src/org/koreader/launcher/MainActivity.java
+++ b/src/org/koreader/launcher/MainActivity.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 public class MainActivity extends NativeActivity {
 
     private final static int SDK_INT = android.os.Build.VERSION.SDK_INT;
+    private final static String VERSION = android.os.Build.VERSION.RELEASE;
     private final static String PRODUCT_ID = android.os.Build.PRODUCT;
     private final static String LOGGER_NAME = "luajit-launcher";
 
@@ -373,6 +374,10 @@ public class MainActivity extends NativeActivity {
 
     public String getProduct() {
         return PRODUCT_ID;
+    }
+
+    public String getVersion() {
+        return VERSION;
     }
 
     private class Box<T> {

--- a/src/org/koreader/launcher/MainActivity.java
+++ b/src/org/koreader/launcher/MainActivity.java
@@ -11,6 +11,7 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.net.wifi.WifiManager;
 import android.os.BatteryManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.Settings;
@@ -25,9 +26,7 @@ import java.util.concurrent.CountDownLatch;
 
 public class MainActivity extends NativeActivity {
 
-    private final static int SDK_INT = android.os.Build.VERSION.SDK_INT;
-    private final static String VERSION = android.os.Build.VERSION.RELEASE;
-    private final static String PRODUCT_ID = android.os.Build.PRODUCT;
+    private final static int SDK_INT = Build.VERSION.SDK_INT;
     private final static String LOGGER_NAME = "luajit-launcher";
 
     static {
@@ -103,12 +102,12 @@ public class MainActivity extends NativeActivity {
     }
 
     private void setFullscreenLayout() {
-        if (SDK_INT < 16) {
+        if (SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
             getWindow().getDecorView().setSystemUiVisibility(View.STATUS_BAR_HIDDEN);
-        } else if (SDK_INT >= 16 && SDK_INT < 19) {
+        } else if (SDK_INT < Build.VERSION_CODES.KITKAT) {
             getWindow().getDecorView().setSystemUiVisibility(
                 View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_LOW_PROFILE);
-        } else if (SDK_INT >= 19) {
+        } else {
             getWindow().getDecorView().setSystemUiVisibility(
                 View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
                     View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
@@ -373,11 +372,11 @@ public class MainActivity extends NativeActivity {
     }
 
     public String getProduct() {
-        return PRODUCT_ID;
+        return Build.PRODUCT;
     }
 
     public String getVersion() {
-        return VERSION;
+        return Build.VERSION.RELEASE;
     }
 
     private class Box<T> {

--- a/src/org/koreader/launcher/MainActivity.java
+++ b/src/org/koreader/launcher/MainActivity.java
@@ -80,7 +80,6 @@ public class MainActivity extends NativeActivity {
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
-        logActivity("new intent");
         setIntent(intent);
     }
 
@@ -98,7 +97,7 @@ public class MainActivity extends NativeActivity {
     }
 
     private void logActivity(final String state) {
-        Log.v(LOGGER_NAME, String.format("== %S", state));
+        Log.v(LOGGER_NAME, String.format("App %s", state));
     }
 
     private void setFullscreenLayout() {

--- a/src/org/koreader/launcher/MainActivity.java
+++ b/src/org/koreader/launcher/MainActivity.java
@@ -38,7 +38,7 @@ public class MainActivity extends NativeActivity {
 
     public MainActivity() {
         super();
-        Log.v(LOGGER_NAME, "Creating luajit launcher main activity");
+        Log.i(LOGGER_NAME, "Creating luajit launcher main activity");
     }
 
     @Override


### PR DESCRIPTION
It should be possible to build for API 11 (since both clipboard and screenSize work) changing to `<uses-sdk android:minSdkVersion="11" />.`

related to https://github.com/koreader/koreader/issues/4471

added a function to get sdk version from frontend.
setFullscreen should be now easier to understand.
slightly more verbose if requested.

#### For the future:

- handle configurationChanges
- provide a method to dump logs to sdcard: we need a permission for that. read logs. It is easy to implement. Just add the permission in AndroidManifest.xml and use `android.execute("logcat KOReader:V *:I -d /sdcard/koreader/koreader.log")