### PR TITLE
[chore, CI] Add shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ addons:
 # check for XML syntax errors
 script:
   - find . -type f -iname '*.xml' -exec xmllint {} + >/dev/null
-  - bash -c 'shopt -s globstar; shellcheck **/*.{sh,ksh,bash}'
+  - bash -c 'shopt -s globstar; shellcheck **/*.sh'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,6 @@ addons:
       - libxml2-utils
 
 # check for XML syntax errors
-script: find . -type f -iname '*.xml' -exec xmllint {} + >/dev/null
+script:
+  - find . -type f -iname '*.xml' -exec xmllint {} + >/dev/null
+  - bash -c 'shopt -s globstar; shellcheck **/*.{sh,ksh,bash}'

--- a/eink-test/copyEPDControllers.sh
+++ b/eink-test/copyEPDControllers.sh
@@ -7,9 +7,9 @@ TARGET_PATH="src/org/koreader/einkTest"
 ROCKCHIP_PATH="${BASE_PATH}/rockchip"
 ROCKCHIP_EPD="RK30xxEPDController"
 
-for EPD in "${ROCKCHIP_EPD}"; do
+for EPD in ${ROCKCHIP_EPD}; do
     src="${ROCKCHIP_PATH}/${EPD}.java"
     dest="${TARGET_PATH}/${EPD}.java"
     echo "copying ${EPD} controller from ${src} to ${dest}"
-    sed 's/package org.koreader.device.rockchip/package org.koreader.einkTest/' "${src}" > "${dest}"
+    sed 's/package org.koreader.device.rockchip/package org.koreader.einkTest/' "${src}" >"${dest}"
 done


### PR DESCRIPTION
To prevent things like this:

```
In platform/android/luajit-launcher/eink-test/copyEPDControllers.sh line 10:
for EPD in "${ROCKCHIP_EPD}"; do
           ^-- SC2066: Since you double quoted this, it will not word split, and the loop will only run once.
```