### PR TITLE
Misc enhancements

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1484,11 +1484,18 @@ local function run(android_app_state)
 
     android.isEink = function()
         return JNI:context(android.app.activity.vm, function(JNI)
-            return JNI:callIntMethod(
+            local is_supported = JNI:callIntMethod(
                 android.app.activity.clazz,
                 "isEink",
                 "()I"
             ) == 1
+
+            local platform = JNI:callObjectMethod(
+                android.app.activity.clazz,
+                "getEinkPlatform",
+                "()Ljava/lang/String;"
+            )
+            return is_supported, JNI:to_string(platform)
         end)
     end
 
@@ -1497,6 +1504,16 @@ local function run(android_app_state)
             return JNI:callIntMethod(
                 android.app.activity.clazz,
                 "isEinkFull",
+                "()I"
+            ) == 1
+        end)
+    end
+
+    android.needsWakelocks = function()
+        return JNI:context(android.app.activity.vm, function(JNI)
+            return JNI:callIntMethod(
+                android.app.activity.clazz,
+                "needsWakelocks",
                 "()I"
             ) == 1
         end)

--- a/src/org/koreader/device/DeviceInfo.java
+++ b/src/org/koreader/device/DeviceInfo.java
@@ -1,6 +1,9 @@
 /**
- * generic EPD Controller for Android devices,
+ * Device info using Android build properties,
  * based on https://github.com/unwmun/refreshU
+ *
+ * Note: devices don't need to be declared here unless
+ * they have known eink update routines and/or bug workarounds.
  */
 
 package org.koreader.device;
