### PR TITLE
set logger name at build time (based on application name)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ gen/
 libs/
 obj/
 assets/module
+jni/logger.h
 jni/luajit-build
 eink-test/bin
 eink-test/gen

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ ifdef ANDROID_VERSION
 	VERSION?=$(ANDROID_VERSION)
 endif
 
+# support different app names
+ifdef ANDROID_APPNAME
+	APPNAME?=$(ANDROID_APPNAME)
+endif
+
 # support different flavors
 ifdef ANDROID_FLAVOR
 	FLAVOR?=$(ANDROID_FLAVOR)
@@ -39,6 +44,7 @@ endif
 # Defaults
 NAME?=1.5
 VERSION?=5
+APPNAME?="luajit-launcher"
 FLAVOR?="rocks"
 
 update:
@@ -54,20 +60,21 @@ update:
 build-native:
 	# build luajit, lzma and native activity for desired arch (armeabi-v7a, x86, x86_64)
 	./mk-luajit.sh $(ANDROID_FULL_ARCH)
+	@echo "#define LOGGER_NAME \"$(APPNAME)\"" > jni/logger.h
 	ndk-build ANDROID_FULL_ARCH=$(ANDROID_FULL_ARCH)
 
 debug: update build-native
 	# build signed debug apk, with version code and version name
-	ant -Dname=$(NAME) -Dcode=$(VERSION) -Dflavor=$(FLAVOR) debug
+	ant -Dname=$(NAME) -Dcode=$(VERSION) -DappName=$(APPNAME) -Dflavor=$(FLAVOR) debug
 	cp -pv bin/NativeActivity-debug.apk bin/NativeActivity.apk
 	@echo "application was built, type: debug (signed)"
 
 release: update build-native
         # build unsigned release apk, with version code and version name
 	@echo "Building release APK, Version $(NAME), release $(VERSION)"
-	ant -Dname=$(NAME) -Dcode=$(VERSION) -Dflavor=$(FLAVOR) release
+	ant -Dname=$(NAME) -Dcode=$(VERSION) -DappName=$(APPNAME) -Dflavor=$(FLAVOR) release
 	cp -pv bin/NativeActivity-release-unsigned.apk bin/NativeActivity.apk
-	@echo "application was built, type: release (unsigned), flavor: $(FLAVOR), version: $(NAME), release $(VERSION), api $(SDKAPI)"
+	@echo "application $(APPNAME) was built, type: release (unsigned), flavor: $(FLAVOR), version: $(NAME), release $(VERSION), api $(SDKAPI)"
 	@echo "WARNING: You'll need to sign this application to be able to install it"
 
 clean:

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1287,6 +1287,20 @@ local function run(android_app_state)
         end)
     end
 
