### PR TITLE
[very wip]: add support for ACTION_VIEW on content:// schemes

### DIFF
--- a/app/src/org/koreader/launcher/BaseActivity.java
+++ b/app/src/org/koreader/launcher/BaseActivity.java
@@ -18,7 +18,7 @@ import org.koreader.launcher.helper.*;
 /* BaseActivity.java
  *
  * Convenience wrapper on top of NativeActivity with a base implementation of the JNILuaInterface.
- * This class doesn't know about views and runtime permissions.
+ * This class doesn't know about views, runtime permissions or activity results.
  */
 
 abstract class BaseActivity extends NativeActivity implements JNILuaInterface {
@@ -34,12 +34,19 @@ abstract class BaseActivity extends NativeActivity implements JNILuaInterface {
     // windows insets
     private int top_inset_height;
 
-    // helpers
+    // fullscreen dialog using while uncompressing assets.
     private FramelessProgressDialog dialog;
+
+    // helpers
     private ClipboardHelper clipboard;
     private NetworkHelper network;
+
+    FileHelper files;
     PowerHelper power;
     ScreenHelper screen;
+
+    // absolute path of the last document imported to cache
+    String last_imported_file;
 
     /*---------------------------------------------------------------
      *                        activity callbacks                    *
@@ -50,6 +57,7 @@ abstract class BaseActivity extends NativeActivity implements JNILuaInterface {
         Logger.d(TAG, "onCreate()");
         super.onCreate(savedInstanceState);
         clipboard = new ClipboardHelper(this);
+        files = new FileHelper(this);
         network = new NetworkHelper(this);
         power = new PowerHelper(this);
         screen = new ScreenHelper(this);
@@ -77,6 +85,7 @@ abstract class BaseActivity extends NativeActivity implements JNILuaInterface {
     protected void onDestroy() {
         Logger.d(TAG, "onDestroy()");
         clipboard = null;
+        files = null;
         network = null;
         power = null;
         screen = null;
@@ -174,6 +183,26 @@ abstract class BaseActivity extends NativeActivity implements JNILuaInterface {
     public void einkUpdate(int mode, long delay, int x, int y, int width, int height) {
         Logger.w(TAG,
             "einkUpdate(mode, delay, x, y, width, height) not implemented in this class!");
+    }
+
+    /* file utils */
+    public String getFilePathFromIntent() {
+        return files.getAbsolutePath(getIntent().getData());
+    }
+
+    public String getLastImportedFilePath() {
+        if (last_imported_file == null) {
+            return "none";
+        } else {
+            String cur = last_imported_file;
+            last_imported_file = null;
+            return cur;
+        }
+    }
+
+    public int importFileFromStorageAccessFramework() {
+        // not implemented here.
+        return 0;
     }
 
     /* intents */

--- a/app/src/org/koreader/launcher/JNILuaInterface.java
+++ b/app/src/org/koreader/launcher/JNILuaInterface.java
@@ -20,6 +20,7 @@ interface JNILuaInterface {
     void setWifiEnabled(boolean enabled);
     void showProgress(String title, String message);
     void showToast(String message);
+    void showToast(String message, final boolean is_long);
 
     int download(String url, String name);
     int getBatteryLevel();
@@ -31,6 +32,7 @@ interface JNILuaInterface {
     int hasClipboardTextIntResultWrapper();
     int hasExternalStoragePermission();
     int hasWriteSettingsPermission();
+    int importFileFromStorageAccessFramework();
     int isCharging();
     int isDebuggable();
     int isEink();
@@ -43,7 +45,9 @@ interface JNILuaInterface {
 
     String getClipboardText();
     String getEinkPlatform();
+    String getFilePathFromIntent();
     String getFlavor();
+    String getLastImportedFilePath();
     String getName();
     String getNetworkInfo();
     String getProduct();

--- a/app/src/org/koreader/launcher/MainActivity.java
+++ b/app/src/org/koreader/launcher/MainActivity.java
@@ -2,8 +2,10 @@ package org.koreader.launcher;
 
 import java.util.Locale;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -34,6 +36,7 @@ public final class MainActivity extends BaseActivity implements
 
     private final static String TAG = "MainActivity";
     private final static int REQUEST_WRITE_STORAGE = 1;
+    private final static int REQUEST_STORAGE_FRAMEWORK = 2;
 
     private NativeSurfaceView view;
 
@@ -118,6 +121,19 @@ public final class MainActivity extends BaseActivity implements
         }
     }
 
+    /* Called on activity result */
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent resultData) {
+        if ((requestCode == REQUEST_STORAGE_FRAMEWORK) && (resultCode == Activity.RESULT_OK)) {
+            Uri uri;
+            if (resultData != null) {
+                uri = resultData.getData();
+                // retrieve the absolute path to a file, if any
+                last_imported_file = files.getAbsolutePath(uri);
+            }
+        }
+    }
+
     /* Called when the activity is going to be destroyed */
     @Override
     public void onDestroy() {
@@ -157,6 +173,23 @@ public final class MainActivity extends BaseActivity implements
         } else {
             // on older apis permissions are granted at install time
             return 1;
+        }
+    }
+
+    @Override
+    public int importFileFromStorageAccessFramework() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType("*/*");
+            try {
+                startActivityForResult(intent, REQUEST_STORAGE_FRAMEWORK);
+                return 1;
+            } catch (Exception e) {
+                return 0;
+            }
+        } else {
+            return 0;
         }
     }
 

