### PR TITLE
[wip]: add basic support for downloads and notifications

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1529,18 +1529,18 @@ local function run(android_app_state)
     end
 
     android.download = function(url, name)
-        android.LOGV("downloading " .. name .. " from " .. url)
         return JNI:context(android.app.activity.vm, function(JNI)
             local uri_string = JNI.env[0].NewStringUTF(JNI.env, url)
             local download_name = JNI.env[0].NewStringUTF(JNI.env, name)
-            JNI:callVoidMethod(
+            local is_downloaded = JNI:callIntMethod(
                 android.app.activity.clazz,
                 "download",
-                "(Ljava/lang/String;Ljava/lang/String;)V",
+                "(Ljava/lang/String;Ljava/lang/String;)I",
                 uri_string, download_name
-            )
+            ) == 1
             JNI.env[0].DeleteLocalRef(JNI.env, uri_string)
             JNI.env[0].DeleteLocalRef(JNI.env, download_name)
+            return is_downloaded
         end)
     end
 

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1528,6 +1528,35 @@ local function run(android_app_state)
         end)
     end
 
+    android.download = function(url, name)
+        android.LOGV("downloading " .. name .. " from " .. url)
+        return JNI:context(android.app.activity.vm, function(JNI)
+            local uri_string = JNI.env[0].NewStringUTF(JNI.env, url)
+            local download_name = JNI.env[0].NewStringUTF(JNI.env, name)
+            JNI:callVoidMethod(
+                android.app.activity.clazz,
+                "download",
+                "(Ljava/lang/String;Ljava/lang/String;)V",
+                uri_string, download_name
+            )
+            JNI.env[0].DeleteLocalRef(JNI.env, uri_string)
+            JNI.env[0].DeleteLocalRef(JNI.env, download_name)
+        end)
+    end
+
+    android.notification = function(message)
+        return JNI:context(android.app.activity.vm, function(JNI)
+            local text = JNI.env[0].NewStringUTF(JNI.env, message)
+            JNI:callVoidMethod(
+                android.app.activity.clazz,
+                "showToast",
+                "(Ljava/lang/String;)V",
+                text
+            )
+            JNI.env[0].DeleteLocalRef(JNI.env, text)
+        end)
+    end
+
     android.getStatusBarHeight = function()
         return JNI:context(android.app.activity.vm, function(JNI)
             return JNI:callIntMethod(

--- a/src/org/koreader/launcher/MainActivity.java
+++ b/src/org/koreader/launcher/MainActivity.java
@@ -16,6 +16,8 @@ import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
 
+import java.io.File;
+
 import org.koreader.device.DeviceInfo;
 import org.koreader.device.EPDController;
 import org.koreader.device.EPDFactory;
@@ -275,13 +277,20 @@ public class MainActivity extends android.app.NativeActivity {
         return String.format("%s;%s;%s", wi.getSSID(), ip_address, gw_address);
     }
 
-    public void download(final String url, final String name) {
+    public int download(final String url, final String name) {
+        File file = new File(Environment.getExternalStoragePublicDirectory(
+            Environment.DIRECTORY_DOWNLOADS) + "/" + name);
+
+        Log.v(LOGGER_NAME, file.getAbsolutePath());
+        if (file.exists()) return 1;
+
         DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url));
         request.allowScanningByMediaScanner();
         request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
         request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, name);
         DownloadManager manager = (DownloadManager) getSystemService(Context.DOWNLOAD_SERVICE);
         manager.enqueue(request);
+        return 0;
     }
 
     // ----------------------------------

--- a/src/org/koreader/launcher/MainActivity.java
+++ b/src/org/koreader/launcher/MainActivity.java
@@ -1,16 +1,20 @@
 package org.koreader.launcher;
 
+import android.app.DownloadManager;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.net.DhcpInfo;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.text.format.Formatter;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
 import android.os.Handler;
 import android.util.Log;
 import android.view.View;
+import android.widget.Toast;
 
 import org.koreader.device.DeviceInfo;
 import org.koreader.device.EPDController;
@@ -159,7 +163,17 @@ public class MainActivity extends android.app.NativeActivity {
         epd.setEpdMode(root_view, mode_name);
     }
 
-    /** dialogs */
+    /** native dialogs and widgets run on UI Thread */
+    public void showToast(final String message) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                final Toast toast = Toast.makeText(MainActivity.this, message, Toast.LENGTH_SHORT);
+                toast.show();
+            }
+        });
+    }
+
     public void showProgress(final String title, final String message) {
         runOnUiThread(new Runnable() {
             @Override
@@ -259,6 +273,15 @@ public class MainActivity extends android.app.NativeActivity {
         }
 
         return String.format("%s;%s;%s", wi.getSSID(), ip_address, gw_address);
+    }
+
+    public void download(final String url, final String name) {
+        DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url));
+        request.allowScanningByMediaScanner();
+        request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+        request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, name);
+        DownloadManager manager = (DownloadManager) getSystemService(Context.DOWNLOAD_SERVICE);
+        manager.enqueue(request);
     }
 
     // ----------------------------------


### PR DESCRIPTION
probably android.notification can be repurposed to notify certain error conditions.

As happens with dialogs, we cannot interact with toasts. We can show elements on top of our activity but we can't touch them. We will need a separate activity if we want that (and we won't want that!)