@@ -12,7 +15,13 @@ import java.util.Iterator;
 
 public class DeviceInfo {
 
-    public enum Device {
+    public final static String MANUFACTURER;
+    public final static String BRAND;
+    public final static String MODEL;
+    public final static String DEVICE;
+    public final static String PRODUCT;
+
+    public enum EinkDevice {
         UNKNOWN,
         BOYUE_T61,
         BOYUE_T62,
@@ -27,129 +36,143 @@ public class DeviceInfo {
         NOOK_V520,
     }
 
-    public final static int EPD_FULL = 1;
-    public final static int EPD_PART = 2;
-    public final static int EPD_A2 = 3;
-    public final static int EPD_AUTO = 4;
+    public static EinkDevice CURRENT_DEVICE = EinkDevice.UNKNOWN;
 
-    public final static String MANUFACTURER;
-    public final static String BRAND;
-    public final static String MODEL;
-    public final static String DEVICE;
-    public final static String PRODUCT;
+    public static final boolean BOYUE_T61;
+    public static final boolean BOYUE_T62;
+    public static final boolean BOYUE_T80S;
+    public static final boolean BOYUE_T80D;
+    public static final boolean BOYUE_T78D;
+    public static final boolean BOYUE_T103D;
+    public static final boolean ONYX_C67;
+    public static final boolean ENERGY;
+    public static final boolean INKBOOK;
+    public static final boolean TOLINO;
+    public static final boolean NOOK_V520;
+    public static final boolean SONY_RP1;
+    public static final boolean EMULATOR_X86;
 
-    public static final boolean EINK_BOYUE_T61;
-    public static final boolean EINK_BOYUE_T62;
-    public static final boolean EINK_BOYUE_T80S;
-    public static final boolean EINK_BOYUE_T80D;
-    public static final boolean EINK_BOYUE_T78D;
-    public static final boolean EINK_BOYUE_T103D;
-    public static final boolean EINK_ONYX_C67;
-    public static final boolean EINK_ENERGY;
-    public static final boolean EINK_INKBOOK;
-    public static final boolean EINK_TOLINO;
-    public static final boolean EINK_NOOK_V520;
-
+    public static final boolean EINK_FREESCALE;
+    public static final boolean EINK_ROCKCHIP;
     public static final boolean EINK_SUPPORT;
     public static final boolean EINK_FULL_SUPPORT;
-    public static Device CURRENT_DEVICE = Device.UNKNOWN;
+    public static final boolean BUG_WAKELOCKS;
 
     static {
+        // we use the standard android build properties for device id.
         MANUFACTURER = getBuildField("MANUFACTURER");
         BRAND = getBuildField("BRAND");
         MODEL = getBuildField("MODEL");
         DEVICE = getBuildField("DEVICE");
         PRODUCT = getBuildField("PRODUCT");
 
-        HashMap<Device, Boolean> deviceMap = new HashMap<Device, Boolean>();
+        HashMap<EinkDevice, Boolean> deviceMap = new HashMap<EinkDevice, Boolean>();
 
         // Boyue T62, manufacturer uses both "boeye" and "boyue" ids.
-        EINK_BOYUE_T62 = ( MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue") )
+        BOYUE_T62 = ( MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue") )
                 && (PRODUCT.toLowerCase().startsWith("t62") || MODEL.contentEquals("rk30sdk"))
                 && DEVICE.toLowerCase().startsWith("t62");
-        deviceMap.put(Device.BOYUE_T62, EINK_BOYUE_T62);
+        deviceMap.put(EinkDevice.BOYUE_T62, BOYUE_T62);
 
         // Boyue T61, uses RK3066 chipset
-        EINK_BOYUE_T61 = ( MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue") )
+        BOYUE_T61 = ( MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue") )
                 && ( PRODUCT.toLowerCase().startsWith("t61") || MODEL.contentEquals("rk30sdk") )
                 && DEVICE.toLowerCase().startsWith("t61");
-        deviceMap.put(Device.BOYUE_T61, EINK_BOYUE_T61);
+        deviceMap.put(EinkDevice.BOYUE_T61, BOYUE_T61);
 
         // Boyue Likebook Plus
-        EINK_BOYUE_T80S = (MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue"))
+        BOYUE_T80S = (MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue"))
                 && PRODUCT.toLowerCase().contentEquals("t80s");
-        deviceMap.put(Device.BOYUE_T80S, EINK_BOYUE_T80S);
+        deviceMap.put(EinkDevice.BOYUE_T80S, BOYUE_T80S);
 
         // Boyue Likebook Mars
-        EINK_BOYUE_T80D = (MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue"))
+        BOYUE_T80D = (MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue"))
                 && PRODUCT.toLowerCase().contentEquals("t80d");
-        deviceMap.put(Device.BOYUE_T80D, EINK_BOYUE_T80D);
+        deviceMap.put(EinkDevice.BOYUE_T80D, BOYUE_T80D);
 
         // Boyue Likebook Muses
-        EINK_BOYUE_T78D = (MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue"))
+        BOYUE_T78D = (MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue"))
                 && PRODUCT.toLowerCase().contentEquals("t78d");
-        deviceMap.put(Device.BOYUE_T78D, EINK_BOYUE_T78D);
+        deviceMap.put(EinkDevice.BOYUE_T78D, BOYUE_T78D);
 
         // Boyue Likebook Mimas
-        EINK_BOYUE_T103D = (MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue"))
+        BOYUE_T103D = (MANUFACTURER.toLowerCase().contentEquals("boeye") || MANUFACTURER.toLowerCase().contentEquals("boyue"))
                 && PRODUCT.toLowerCase().contentEquals("t103d");
-        deviceMap.put(Device.BOYUE_T103D, EINK_BOYUE_T103D);
+        deviceMap.put(EinkDevice.BOYUE_T103D, BOYUE_T103D);
 
         // Onyx C67
-        EINK_ONYX_C67 = MANUFACTURER.toLowerCase().contentEquals("onyx")
+        ONYX_C67 = MANUFACTURER.toLowerCase().contentEquals("onyx")
                 && ( PRODUCT.toLowerCase().startsWith("c67") || MODEL.contentEquals("rk30sdk") )
                 && DEVICE.toLowerCase().startsWith("c67");
-        deviceMap.put(Device.ONYX_C67, EINK_ONYX_C67);
+        deviceMap.put(EinkDevice.ONYX_C67, ONYX_C67);
 
         // Energy Sistem eReaders. Tested on Energy Ereader Pro 4
-        EINK_ENERGY = (BRAND.toLowerCase().contentEquals("energysistem") || BRAND.toLowerCase().contentEquals("energy_sistem"))
+        ENERGY = (BRAND.toLowerCase().contentEquals("energysistem") || BRAND.toLowerCase().contentEquals("energy_sistem"))
                 && MODEL.toLowerCase().startsWith("ereader");
-        deviceMap.put(Device.ENERGY, EINK_ENERGY);
+        deviceMap.put(EinkDevice.ENERGY, ENERGY);
 
         // Artatech Inkbook Prime/Prime HD.
-        EINK_INKBOOK = MANUFACTURER.toLowerCase().contentEquals("artatech")
+        INKBOOK = MANUFACTURER.toLowerCase().contentEquals("artatech")
                 && BRAND.toLowerCase().contentEquals("inkbook")
                 && MODEL.toLowerCase().startsWith("prime");
-        deviceMap.put(Device.INKBOOK, EINK_INKBOOK);
+        deviceMap.put(EinkDevice.INKBOOK, INKBOOK);
 
         // Tolino
-        EINK_TOLINO = (BRAND.toLowerCase().contentEquals("tolino") && (MODEL.toLowerCase().contentEquals("imx50_rdp")))
+        TOLINO = (BRAND.toLowerCase().contentEquals("tolino") && (MODEL.toLowerCase().contentEquals("imx50_rdp")))
                 || (MODEL.toLowerCase().contentEquals("tolino")
                 && (DEVICE.toLowerCase().contentEquals("tolino_vision2") || DEVICE.toLowerCase().contentEquals("ntx_6sl")));
-        deviceMap.put(Device.TOLINO, EINK_TOLINO);
+        deviceMap.put(EinkDevice.TOLINO, TOLINO);
 
         // Nook Glowlight 3
-        EINK_NOOK_V520 = MANUFACTURER.toLowerCase().contentEquals("barnesandnoble")
+        NOOK_V520 = MANUFACTURER.toLowerCase().contentEquals("barnesandnoble")
                 && MODEL.toLowerCase().contentEquals("bnrv520");
-        deviceMap.put(Device.NOOK_V520, EINK_NOOK_V520);
+        deviceMap.put(EinkDevice.NOOK_V520, NOOK_V520);
 
-        // add your eink device here...
+        // Sony DPT-RP1
+        SONY_RP1 = MANUFACTURER.toLowerCase().contentEquals("sony")
+                && MODEL.toLowerCase().contentEquals("dpt-rp1");
 
-        // true if we found a supported device
-        EINK_SUPPORT = (
-            EINK_BOYUE_T61 ||
-            EINK_BOYUE_T62 ||
-            EINK_BOYUE_T78D ||
-            EINK_BOYUE_T80D ||
-            EINK_BOYUE_T103D ||
-            EINK_ENERGY ||
-            EINK_INKBOOK ||
-            EINK_ONYX_C67 ||
-            EINK_TOLINO ||
-            EINK_NOOK_V520
+        // Android emulator for x86
+        EMULATOR_X86 = MODEL.contentEquals("Android SDK built for x86");
+
+        // freescale epd driver
+        EINK_FREESCALE = (
+            TOLINO ||
+            NOOK_V520
         );
 
-        // true if we have full eink control over android
+        // rockchip epd driver
+        EINK_ROCKCHIP = (
+            BOYUE_T61 ||
+            BOYUE_T62 ||
+            BOYUE_T78D ||
+            BOYUE_T80D ||
+            BOYUE_T103D ||
+            ENERGY ||
+            INKBOOK ||
+            ONYX_C67
+        );
+
+        // basic support
+        EINK_SUPPORT = (
+            EINK_FREESCALE ||
+            EINK_ROCKCHIP
+        );
+
+        // full support
         EINK_FULL_SUPPORT = (
-            EINK_TOLINO ||
-            EINK_NOOK_V520
+            TOLINO
+        );
+
+        // need wakelocks
+        BUG_WAKELOCKS = (
+            SONY_RP1
         );
 
         // find current device.
-        Iterator<Device> iter = deviceMap.keySet().iterator();
-
+        Iterator<EinkDevice> iter = deviceMap.keySet().iterator();
         while (iter.hasNext()) {
-            Device device = iter.next();
+            EinkDevice device = iter.next();
             Boolean flag = deviceMap.get(device);
 
             if (flag) {

--- a/src/org/koreader/launcher/MainActivity.java
+++ b/src/org/koreader/launcher/MainActivity.java
@@ -203,18 +203,31 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         return (device.EINK_FULL_SUPPORT) ? 1 : 0;
     }
 
+    public String getEinkPlatform() {
+        if (device.EINK_FREESCALE) {
+            return "freescale";
+        } else if (device.EINK_ROCKCHIP){
+            return "rockchip";
+        } else {
+            return "none";
+        }
+    }
+
+    public int needsWakelocks() {
+        return (device.BUG_WAKELOCKS) ? 1 : 0;
+    }
 
     /** Used on Rockchip devices */
     public void einkUpdate(int mode) {
         String mode_name = "invalid mode";
 
-        if (mode == device.EPD_FULL) {
+        if (mode == 1) {
             mode_name = "EPD_FULL";
-        } else if (mode == device.EPD_PART) {
+        } else if (mode == 2) {
             mode_name = "EPD_PART";
-        } else if (mode == device.EPD_A2) {
+        } else if (mode == 3) {
             mode_name = "EPD_A2";
-        } else if (mode == device.EPD_AUTO) {
+        } else if (mode == 4) {
             mode_name = "EPD_AUTO";
         } else {
             Logger.e(TAG, String.format("%s: %d", mode_name, mode));
@@ -319,6 +332,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         return getWifiManager().isWifiEnabled() ? 1 : 0;
     }
 
+    @SuppressWarnings("deprecation")
     public String getNetworkInfo() {
         final WifiInfo wi = getWifiManager().getConnectionInfo();
         final DhcpInfo dhcp = getWifiManager().getDhcpInfo();


### PR DESCRIPTION
- enable wakelocks on buggy firmwares ~~and the x86 emulator~~

~~I added the emulator to test the logic myself. Ofc it isn't needed, but shouldn't hurt.~~

Basically: provides a way to check if a device needs wakelocks enabled and the frontend should disallow changing the state on buggy firmware.

- exposes epd platform to frontend

To request updates differently

- better names in DeviceInfo

fixes #125