### PR TITLE
Layout fixes

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -15,7 +15,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <application android:icon="@drawable/icon" android:label="@string/app_name"
         android:largeHeap="true" android:vmSafeMode="true">
-        <meta-data android:name="android.max_aspect" android:value="2.1" />
+        <meta-data android:name="android.max_aspect" android:value="3.1" />
         <activity android:name="org.koreader.launcher.MainActivity"
                 android:label="@string/app_name"
                 android:screenOrientation="sensorPortrait"

--- a/src/org/koreader/launcher/ScreenHelper.java
+++ b/src/org/koreader/launcher/ScreenHelper.java
@@ -121,24 +121,6 @@ public class ScreenHelper {
         }
     }
 
-    @SuppressWarnings("deprecation")
-    public void setFullscreenLayout() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-            ((Activity)context).getWindow().getDecorView().setSystemUiVisibility(View.STATUS_BAR_HIDDEN);
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
-            ((Activity)context).getWindow().getDecorView().setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_LOW_PROFILE);
-        } else {
-            ((Activity)context).getWindow().getDecorView().setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
-                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
-                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
-                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
-                    View.SYSTEM_UI_FLAG_FULLSCREEN |
-                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-        }
-    }
-
     private Point getScreenSize() {
         Point size = new Point();
         Display display = ((Activity)context).getWindowManager().getDefaultDisplay();


### PR DESCRIPTION
Should fix https://github.com/koreader/koreader/issues/4584

I based this on ndk samples (teapots). But the sample is broken (it sets a listener on visibility changes and even then it calls setImmersiveSticky).

This also removes one of the deprecations (if google's code isnt' totally borked). I tested this on emulator 9/4.2. Can't test in 4.0.3 because google efforts to make our life harder (support for sdcard is broken).

