### PR TITLE
[wip]: add support for generic epd driver and a stub for known device bugs

### DIFF
--- a/src/org/koreader/device/DeviceInfo.java
+++ b/src/org/koreader/device/DeviceInfo.java
@@ -11,31 +11,10 @@ import java.util.Iterator;
 
 
 public class DeviceInfo {
+    // has a working eink driver
+    public static final boolean IS_EINK_SUPPORTED;
 
-    public enum Device {
-        UNKNOWN,
-        EINK_BOYUE_T61,
-        EINK_BOYUE_T62,
-        EINK_BOYUE_T80S,
-        EINK_BOYUE_T80D,
-        EINK_BOYUE_T78D,
-        EINK_BOYUE_T103D,
-        EINK_ONYX_C67,
-        EINK_ENERGY,
-        EINK_INKBOOK,
-    }
-
-    public final static int EPD_FULL = 1;
-    public final static int EPD_PART = 2;
-    public final static int EPD_A2 = 3;
-    public final static int EPD_AUTO = 4;
-
-    public final static String MANUFACTURER;
-    public final static String BRAND;
-    public final static String MODEL;
-    public final static String DEVICE;
-    public final static String PRODUCT;
-
+    // supported eink devices
     public static final boolean EINK_BOYUE_T61;
     public static final boolean EINK_BOYUE_T62;
     public static final boolean EINK_BOYUE_T80S;
@@ -45,9 +24,51 @@ public class DeviceInfo {
     public static final boolean EINK_ONYX_C67;
     public static final boolean EINK_ENERGY;
     public static final boolean EINK_INKBOOK;
+    public static final boolean EINK_GENERIC;
 
-    public static final boolean IS_EINK_SUPPORTED;
-    public static Device CURRENT_DEVICE = Device.UNKNOWN;
+    // has a known bug that we need to handle
+    public static final boolean HAS_BUGS;
+
+    // known bugs
+    public static final boolean BUG_NEEDS_WAKELOCKS = false;
+
+    // EPD modes for rockchip devices
+    // to-do: move them elsewhere...
+    public final static int EPD_FULL = 1;
+    public final static int EPD_PART = 2;
+    public final static int EPD_A2 = 3;
+    public final static int EPD_AUTO = 4;
+
+    public enum Eink {
+        UNKNOWN,
+        BOYUE_T61,
+        BOYUE_T62,
+        BOYUE_T80S,
+        BOYUE_T80D,
+        BOYUE_T78D,
+        BOYUE_T103D,
+        ONYX_C67,
+        ENERGY,
+        INKBOOK,
+        GENERIC,
+    }
+
+    public enum Bug {
+        NONE,
+        NEEDS_WAKELOCKS,
+    }
+
+    /** perform a check on this specific device,
+      starting with an unknown epd driver and no quirks */
+
+    public static Eink EPD = Eink.UNKNOWN;
+    public static Bug BUG = Bug.NONE;
+
+    public final static String MANUFACTURER;
+    public final static String BRAND;
+    public final static String MODEL;
+    public final static String DEVICE;
+    public final static String PRODUCT;
 
     static {
         MANUFACTURER = getBuildField("MANUFACTURER");
@@ -56,58 +77,65 @@ public class DeviceInfo {
         DEVICE = getBuildField("DEVICE");
         PRODUCT = getBuildField("PRODUCT");
 
-        HashMap<Device, Boolean> deviceMap = new HashMap<Device, Boolean>();
+        HashMap<Eink, Boolean> deviceMap = new HashMap<Eink, Boolean>();
+        HashMap<Bug, Boolean> bugMap = new HashMap<Bug, Boolean>();
 
         // Boyue T62, manufacturer uses both "boeye" and "boyue" ids.
         EINK_BOYUE_T62 = ( MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue") )
                 && (PRODUCT.toLowerCase().startsWith("t62") || MODEL.contentEquals("rk30sdk"))
                 && DEVICE.toLowerCase().startsWith("t62");
-        deviceMap.put(Device.EINK_BOYUE_T62, EINK_BOYUE_T62);
+        deviceMap.put(Eink.BOYUE_T62, EINK_BOYUE_T62);
 
         // Boyue T61, uses RK3066 chipset
         EINK_BOYUE_T61 = ( MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue") )
                 && ( PRODUCT.toLowerCase().startsWith("t61") || MODEL.contentEquals("rk30sdk") )
                 && DEVICE.toLowerCase().startsWith("t61");
-        deviceMap.put(Device.EINK_BOYUE_T61, EINK_BOYUE_T61);
+        deviceMap.put(Eink.BOYUE_T61, EINK_BOYUE_T61);
 
         // Boyue Likebook Plus
         EINK_BOYUE_T80S = (MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue"))
                 && PRODUCT.toLowerCase().contentEquals("t80s");
-        deviceMap.put(Device.EINK_BOYUE_T80S, EINK_BOYUE_T80S);
+        deviceMap.put(Eink.BOYUE_T80S, EINK_BOYUE_T80S);
 
         // Boyue Likebook Mars
         EINK_BOYUE_T80D = (MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue"))
                 && PRODUCT.toLowerCase().contentEquals("t80d");
-        deviceMap.put(Device.EINK_BOYUE_T80D, EINK_BOYUE_T80D);
+        deviceMap.put(Eink.BOYUE_T80D, EINK_BOYUE_T80D);
 
         // Boyue Likebook Muses
         EINK_BOYUE_T78D = (MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue"))
                 && PRODUCT.toLowerCase().contentEquals("t78d");
-        deviceMap.put(Device.EINK_BOYUE_T78D, EINK_BOYUE_T78D);
+        deviceMap.put(Eink.BOYUE_T78D, EINK_BOYUE_T78D);
 
         // Boyue Likebook Mimas
         EINK_BOYUE_T103D = (MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue"))
                 && PRODUCT.toLowerCase().contentEquals("t103d");
-        deviceMap.put(Device.EINK_BOYUE_T103D, EINK_BOYUE_T103D);
+        deviceMap.put(Eink.BOYUE_T103D, EINK_BOYUE_T103D);
 
         // Onyx C67
         EINK_ONYX_C67 = MANUFACTURER.toLowerCase().contentEquals("onyx")
                 && ( PRODUCT.toLowerCase().startsWith("c67") || MODEL.contentEquals("rk30sdk") )
                 && DEVICE.toLowerCase().startsWith("c67");
-        deviceMap.put(Device.EINK_ONYX_C67, EINK_ONYX_C67);
+        deviceMap.put(Eink.ONYX_C67, EINK_ONYX_C67);
 
         // Energy Sistem eReaders. Tested on Energy Ereader Pro 4
         EINK_ENERGY = (BRAND.toLowerCase().contentEquals("energysistem") || BRAND.toLowerCase().contentEquals("energy_sistem"))
                 && MODEL.toLowerCase().startsWith("ereader");
-        deviceMap.put(Device.EINK_ENERGY, EINK_ENERGY);
+        deviceMap.put(Eink.ENERGY, EINK_ENERGY);
 
         // Artatech Inkbook Prime/Prime HD.
         EINK_INKBOOK = MANUFACTURER.toLowerCase().contentEquals("artatech")
                 && BRAND.toLowerCase().contentEquals("inkbook")
                 && MODEL.toLowerCase().startsWith("prime");
-        deviceMap.put(Device.EINK_INKBOOK, EINK_INKBOOK);
+        deviceMap.put(Eink.INKBOOK, EINK_INKBOOK);
 
-        // add your eink device here...
+        // Sony DPT-RP1 (generic epd, needs wakelocks)
+        EINK_GENERIC = MANUFACTURER.toLowerCase().contentEquals("sony")
+                && MODEL.toLowerCase().contentEquals("dpt-rp1");
+        deviceMap.put(Eink.GENERIC, EINK_GENERIC);
+        bugMap.put(Bug.NEEDS_WAKELOCKS, EINK_GENERIC);
+
+        // add your device here...
 
 
         // true if we found a supported device
@@ -119,20 +147,39 @@ public class DeviceInfo {
             EINK_BOYUE_T103D ||
             EINK_ENERGY ||
             EINK_INKBOOK ||
-            EINK_ONYX_C67
+            EINK_ONYX_C67 ||
+            EINK_GENERIC
         );
 
-        // find current device.
-        Iterator<Device> iter = deviceMap.keySet().iterator();
+        // true if we found a known bug
+        HAS_BUGS = (
+            BUG_NEEDS_WAKELOCKS
+        );
 
-        while (iter.hasNext()) {
-            Device device = iter.next();
-            Boolean flag = deviceMap.get(device);
+        // find e-ink driver for current device
+        Iterator<Eink> einkIterator = deviceMap.keySet().iterator();
+
+        while (einkIterator.hasNext()) {
+            Eink eink = einkIterator.next();
+            Boolean flag = deviceMap.get(eink);
 
             if (flag) {
-                CURRENT_DEVICE = device;
+                EPD = eink;
             }
         }
+
+        // find known bugs for current device
+        Iterator<Bug> bugIterator = bugMap.keySet().iterator();
+
+        while (bugIterator.hasNext()) {
+            Bug bug = bugIterator.next();
+            Boolean flag = bugMap.get(bug);
+
+            if (flag) {
+                BUG = bug;
+            }
+        }
+
     }
 
     private static String getBuildField(String fieldName) {

--- a/src/org/koreader/device/EPDController.java
+++ b/src/org/koreader/device/EPDController.java
@@ -9,5 +9,5 @@ import android.view.View;
 
 
 public interface EPDController {
-    void setEpdMode(View targetView, String epdMode);
+    void setEpdMode(View targetView, String epdMode, long delay, int x, int y, int width, int height, int mode);
 }

--- a/src/org/koreader/device/EPDFactory.java
+++ b/src/org/koreader/device/EPDFactory.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.util.Log;
 
 import org.koreader.device.DeviceInfo;
+import org.koreader.device.generic.GenericEPDController;
 import org.koreader.device.rockchip.RK3026EPDController;
 import org.koreader.device.rockchip.RK3066EPDController;
 import org.koreader.device.rockchip.RK3368EPDController;
@@ -19,30 +20,36 @@ public class EPDFactory {
         EPDController epdController = null;
         String controllerName = null;
 
-        switch (DeviceInfo.CURRENT_DEVICE) {
+        switch (DeviceInfo.EPD) {
 
             /** Supported rk3026 devices */
-            case EINK_BOYUE_T61:
-            case EINK_BOYUE_T80S:
-            case EINK_ONYX_C67:
-            case EINK_ENERGY:
-            case EINK_INKBOOK:
+            case BOYUE_T61:
+            case BOYUE_T80S:
+            case ONYX_C67:
+            case ENERGY:
+            case INKBOOK:
                 controllerName = "Rockchip RK3026";
                 epdController = new RK3026EPDController();
                 break;
 
             /** supported rk3066 devices */
-            case EINK_BOYUE_T62:
+            case BOYUE_T62:
                 controllerName = "Rockchip RK3066";
                 epdController = new RK3066EPDController();
                 break;
 
             /** supported rk3368 devices */
-            case EINK_BOYUE_T80D:
-            case EINK_BOYUE_T78D:
-            case EINK_BOYUE_T103D:
+            case BOYUE_T80D:
+            case BOYUE_T78D:
+            case BOYUE_T103D:
                 controllerName = "Rockchip RK3368";
                 epdController = new RK3368EPDController();
+                break;
+
+            /** fallback method: invalidating the view */
+            case GENERIC:
+                controllerName = "Generic Android surface";
+                epdController = new GenericEPDController();
                 break;
 
             /** unsupported devices */

--- a/src/org/koreader/device/generic/GenericEPDController.java
+++ b/src/org/koreader/device/generic/GenericEPDController.java
@@ -1,0 +1,22 @@
+package org.koreader.device.generic;
+
+import android.util.Log;
+import android.view.View;
+
+import org.koreader.device.EPDController;
+
+
+@SuppressWarnings("unused, unchecked")
+public class GenericEPDController implements EPDController {
+    @Override
+    public void setEpdMode(View targetView, String epdMode) {
+
+        /** just invalidate current view */
+        try {
+            Class.forName("android.view.View").getMethod("postInvalidate",
+                new Class[]{}).invoke(null, new Object[]{});
+        } catch (Exception e) {
+            Log.e("epd", e.toString());
+        }
+    }
+}


### PR DESCRIPTION
Untested. Waiting feedback in https://github.com/koreader/koreader/issues/4881#issuecomment-489374278

to-do: 

- disable wakelock switching if device needs wakelocks.
- update EPDController interface to support region/full updates based on current device/driver

thinking about:

- update android.screen.width and android.screen.height each time the surface was changed (needed for rotation, split screen, 3rd party keyboards...)