### PR TITLE
add logd to log luajit-launcher debug strings

### DIFF
--- a/src/org/koreader/device/EPDFactory.java
+++ b/src/org/koreader/device/EPDFactory.java
@@ -54,8 +54,6 @@ public class EPDFactory {
 
         if (controllerName != null) {
             Log.i(TAG, String.format("Using %s EPD Controller", controllerName));
-        } else {
-            Log.w(TAG, "Device does not have an eink screen or driver is unsupported");
         }
 
         return epdController;

--- a/src/org/koreader/launcher/Logger.java
+++ b/src/org/koreader/launcher/Logger.java
@@ -4,7 +4,9 @@ import android.util.Log;
 
 public class Logger {
     public static void d(final String TAG, final String message) {
-        Log.d(TAG, message);
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, message);
+        }
     }
     public static void v(final String TAG, final String message) {
         Log.v(TAG, message);

--- a/src/org/koreader/launcher/MainActivity.java
+++ b/src/org/koreader/launcher/MainActivity.java
@@ -37,10 +37,6 @@ public class MainActivity extends android.app.NativeActivity {
     private PowerHelper power;
     private ScreenHelper screen;
 
-    public MainActivity() {
-        super();
-    }
-
     /** Called when the activity is first created. */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -48,7 +44,7 @@ public class MainActivity extends android.app.NativeActivity {
 
         // set a tag for logging
         TAG = getName();
-        Logger.i(TAG, "Creating main activity");
+        Logger.d(TAG, "App created");
 
         // set a epd controller for eink devices
         epd = EPDFactory.getEPDController(TAG);
@@ -74,7 +70,7 @@ public class MainActivity extends android.app.NativeActivity {
     /** Called when the activity has become visible. */
     @Override
     protected void onResume() {
-        Logger.v(TAG, "App resumed");
+        Logger.d(TAG, "App resumed");
         power.setWakelock(true);
         super.onResume();
         /** switch to fullscreen for older devices */
@@ -92,7 +88,7 @@ public class MainActivity extends android.app.NativeActivity {
     /** Called when another activity is taking focus. */
     @Override
     protected void onPause() {
-        Logger.v(TAG, "App paused");
+        Logger.d(TAG, "App paused");
         power.setWakelock(false);
         super.onPause();
     }
@@ -100,14 +96,14 @@ public class MainActivity extends android.app.NativeActivity {
     /** Called when the activity is no longer visible. */
     @Override
     protected void onStop() {
-        Logger.v(TAG, "App stopped");
+        Logger.d(TAG, "App stopped");
         super.onStop();
     }
 
     /** Called just before the activity is destroyed. */
     @Override
     protected void onDestroy() {
-        Logger.v(TAG, "App destroyed");
+        Logger.d(TAG, "App destroyed");
         clipboard = null;
         power = null;
 	screen = null;
@@ -126,6 +122,19 @@ public class MainActivity extends android.app.NativeActivity {
      *  If you add a new function here remember to write the companion
      *  lua function in that file */
 
+
+    /** build */
+    public int isDebuggable() {
+        return (BuildConfig.DEBUG) ? 1 : 0;
+    }
+
+    public String getFlavor() {
+        return getResources().getString(R.string.app_flavor);
+    }
+
+    public String getName() {
+        return getResources().getString(R.string.app_name);
+    }
 
     /** clipboard */
     public String getClipboardText() {
@@ -147,14 +156,6 @@ public class MainActivity extends android.app.NativeActivity {
 
     public String getVersion() {
         return android.os.Build.VERSION.RELEASE;
-    }
-
-    public String getFlavor() {
-        return getResources().getString(R.string.app_flavor);
-    }
-
-    public String getName() {
-        return getResources().getString(R.string.app_name);
     }
 
     public int isEink() {
@@ -297,7 +298,7 @@ public class MainActivity extends android.app.NativeActivity {
         File file = new File(Environment.getExternalStoragePublicDirectory(
             Environment.DIRECTORY_DOWNLOADS) + "/" + name);
 
-        Logger.v(TAG, file.getAbsolutePath());
+        Logger.d(TAG, file.getAbsolutePath());
         if (file.exists()) return 1;
 
         DownloadManager.Request request = new DownloadManager.Request(Uri.parse(url));

--- a/src/org/koreader/launcher/PowerHelper.java
+++ b/src/org/koreader/launcher/PowerHelper.java
@@ -69,14 +69,14 @@ public class PowerHelper {
             wakelockRelease();
             PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
             wakelock = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK, WAKELOCK_ID);
-            Logger.v(TAG, "wakelock: acquiring " + WAKELOCK_ID);
+            Logger.d(TAG, "wakelock: acquiring " + WAKELOCK_ID);
             wakelock.acquire();
         }
     }
 
     private void wakelockRelease() {
         if (isWakeLockAllowed && wakelock != null) {
-            Logger.v(TAG, "wakelock: releasing " + WAKELOCK_ID);
+            Logger.d(TAG, "wakelock: releasing " + WAKELOCK_ID);
             wakelock.release();
             wakelock = null;
         }


### PR DESCRIPTION
Reason: while adding new stuff to luajit-launcher I need to read a lot of logs. KOReader debug statements (logged with the verbose level) are not relevant here, so having a separate log level comes handy.

This is my proposal: debug statements are not printed in release builds. If you find the need to include (some of) them in release builds I'm ok with that as long as I can still log the relevant launcher stuff with `KOReader:D` without all the noise logged by the frontend.

Pinging @NiLuJe and @poire-z 