### PR TITLE
build eink-test for supported abis only, ignore debug builds, copy artifacts to bin/ folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ release: update build-luajit
 	@echo "WARNING: You'll need to sign this application to be able to install it"
 	mkdir -p bin/
 	find launcher/build/outputs/apk/ -type f -name '*.apk' -exec mv -v {} bin/ \;
+	find eink-test/build/outputs/apk/ -type f -name '*.apk' -exec mv -v {} bin/ \;
 
 clean:
 	# clean luajit build tree and remove binaries (assets and apks)

--- a/eink-test/build.gradle
+++ b/eink-test/build.gradle
@@ -19,9 +19,27 @@ android {
         }
     }
 
+    flavorDimensions "abi"
+    productFlavors {
+        arm {
+            ndk { abiFilters "armeabi-v7a" }
+            dimension = 'abi'
+        }
+        x86 {
+            ndk { abiFilters "x86" }
+            dimension = 'abi'
+        }
+    }
+
+    variantFilter { variant ->
+        if (variant.buildType.name == 'debug') {
+            setIgnore(true)
+        }
+    }
+
     applicationVariants.all { variant ->
         variant.outputs.all {
-            outputFileName = "einkTest.apk"
+            outputFileName = "einkTest-${variant.getFlavorName()}.apk"
         }
     }
 


### PR DESCRIPTION
Related to https://github.com/koreader/virdevenv/pull/40.

It will create new release apks for einkTest using the Makefile. Debug builds will be ignored.

Artifacts are placed in bin/ with name 'einkTest-${abi}.apk'