### PR TITLE
add fullscreen toggle for jelly bean

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1355,6 +1355,16 @@ local function run(android_app_state)
         end)
     end
 
+    android.getScreenAvailableHeight = function()
+        return JNI:context(android.app.activity.vm, function(JNI)
+            return JNI:callIntMethod(
+                android.app.activity.clazz,
+                "getScreenAvailableHeight",
+                "()I"
+            )
+        end)
+    end
+
     android.screen = {}
     android.screen.width = android.getScreenWidth()
     android.screen.height = android.getScreenHeight()

--- a/src/org/koreader/launcher/MainActivity.java
+++ b/src/org/koreader/launcher/MainActivity.java
@@ -298,6 +298,10 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         return screen.getScreenHeight();
     }
 
+    public int getScreenAvailableHeight() {
+        return screen.getScreenAvailableHeight();
+    }
+
     public int getScreenWidth() {
         return screen.getScreenWidth();
     }
@@ -307,11 +311,31 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
     }
 
     public int isFullscreen() {
-        return screen.isFullscreen();
+        // for newer Jelly Bean devices (apis 17 - 18)
+        if ((SDK_INT == Build.VERSION_CODES.JELLY_BEAN_MR2) ||
+            (SDK_INT == Build.VERSION_CODES.JELLY_BEAN_MR1)) {
+            return screen.isFullscreen();
+        }
+        // for older devices (apis 14 - 15 - 16)
+        else if (SDK_INT <= Build.VERSION_CODES.JELLY_BEAN) {
+            return screen.isFullscreenDeprecated();
+        }
+        // for devices with immersive mode (api 19+)
+        else {
+            return 1;
+        }
     }
 
     public void setFullscreen(final boolean enabled) {
-        screen.setFullscreen(enabled);
+        // for newer Jelly Bean devices (apis 17 - 18)
+        if ((SDK_INT == Build.VERSION_CODES.JELLY_BEAN_MR2) ||
+            (SDK_INT == Build.VERSION_CODES.JELLY_BEAN_MR1)) {
+            screen.setFullscreen(enabled);
+        }
+        // for older devices (apis 14 - 15 - 16)
+        else if (SDK_INT <= Build.VERSION_CODES.JELLY_BEAN) {
+            screen.setFullscreenDeprecated(enabled);
+        }
     }
 
     public void setScreenBrightness(final int brightness) {

--- a/src/org/koreader/launcher/ScreenHelper.java
+++ b/src/org/koreader/launcher/ScreenHelper.java
@@ -16,6 +16,8 @@ public class ScreenHelper {
     private String TAG;
     private Context context;
 
+    public boolean is_fullscreen = true;
+
     public ScreenHelper(Context context) {
         this.context = context;
         this.TAG = context.getResources().getString(R.string.app_name);
@@ -28,6 +30,10 @@ public class ScreenHelper {
 
     public int getScreenHeight() {
         return getScreenSize().y;
+    }
+
+    public int getScreenAvailableHeight() {
+        return getScreenSizeWithConstraints().y;
     }
 
     public int getStatusBarHeight() {
@@ -91,10 +97,18 @@ public class ScreenHelper {
 
     /** Screen layout */
     public int isFullscreen() {
+        return (is_fullscreen) ? 1 : 0;
+    }
+
+    public int isFullscreenDeprecated() {
         return ((((Activity)context).getWindow().getAttributes().flags & WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0) ? 1 : 0;
     }
 
     public void setFullscreen(final boolean fullscreen) {
+        is_fullscreen = fullscreen;
+    }
+
+    public void setFullscreenDeprecated(final boolean fullscreen) {
         final CountDownLatch cd = new CountDownLatch(1);
         ((Activity)context).runOnUiThread(new Runnable() {
             @Override
@@ -125,6 +139,22 @@ public class ScreenHelper {
             // JellyBean 4.2 (API 17) and higher
             DisplayMetrics metrics = new DisplayMetrics();
             display.getRealMetrics(metrics);
+            size.set(metrics.widthPixels, metrics.heightPixels);
+        } catch (NoSuchMethodError e) {
+            // Honeycomb 3.0 (API 11) and higher
+            display.getSize(size);
+        }
+        return size;
+    }
+
+
+    private Point getScreenSizeWithConstraints() {
+        Point size = new Point();
+        Display display = ((Activity)context).getWindowManager().getDefaultDisplay();
+        try {
+            // JellyBean 4.2 (API 17) and higher
+            DisplayMetrics metrics = new DisplayMetrics();
+            display.getMetrics(metrics);
             size.set(metrics.widthPixels, metrics.heightPixels);
         } catch (NoSuchMethodError e) {
             // Honeycomb 3.0 (API 11) and higher


### PR DESCRIPTION
See https://github.com/koreader/koreader/issues/4794#issuecomment-473446746

most device owners will want to start KOReader in fullscreen. Only people facing issues where the contents don't fit on available screen area will want to disable fullscreen.

This entire PR does almost nothing. All work need to be done on the frontend.

Related to https://github.com/koreader/koreader/issues/4794