### PR TITLE
set android versionCode and android versionName at buildtime

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="org.koreader.launcher"
-      android:versionCode="4"
-      android:versionName="1.4"
+      android:versionCode="5"
+      android:versionName="1.5"
     >
     <uses-sdk android:minSdkVersion="14" />
     <uses-sdk android:targetSdkVersion="19" />

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2,7 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="org.koreader.launcher"
       android:versionCode="4"
-      android:versionName="1.4">
+      android:versionName="1.4"
+    >
     <uses-sdk android:minSdkVersion="14" />
     <uses-sdk android:targetSdkVersion="19" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 # Supported Android ABIs: armeabi-v7a, x86 and x86_64
-
 ifdef ANDROID_ARCH
 	ifeq ($(ANDROID_ARCH), arm)
 		ANDROID_FULL_ARCH?=armeabi-v7a
@@ -11,13 +10,35 @@ endif
 # Default is build for arm
 ANDROID_FULL_ARCH?=armeabi-v7a
 
-# Minimum SDK API is 19, required to use View.VERSION_CODES.KITKAT
-SDKAPI_MIN=$(shell [ ${NDKABI} -ge 19 ] && echo -n ${NDKABI} || echo -n 19)
+# API19 is used by the docker build image.
+# It's also required to use View.VERSION_CODES.KITKAT.
+TARGET_API=19
+
+ifdef NDKABI
+	# Update target API if is higher than current target
+	SDKAPI=$(shell [ ${NDKABI} -gt ${TARGET_API} ] && echo -n ${NDKABI} || echo -n ${TARGET_API})
+endif
+
+SDKAPI?=$(TARGET_API)
+
+# override android:versionName="string"
+ifdef ANDROID_NAME
+	NAME?=$(ANDROID_NAME)
+endif
+
+# override android:versionCode="integer"
+ifdef ANDROID_VERSION
+	VERSION?=$(ANDROID_VERSION)
+endif
+
+# Defaults
+NAME?=1.4
+VERSION?=4
 
 update:
 	# update local.properties and project.properties with sdk/ndk paths for current user
 	# this works with sdk tools <= 25.3.0
-	android update project --path . -t android-$(SDKAPI_MIN)
+	android update project --path . -t android-$(SDKAPI)
 
 	# update sources
 	git submodule init
@@ -30,16 +51,20 @@ build-native:
 	ndk-build ANDROID_FULL_ARCH=$(ANDROID_FULL_ARCH)
 
 debug: update build-native
+	# build signed debug apk.
 	ant debug
 	cp -pv bin/NativeActivity-debug.apk bin/NativeActivity.apk
 	@echo "application was built, type: debug (signed)"
 
 release: update build-native
-	ant release
+        # build unsigned release apk, with version code and version name
+	@echo "Building release APK, Version $(NAME), release $(VERSION)"
+	ant -Dname=$(NAME) -Dcode=$(VERSION) release
 	cp -pv bin/NativeActivity-release-unsigned.apk bin/NativeActivity.apk
-	@echo "application was built, type: release (unsigned)"
-	@echo "You'll need to sign this application to be able to install it"
+	@echo "application was built, type: release (unsigned), version: $(NAME), release $(VERSION), api $(SDKAPI)"
+	@echo "WARNING: You'll need to sign this application to be able to install it"
 
 clean:
+	ndk-build ANDROID_FULL_ARCH=$(ANDROID_FULL_ARCH) clean
 	./mk-luajit.sh clean
 	rm -rf bin obj libs gen jni/luajit-build local.properties assets/module

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ ifdef ANDROID_VERSION
 endif
 
 # Defaults
-NAME?=1.4
-VERSION?=4
+NAME?=1.5
+VERSION?=5
 
 update:
 	# update local.properties and project.properties with sdk/ndk paths for current user
@@ -51,8 +51,8 @@ build-native:
 	ndk-build ANDROID_FULL_ARCH=$(ANDROID_FULL_ARCH)
 
 debug: update build-native
-	# build signed debug apk.
-	ant debug
+	# build signed debug apk, with version code and version name
+	ant -Dname=$(NAME) -Dcode=$(VERSION) debug
 	cp -pv bin/NativeActivity-debug.apk bin/NativeActivity.apk
 	@echo "application was built, type: debug (signed)"
 

--- a/build.xml
+++ b/build.xml
@@ -26,15 +26,26 @@
     <loadproperties srcFile="project.properties" />
 
     <!-- Override android:versionName and android:versionCode with commandline arguments -->
-    <target name="set-version-using-commandline-args">
+    <target name="-pre-build">
+        <echo message="Creating a backup of AndroidManifest.xml"/>
+        <copy file="AndroidManifest.xml" tofile="AndroidManifest.backup" preservelastmodified="false" />
+        <echo message="Overriding version code from AndroidManifest.xml"/>
         <replaceregexp
             file="AndroidManifest.xml"
             match="android:versionCode(.*)"
             replace='android:versionCode="${code}"'/>
+        <echo message="Overriding version name from AndroidManifest.xml"/>
         <replaceregexp
             file="AndroidManifest.xml"
             match="android:versionName(.*)"
             replace='android:versionName="${name}"'/>
+    </target>
+
+    <!-- Restore AndroidManifest.xml to its original state -->
+    <target name="-post-build">
+        <echo message="Restoring the AndroidManifest.xml backup"/>
+        <copy file="AndroidManifest.backup" tofile="AndroidManifest.xml" preservelastmodified="false" />
+        <delete file="AndroidManifest.backup" />
     </target>
 
     <!-- Disable png crunching, because it's incompatible with reproducible builds -->

--- a/build.xml
+++ b/build.xml
@@ -25,6 +25,19 @@
          This contains project specific properties such as project target, and library dependencies. -->
     <loadproperties srcFile="project.properties" />
 
+    <!-- Override android:versionName and android:versionCode with commandline arguments -->
+    <target name="set-version-using-commandline-args">
+        <replaceregexp
+            file="AndroidManifest.xml"
+            match="android:versionCode(.*)"
+            replace='android:versionCode="${code}"'/>
+        <replaceregexp
+            file="AndroidManifest.xml"
+            match="android:versionName(.*)"
+            replace='android:versionName="${name}"'/>
+    </target>
+
+    <!-- Disable png crunching, because it's incompatible with reproducible builds -->
     <target name="-crunch">
         <echo message="Skipping png optimization"/>
     </target>


### PR DESCRIPTION
Related to https://github.com/koreader/koreader/issues/2040
Fixes #105 

In particular with @Frenzie comment:

> So we'd just force-feed the right values into https://github.com/koreader/android-luajit-launcher/blob/8825b5d9d1c9cc11770c4c8acc099a1b60a16022/AndroidManifest.xml#L4-L5 (whether through Ant or by modifying that file dynamically).

Now ant support dynamic versioning with -Dcode and -Dname. Makefile was upgraded to override AndroidManifest.xml values.

For example: 
```Makefile
make ANDROID_NAME=2018.12-100-deadbeef ANDROID_VERSION=100 release
...
BUILD SUCCESSFUL
Total time: 1 second
cp -pv bin/NativeActivity-release-unsigned.apk bin/NativeActivity.apk
'bin/NativeActivity-release-unsigned.apk' -> 'bin/NativeActivity.apk'
application was built, type: release (unsigned), version: 2018.12-100-deadbeef, release 100, api 19
WARNING: You'll need to sign this application to be able to install it
```

If no ANDROID_VERSION/ANDROID_NAME args are passed to the Makefile it will use a set of defaults (the same used by AndroidManifest).


It also fixes a error message in a comparaison when NDKABI was not used to build the program.