+    android.getName = function()
+        return JNI:context(android.app.activity.vm, function(JNI)
+            local name = JNI:callObjectMethod(
+                android.app.activity.clazz,
+                "getName",
+                "()Ljava/lang/String;"
+            )
+            return JNI:to_string(name)
+        end)
+    end
+
+    -- update logger name
+    android.log_name = android.getName()
+
     android.getScreenWidth = function()
         return JNI:context(android.app.activity.vm, function(JNI)
             return JNI:callIntMethod(

--- a/build.xml
+++ b/build.xml
@@ -37,7 +37,13 @@
             match="android:versionName(.*)"
             replace='android:versionName="${name}"'/>
 
-        <!-- Override android flavor too -->
+        <!-- Override android appname & flavor too -->
+        <echo message="Overriding android app name"/>
+        <replaceregexp
+            file="res/values/strings.xml"
+            match='name="app_name"(.*)'
+            replace='name="app_name"&gt;${appName}&lt;\/string&gt;'/>
+
         <echo message="Overriding android flavor"/>
         <replaceregexp
             file="res/values/strings.xml"

--- a/eink-test/src/org/koreader/test/eink/MainActivity.java
+++ b/eink-test/src/org/koreader/test/eink/MainActivity.java
@@ -96,7 +96,7 @@ public class MainActivity extends android.app.Activity {
 	        RK30xxEPDController.requestEpdMode(v, "EPD_FULL", true);
             } else if (test == RK33xxNORMAL) {
                 Log.i(TAG, "rockchip 33xx normal update");
-                RK33xxEPDController.requestEpdMode();
+                RK33xxEPDController.requestEpdMode("EPD_FULL");
             } else if (test == FAKE) {
                 Log.i(TAG, "fake update");
             } else {

--- a/jni/android-main.c
+++ b/jni/android-main.c
@@ -31,8 +31,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "luajit-2.1/lualib.h"
 #include "luajit-2.1/lauxlib.h"
 
-#define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR,"luajit-launcher",__VA_ARGS__)
-#define  LOGV(...)  __android_log_print(ANDROID_LOG_VERBOSE,"luajit-launcher",__VA_ARGS__)
+#include "logger.h"
+
+#define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR,LOGGER_NAME,__VA_ARGS__)
+#define  LOGV(...)  __android_log_print(ANDROID_LOG_VERBOSE,LOGGER_NAME,__VA_ARGS__)
 #define  LOADER_ASSET "android.lua"
 
 
@@ -119,7 +121,7 @@ void android_main(struct android_app* state) {
     lua_close(L);
 
 quit:
-    LOGE("Destroying NativeActivity due to previous errors");
+    LOGE("Destroying activity due to previous errors");
     ANativeActivity_finish(state->activity);
     exit(1);
 }

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">KOReader</string>
+    <string name="app_name">luajit-launcher</string>
     <string name="app_flavor">rocks</string>
 </resources>

--- a/src/org/koreader/device/DeviceInfo.java
+++ b/src/org/koreader/device/DeviceInfo.java
@@ -6,8 +6,6 @@
 package org.koreader.device;
 
 import android.os.Build;
-import android.util.Log;
-
 import java.util.HashMap;
 import java.util.Iterator;
 
@@ -113,7 +111,16 @@ public class DeviceInfo {
 
 
         // true if we found a supported device
-        IS_EINK_SUPPORTED = (EINK_BOYUE_T62 || EINK_BOYUE_T61 || EINK_BOYUE_T80S || EINK_BOYUE_T103D || EINK_ONYX_C67 || EINK_ENERGY || EINK_INKBOOK);
+        IS_EINK_SUPPORTED = (
+            EINK_BOYUE_T61 ||
+            EINK_BOYUE_T62 ||
+            EINK_BOYUE_T78D ||
+            EINK_BOYUE_T80D ||
+            EINK_BOYUE_T103D ||
+            EINK_ENERGY ||
+            EINK_INKBOOK ||
+            EINK_ONYX_C67
+        );
 
         // find current device.
         Iterator<Device> iter = deviceMap.keySet().iterator();
@@ -132,7 +139,6 @@ public class DeviceInfo {
         try {
             return (String)Build.class.getField(fieldName).get(null);
         } catch (Exception e) {
-            Log.w("luajit-launcher", "Exception while trying to check Build." + fieldName);
             return "";
         }
     }

--- a/src/org/koreader/device/EPDFactory.java
+++ b/src/org/koreader/device/EPDFactory.java
@@ -6,16 +6,18 @@
 package org.koreader.device;
 
 import android.view.View;
+import android.util.Log;
 
 import org.koreader.device.rockchip.RK3026EPDController;
 import org.koreader.device.rockchip.RK3066EPDController;
 import org.koreader.device.rockchip.RK3368EPDController;
 
-
 public class EPDFactory {
 
-    public static EPDController getEPDController() {
+    public static EPDController getEPDController(final String TAG) {
         EPDController epdController = null;
+        String controllerName = null;
+
         switch (DeviceInfo.CURRENT_DEVICE) {
 
             /** Supported rk3026 devices */
@@ -24,11 +26,13 @@ public class EPDFactory {
             case EINK_ONYX_C67:
             case EINK_ENERGY:
             case EINK_INKBOOK:
+                controllerName = "Rockchip RK3026";
                 epdController = new RK3026EPDController();
                 break;
 
             /** supported rk3066 devices */
             case EINK_BOYUE_T62:
+                controllerName = "Rockchip RK3066";
                 epdController = new RK3066EPDController();
                 break;
 
@@ -36,6 +40,7 @@ public class EPDFactory {
             case EINK_BOYUE_T80D:
             case EINK_BOYUE_T78D:
             case EINK_BOYUE_T103D:
+                controllerName = "Rockchip RK3368";
                 epdController = new RK3368EPDController();
                 break;
 
@@ -46,6 +51,13 @@ public class EPDFactory {
 
             default : break;
         }
+
+        if (controllerName != null) {
+            Log.i(TAG, String.format("Using %s EPD Controller", controllerName));
+        } else {
+            Log.w(TAG, "Device does not have an eink screen or driver is unsupported");
+        }
+
         return epdController;
     }
 

--- a/src/org/koreader/device/rockchip/RK30xxEPDController.java
+++ b/src/org/koreader/device/rockchip/RK30xxEPDController.java
@@ -36,7 +36,7 @@ public abstract class RK30xxEPDController
         EPD_POWEROFF
     }
 
-    public static final String LOGGER_NAME = "luajit-launcher";
+    public static final String TAG = "epd";
 
     public static final String EPD_NULL = "EPD_NULL";
 
@@ -73,11 +73,11 @@ public abstract class RK30xxEPDController
             isInA2.setAccessible(true);
 
         } catch (ClassNotFoundException e) {
-            Log.e(LOGGER_NAME, e.toString());
+            Log.e(TAG, e.toString());
         } catch (NoSuchMethodException e) {
-            Log.e(LOGGER_NAME, e.toString());
+            Log.e(TAG, e.toString());
         } catch (NoSuchFieldException e) {
-            Log.e(LOGGER_NAME, e.toString());
+            Log.e(TAG, e.toString());
         }
     }
 
@@ -85,10 +85,10 @@ public abstract class RK30xxEPDController
     {
         try {
             boolean value = (Boolean)isInA2.get(view);
-            Log.d(LOGGER_NAME, "isInA2 : " + value);
+            Log.d(TAG, "isInA2 : " + value);
             return value;
         } catch (IllegalAccessException e) {
-            Log.e(LOGGER_NAME, e.toString());
+            Log.e(TAG, e.toString());
             return false;
         }
     }
@@ -99,10 +99,10 @@ public abstract class RK30xxEPDController
             requestEpdModeMethod1.invoke(view, stringToEnum(mode));
             return true;
         } catch (IllegalAccessException e) {
-            Log.e(LOGGER_NAME, e.toString());
+            Log.e(TAG, e.toString());
             return false;
         } catch (InvocationTargetException e) {
-            Log.e(LOGGER_NAME, e.toString());
+            Log.e(TAG, e.toString());
             return false;
         }
     }
@@ -112,10 +112,10 @@ public abstract class RK30xxEPDController
             requestEpdModeMethod2.invoke(view, stringToEnum(mode), flag);
             return true;
         } catch (IllegalAccessException e) {
-            Log.e(LOGGER_NAME, e.toString());
+            Log.e(TAG, e.toString());
             return false;
         } catch (InvocationTargetException e) {
-            Log.e(LOGGER_NAME, e.toString());
+            Log.e(TAG, e.toString());
             return false;
         }
     }

--- a/src/org/koreader/device/rockchip/RK33xxEPDController.java
+++ b/src/org/koreader/device/rockchip/RK33xxEPDController.java
@@ -11,7 +11,7 @@ import android.util.Log;
 
 @SuppressWarnings("unchecked")
 public abstract class RK33xxEPDController {
-    private static final String TAG = "luajit-launcher";
+    private static final String TAG = "epd";
     public static final int EPD_FULL = 1;
     public static final int EPD_A2 = 2;
     public static final int EPD_PART = 3;

--- a/src/org/koreader/launcher/Clipboard.java
+++ b/src/org/koreader/launcher/Clipboard.java
@@ -5,17 +5,19 @@ import android.content.Context;
 import android.content.ClipData;
 import android.content.ClipDescription;
 import android.content.ClipboardManager;
-import android.util.Log;
 
 import java.util.concurrent.CountDownLatch;
+
 
 public class Clipboard {
     private Context context;
     private ClipboardManager clipboard;
+    private String TAG;
 
     public Clipboard(Context context) {
         this.context = context;
         this.clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+        this.TAG = context.getResources().getString(R.string.app_name);
     }
 
     public String getClipboardText() {
@@ -30,7 +32,7 @@ public class Clipboard {
                         result.value = item.getText().toString();
                     }
                 } catch (Exception e) {
-                    Log.e("luajit-launcher", "clipboard error: " + e.toString());
+                    Logger.e(TAG, "clipboard error: " + e.toString());
                     result.value = "";
                 }
                 cd.countDown();
@@ -56,7 +58,7 @@ public class Clipboard {
                     ClipData clip = ClipData.newPlainText("KOReader_clipboard", text);
                     clipboard.setPrimaryClip(clip);
                 } catch (Exception e) {
-                    Log.e("luajit-launcher", "clipboard error: " + e.toString());
+                    Logger.e(TAG, "clipboard error: " + e.toString());
                 }
             }
         });

--- a/src/org/koreader/launcher/Logger.java
+++ b/src/org/koreader/launcher/Logger.java
@@ -1,0 +1,21 @@
+package org.koreader.launcher;
+
+import android.util.Log;
+
+public class Logger {
+    public static void d(final String TAG, final String message) {
+        Log.d(TAG, message);
+    }
+    public static void v(final String TAG, final String message) {
+        Log.v(TAG, message);
+    }
+    public static void i(final String TAG, final String message) {
+        Log.i(TAG, message);
+    }
+    public static void w(final String TAG, final String message) {
+        Log.w(TAG, message);
+    }
+    public static void e(final String TAG, final String message) {
+        Log.e(TAG, message);
+    }
+}

--- a/src/org/koreader/launcher/PowerHelper.java
+++ b/src/org/koreader/launcher/PowerHelper.java
@@ -5,12 +5,12 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.BatteryManager;
 import android.os.PowerManager;
-import android.util.Log;
 
 
 public class PowerHelper {
     private static final String WAKELOCK_ID = "ko-wakelock";
 
+    private String TAG;
     private Context context;
     private IntentFilter filter;
     private PowerManager.WakeLock wakelock;
@@ -20,6 +20,7 @@ public class PowerHelper {
         /* use application context */
         this.context = context.getApplicationContext();
         this.filter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
+        this.TAG = context.getResources().getString(R.string.app_name);
     }
 
     public int batteryPercent() {
@@ -68,14 +69,14 @@ public class PowerHelper {
             wakelockRelease();
             PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
             wakelock = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK, WAKELOCK_ID);
-            Log.v("luajit-launcher", "wakelock: acquiring " + WAKELOCK_ID);
+            Logger.v(TAG, "wakelock: acquiring " + WAKELOCK_ID);
             wakelock.acquire();
         }
     }
 
     private void wakelockRelease() {
         if (isWakeLockAllowed && wakelock != null) {
-            Log.v("luajit-launcher", "wakelock: releasing " + WAKELOCK_ID);
+            Logger.v(TAG, "wakelock: releasing " + WAKELOCK_ID);
             wakelock.release();
             wakelock = null;
         }

--- a/src/org/koreader/launcher/ScreenHelper.java
+++ b/src/org/koreader/launcher/ScreenHelper.java
@@ -6,7 +6,6 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.Display;
 import android.view.Window;
 import android.view.WindowManager;
@@ -14,10 +13,12 @@ import android.view.WindowManager;
 import java.util.concurrent.CountDownLatch;
 
 public class ScreenHelper {
+    private String TAG;
     private Context context;
 
     public ScreenHelper(Context context) {
         this.context = context;
+        this.TAG = context.getResources().getString(R.string.app_name);
     }
 
     /** Screen size */
@@ -49,7 +50,7 @@ public class ScreenHelper {
                         context.getContentResolver(),
                         Settings.System.SCREEN_BRIGHTNESS));
                 } catch (Exception e) {
-                    Log.e("luajit-launcher", "getBrightness error: " + e.toString());
+                    Logger.e(TAG, "getBrightness error: " + e.toString());
                     result.value = new Integer(0);
                 }
                 cd.countDown();
@@ -82,7 +83,7 @@ public class ScreenHelper {
                     Settings.System.putInt(context.getContentResolver(),
                         Settings.System.SCREEN_BRIGHTNESS, brightness);
                 } catch (Exception e) {
-                    Log.e("luajit-launcher", "setBrightness error: " + e.toString());
+                    Logger.e(TAG, "setBrightness error: " + e.toString());
                 }
             }
         });
@@ -106,7 +107,7 @@ public class ScreenHelper {
                         window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
                     }
                 } catch (Exception e) {
-                    Log.e("luajit-launcher", "setFullscreen error: " + e.toString());
+                    Logger.e(TAG, "setFullscreen error: " + e.toString());
                 }
                 cd.countDown();
             }


### PR DESCRIPTION
So we are logging everything to "KOReader" or whatever ANDROID_APPNAME used to build the NativeActivity.

Fixes #135 

Fixed eink-test which I broke updating RK33xx driver.
Fixed (again) mars and muses which weren't recognized as eink devices :/

I will write the companion frontend changes later today!