### PR TITLE
Get notch height into account for reporting screen.height (api 28+)

### DIFF
--- a/launcher/AndroidManifest.xml
+++ b/launcher/AndroidManifest.xml
@@ -15,6 +15,7 @@
         <activity android:name="org.koreader.launcher.MainActivity"
                 android:label="@string/app_name"
                 android:screenOrientation="sensorPortrait"
+                android:resizeableActivity="false"
                 android:launchMode="singleInstance"
                 android:theme="@style/Fullscreen">
             <meta-data android:name="android.app.lib_name"


### PR DESCRIPTION
Also set resizeableActivity to false to prevent crashes and take android.max_aspect into account. 

This is needed when targetting api24+

Fix #131 
Fixes https://github.com/koreader/koreader/issues/4769