### PR TITLE
[fix] Add LuaJIT patch to sync with koreader-base

### DIFF
--- a/koreader-luajit-makefile-tweaks.patch
+++ b/koreader-luajit-makefile-tweaks.patch
@@ -1,0 +1,52 @@
+diff --git a/src/Makefile b/src/Makefile
+index d22eb73..6a74228 100644
+--- a/luajit-2.0/src/Makefile
++++ b/luajit-2.0/src/Makefile
+@@ -214,7 +214,8 @@ TARGET_STCC= $(STATIC_CC)
+ TARGET_DYNCC= $(DYNAMIC_CC)
+ TARGET_LD= $(CROSS)$(CC)
+ TARGET_AR= $(CROSS)ar rcus
+-TARGET_STRIP= $(CROSS)strip
++TARGET_RANLIB= $(CROSS)ranlib
++TARGET_STRIP= $(CROSS)strip --strip-unneeded
+ 
+ TARGET_LIBPATH= $(or $(PREFIX),/usr/local)/$(or $(MULTILIB),lib)
+ TARGET_SONAME= libluajit-$(ABIVER).so.$(MAJVER)
+@@ -634,7 +635,7 @@ depend:
+ 
+ $(MINILUA_T): $(MINILUA_O)
+ 	$(E) "HOSTLINK  $@"
+-	$(Q)$(HOST_CC) $(HOST_ALDFLAGS) -o $@ $(MINILUA_O) $(MINILUA_LIBS) $(HOST_ALIBS)
++	$(Q)$(HOST_CC) $(HOST_ACFLAGS) $(HOST_ALDFLAGS) -o $@ $(MINILUA_O) $(MINILUA_LIBS) $(HOST_ALIBS)
+ 
+ host/buildvm_arch.h: $(DASM_DASC) $(DASM_DEP) $(DASM_DIR)/*.lua
+ 	$(E) "DYNASM    $@"
+@@ -644,7 +645,7 @@ host/buildvm.o: $(DASM_DIR)/dasm_*.h
+ 
+ $(BUILDVM_T): $(BUILDVM_O)
+ 	$(E) "HOSTLINK  $@"
+-	$(Q)$(HOST_CC) $(HOST_ALDFLAGS) -o $@ $(BUILDVM_O) $(HOST_ALIBS)
++	$(Q)$(HOST_CC) $(HOST_ACFLAGS) $(HOST_ALDFLAGS) -o $@ $(BUILDVM_O) $(HOST_ALIBS)
+ 
+ $(LJVM_BOUT): $(BUILDVM_T)
+ 	$(E) "BUILDVM   $@"
+@@ -705,16 +706,17 @@ include Makefile.dep
+ $(LUAJIT_A): $(LJVMCORE_O)
+ 	$(E) "AR        $@"
+ 	$(Q)$(TARGET_AR) $@ $(LJVMCORE_O)
++	$(Q)$(TARGET_RANLIB) $@
+ 
+ # The dependency on _O, but linking with _DYNO is intentional.
+ $(LUAJIT_SO): $(LJVMCORE_O)
+ 	$(E) "DYNLINK   $@"
+-	$(Q)$(TARGET_LD) $(TARGET_ASHLDFLAGS) -o $@ $(LJVMCORE_DYNO) $(TARGET_ALIBS)
++	$(Q)$(TARGET_LD) $(TARGET_ACFLAGS) $(TARGET_ASHLDFLAGS) -o $@ $(LJVMCORE_DYNO) $(TARGET_ALIBS)
+ 	$(Q)$(TARGET_STRIP) $@
+ 
+ $(LUAJIT_T): $(TARGET_O) $(LUAJIT_O) $(TARGET_DEP)
+ 	$(E) "LINK      $@"
+-	$(Q)$(TARGET_LD) $(TARGET_ALDFLAGS) -o $@ $(LUAJIT_O) $(TARGET_O) $(TARGET_ALIBS)
++	$(Q)$(TARGET_LD) $(TARGET_ACFLAGS) $(TARGET_ALDFLAGS) -o $@ $(LUAJIT_O) $(TARGET_O) $(TARGET_ALIBS)
+ 	$(Q)$(TARGET_STRIP) $@
+ 	$(E) "OK        Successfully built LuaJIT"
+ 

--- a/mk-luajit.sh
+++ b/mk-luajit.sh
@@ -10,6 +10,19 @@ DEST=$(cd "$(dirname "$0")" && pwd)/jni/luajit-build/$1
 # might be linux-x86_64 or darwin-x86-64
 HOST_ARCH="*"
 
+# Patch luajit like in koreader-base
+# Script pilfered from patch-wrapper in koreader-base
+PATCH_FILE=koreader-luajit-makefile-tweaks.patch
+
+# Reverse patch will succeed if the patch is already applied.
+# In case of failure, it means we should try to apply the patch.
+if ! patch -R -p1 -N --dry-run <"${PATCH_FILE}" >/dev/null 2>&1; then
+    # Now patch for real.
+    if ! patch -p1 -N <"${PATCH_FILE}"; then
+        exit $?
+    fi
+fi
+
 function check_NDK() {
     [[ -n $NDK ]] || export NDK=/opt/android-ndk
     if [ ! -d "$NDK" ]; then


### PR DESCRIPTION
A bit of an emergency fix to just get it working ASAP. A patch was added to base LuaJIT in https://github.com/koreader/koreader-base/pull/892, which caused a mismatch and build failures over here. Unfortunately that was hidden by some excessive Android verbosity inadvertently introduced in https://github.com/koreader/koreader-base/pull/888, and on my local instance where I did a sanity check LuaJIT was already compiled…