### PR TITLE
suppress 'safe' deprecations:

### DIFF
--- a/src/org/koreader/launcher/MainActivity.java
+++ b/src/org/koreader/launcher/MainActivity.java
@@ -107,6 +107,7 @@ public class MainActivity extends NativeActivity {
         Log.v(LOGGER_NAME, String.format("App %s", state));
     }
 
+    @SuppressWarnings("deprecation")
     private void setFullscreenLayout() {
         if (SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
             getWindow().getDecorView().setSystemUiVisibility(View.STATUS_BAR_HIDDEN);

--- a/src/org/koreader/launcher/WakeLockHelper.java
+++ b/src/org/koreader/launcher/WakeLockHelper.java
@@ -9,6 +9,7 @@ import android.util.Log;
  * Used to keep CPU, display and touchscreen
  * idle for a long time without sleep. */
 
+@SuppressWarnings("deprecation")
 public abstract class WakeLockHelper {
     private static PowerManager.WakeLock wakelock;
     private static final String LOGGER_NAME = "luajit-launcher";


### PR DESCRIPTION
STATUSBAR_HIDDEN is used on API<16 only
WAKELOCKS are all deprecated except PARTIAL, as the time of writting they're available on lastest Android version (9).