### PR TITLE
use java target/source 1.6

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -8,6 +8,8 @@
 
     <property name="java.target" value="1.6" />
     <property name="java.source" value="1.6" />
+    <property name="java.compilerargs" value="-Xlint:deprecation" />
+
 
     <!-- The ant.properties file can be created by you. It is only edited by the
          'android' tool to add properties to it.

--- a/build.xml
+++ b/build.xml
@@ -6,6 +6,9 @@
          Version Control Systems. -->
     <property file="local.properties" />
 
+    <property name="java.target" value="1.6" />
+    <property name="java.source" value="1.6" />
+
     <!-- The ant.properties file can be created by you. It is only edited by the
          'android' tool to add properties to it.
          This is the place to change some Ant specific build properties.


### PR DESCRIPTION
It removes some warnings building against JDK8. In theory it supports building with JDK11/10 too, but I didn't test it.

Related to https://github.com/koreader/koreader/issues/4511#issue-403240699 and https://github.com/koreader/koreader/issues/4511#issuecomment-457757843