--- a/app/src/org/koreader/launcher/helper/FileHelper.java
+++ b/app/src/org/koreader/launcher/helper/FileHelper.java
@@ -1,0 +1,145 @@
+package org.koreader.launcher.helper;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+import java.util.Locale;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.MediaStore;
+
+import org.koreader.launcher.Logger;
+
+
+public class FileHelper {
+    private final Context context;
+    private final String tag;
+
+    public FileHelper(Context context) {
+        this.context = context.getApplicationContext();
+        this.tag = this.getClass().getSimpleName();
+        Logger.d(tag, "Starting");
+    }
+
+    /**
+     * gets the absolute path of a document from an uri
+     * @param uri with file/content schemes. Others return null.
+     * @return a string containing the full path of the document.
+     */
+    public String getAbsolutePath(Uri uri) {
+        File file = getFileFromUri(uri);
+        if (file != null) {
+            String path = file.getAbsolutePath();
+            Logger.v(tag, String.format(Locale.US, "open file %s", path));
+            return path;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * gets a file from an uri.
+     * @param uri with scheme file or content. Invalid schemes will return null
+     * @return a file containing the document we want to open.
+     */
+    private File getFileFromUri(Uri uri) {
+        File file = null;
+        if (uri == null) return null;
+        final String scheme = uri.getScheme();
+        if (ContentResolver.SCHEME_FILE.equals(scheme)) {
+            Logger.d(tag, "obtaining path from file uri scheme");
+            file = new File(uri.getPath());
+        } else if (ContentResolver.SCHEME_CONTENT.equals(scheme)) {
+            Logger.d(tag, "obtaining path from content uri scheme");
+            file = getFileFromContentUri(uri);
+        }
+        return file;
+    }
+
+    /**
+     * gets a file from content:// uris
+     * @param uri with scheme content
+     * @return a file
+     */
+    private File getFileFromContentUri(Uri uri) {
+        // there's no way to retrieve a file, so open a inputStream using the content resolver
+        // and store the content inside the cache folder.
+        File file = null;
+        String[] nameColumn = {MediaStore.MediaColumns.DISPLAY_NAME};
+        ContentResolver contentResolver = context.getContentResolver();
+        Cursor cursor = contentResolver.query(uri, nameColumn, null, null, null);
+        if (cursor != null) {
+            cursor.moveToFirst();
+            String name = cursor.getString(cursor.getColumnIndex(nameColumn[0]));
+            cursor.close();
+            Logger.d(tag, String.format(Locale.US, "Importing content: %s", name));
+            String path = getPathFromCache(uri, name);
+            file = new File(path);
+        }
+        return file;
+    }
+
+    /**
+     * gets the absolute path of a cache file
+     * @param uri with scheme content
+     * @param name of the file
+     * @return a string containing the full path of the document.
+     */
+    private String getPathFromCache(Uri uri, String name) {
+        Logger.d(tag, "Getting the absolute path to the cached document");
+        String path = null;
+        InputStream stream = null;
+        if (uri.getAuthority() != null) {
+            Logger.d(tag, String.format(Locale.US, "Using authority: %s", uri.getAuthority()));
+            try {
+                stream = context.getContentResolver().openInputStream(uri);
+                File file = getCacheFile(stream, name);
+                path = file.getPath();
+            } catch (IOException e) {
+                Logger.e(tag, "I/O error: " + e.toString());
+            } finally {
+                try {
+                    if (stream != null) stream.close();
+                } catch (IOException e) {
+                    Logger.e(tag, "I/O error: " + e.toString());
+                }
+            }
+        }
+        return path;
+    }
+
+    /**
+     * gets a cache file from an inputstream buffer
+     * @param stream from contentResolver.openInputStream(uri)
+     * @param name of the file
+     * @return cache file
+     */
+    private File getCacheFile(InputStream stream, String name) throws IOException {
+        Logger.d(tag, "Getting a copy of content from inputstream");
+        File file = null;
+	    if (stream != null) {
+	        int read;
+	        byte[] buffer = new byte[8 * 1024];
+	        file = new File(context.getCacheDir(), name);
+	        Logger.d(tag, String.format(Locale.US,
+                "storing new content on %s", file.getAbsolutePath()));
+
+	        OutputStream output = new FileOutputStream(file);
+	        while ((read = stream.read(buffer)) != -1) {
+                output.write(buffer, 0, read);
+            }
+            try {
+                output.flush();
+                output.close();
+            } catch (IOException e) {
+                Logger.e(tag, "I/O error: " + e.toString());
+            }
+        }
+        return file;
+    }
+}

--- a/app/src/org/koreader/launcher/helper/ScreenHelper.java
+++ b/app/src/org/koreader/launcher/helper/ScreenHelper.java
@@ -211,10 +211,6 @@ public class ScreenHelper {
         return size;
     }
 
-    private class Box<T> {
-        T value;
-    }
-
     private int readSettingScreenOffTimeout() {
         try {
             return Settings.System.getInt(context.getContentResolver(),

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1334,23 +1334,36 @@ local function run(android_app_state)
 
     android.getIntent = function()
         return JNI:context(android.app.activity.vm, function(JNI)
-            local uri = JNI:callObjectMethod(
-                JNI:callObjectMethod(
-                    android.app.activity.clazz,
-                    "getIntent",
-                    "()Landroid/content/Intent;"
-                ),
-                "getData",
-                "()Landroid/net/Uri;"
+            local path = JNI:callObjectMethod(
+                android.app.activity.clazz,
+                "getFilePathFromIntent",
+                "()Ljava/lang/String;"
             )
-            if uri ~= nil then
-                local path = JNI:callObjectMethod(
-                    uri,
-                    "getPath",
-                    "()Ljava/lang/String;"
-                )
+            if path ~= nil then
                 return JNI:to_string(path)
             end
+        end)
+    end
+
+    android.importFile = function()
+        return JNI:context(android.app.activity.vm, function(JNI)
+            return JNI:callIntMethod(
+                android.app.activity.clazz,
+                "importFileFromStorageAccessFramework",
+                "()I"
+            ) == 1
+        end)
+    end
+
+    android.getLastImportedFile = function()
+        return JNI:context(android.app.activity.vm, function(JNI)
+            -- get last imported file path
+            local path = JNI:callObjectMethod(
+                android.app.activity.clazz,
+                "getLastImportedFile",
+                "()Ljava/lang/String;"
+            )
+            return JNI:to_string(path)
         end)
     end
 


### PR DESCRIPTION
**Edit:** updated PR to add support for Android Storage Access Framework on KitKat+ devices. This means gaining access to dropbox, gdrive or any other content providers and being able to import documents from there. This seems important to some users.

This PR implements a interface to obtain a string containing the full path of the file you select on the SAF file picker. We accept all kind of mimetypes here to import.

The frontend needs to be updated to implement the rest of the code:

in openable/readable files: show a menu *file imported, now what?* with some options. move home, move to, open from cache...

in non readable files just move the file to users home is fine.

<details>
<summary>
<b>original message</b>
</summary>
<p>

Not sure if this is a good idea or we just need to label https://github.com/koreader/koreader/issues/4441 as **can't fix** and avoid to open uris with content scheme.

This PRs works as is:

- if the intent provides an uri with scheme "file://" works without problems.
- if the intent provides an uri with scheme "content://":
 1. get a content resolver
 2. open a input stream
 3. store the stream into a cache file
 4. get the full path to that cache file
 5. finally open the file, now that we have a valid path.

I've followed recommendations from https://commonsware.com/blog/2016/03/15/how-consume-content-uri.html, so no strange workarounds that can work on *some* folders in *some* devices. This method should work in every android device from every app.

But has some problems:

1. ~~cache files are stored in /data/data/... and is impossible to return to /sdcard unless "home" is actually set to that folder.~~
2. sdr folder is stored on the same path of the file. If we open the same file from two locations (ie: opening a file via ko file browser or consuming a intent via inputstream) then there are two sdr folders.
3. ofc, inputstream makes a duplicate of the file. That's a bad thing too.

Most of the problems are common to other android document viewers but some are very related to how KOReader works. I found just one app that does the things differently: ReadEra.

ReadEra scans the entire sdcard, looking for recognized mimetypes and hashes each file. It stores the info in a database. When an application opens a file declared as ACTION_VIEW by ReadEra the program just looks if the name is indeed in the database and gets the file path from there. If the file is not in the database it uses inputStream to create a cache file, does a sha256sum and compare the hash agaisnt the database. These are just guesses because the program isn't opensource.

Other programs choose one of the following three routes:

 - they're broken
 - they're importing documents using a cache file (like this PR) and have a file browser to import new content from the application
 - they're skipping the ACTION_VIEW on content schemes and just let you explore the sdcard filesystem (like KOReader is doing now).
</p>
</details>




I'm going to need some feedback here @Frenzie @poire-z @NiLuJe 

