### PR TITLE
SurfaceView override.

### DIFF
--- a/src/org/koreader/device/EPDFactory.java
+++ b/src/org/koreader/device/EPDFactory.java
@@ -8,6 +8,7 @@ package org.koreader.device;
 import android.view.View;
 import android.util.Log;
 
+import org.koreader.device.DeviceInfo;
 import org.koreader.device.rockchip.RK3026EPDController;
 import org.koreader.device.rockchip.RK3066EPDController;
 import org.koreader.device.rockchip.RK3368EPDController;


### PR DESCRIPTION
in order to interact with the epd driver indirectly, via the View class framework, where the epd driver is hooked.

This is part of the solution proposed in https://github.com/koreader/koreader/issues/3517#issuecomment-485347562 to add support for tolinos, but should be compatible with other devices based on the freescale platform.

 All credits to @char11, thanks pal! 

Things are working fine on the emulator/phone, but I lack a eink device to test. 

Please @hugleo, @carlinux, @cellaris (or anybody with a **currently supported** eink device) , could you test https://www.dropbox.com/s/froawrgv4jt6h1p/koreader-android-arm-linux-androideabi-debug-v2019.04-52-g7d742e15_2019-04-22.apk?dl=0 and report if eink updates still work?. Also extra points for the output of `adb logcat -c && adb logcat KOReader:D *:S`

Waiting for feedback before requesting reviews, and so on. If this build still works on Rockchip devices it will be wonderful :+1:  