### PR TITLE
show in the app picker for supported mimetypes **just** if scheme=file.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -30,6 +30,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" />
                 <data android:mimeType="application/pdf" />
                 <data android:mimeType="image/djvu" />
                 <data android:mimeType="image/vnd.djvu" />


### PR DESCRIPTION
# android bullshit starts:

for android 4.0 - 7.1 the application will be shown in the application picker for viewing supported documents
for android 8.0+ the application will be ignored even on supported documents. 

related to https://github.com/koreader/koreader/issues/4441

