### PR TITLE
exit after crashing, to avoid unknown states

### DIFF
--- a/jni/android-main.c
+++ b/jni/android-main.c
@@ -117,7 +117,7 @@ void android_main(struct android_app* state) {
     lua_close(L);
 
 quit:
-    LOGE("Destroying Native Activity due to previous errors");
+    LOGE("Destroying NativeActivity due to previous errors");
     ANativeActivity_finish(state->activity);
     exit(1);
 }

--- a/jni/android-main.c
+++ b/jni/android-main.c
@@ -117,5 +117,7 @@ void android_main(struct android_app* state) {
     lua_close(L);
 
 quit:
+    LOGE("Destroying Native Activity due to previous errors");
     ANativeActivity_finish(state->activity);
+    exit(1);
 }


### PR DESCRIPTION
Related to https://github.com/koreader/koreader/issues/4543

Exit android_main if the application fails trying to load assets, libraries or trying to run a lua file.

This makes possible to start the activity again when requested without having to "force kill" the application manually.