### PR TITLE
Add options to modify screen timeout while the application is running

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1407,6 +1407,27 @@ local function run(android_app_state)
         end)
     end
 
+    android.getScreenTimeout = function()
+        return JNI:context(android.app.activity.vm, function(JNI)
+            return JNI:callIntMethod(
+                android.app.activity.clazz,
+                "getScreenTimeout",
+                "()I"
+            )
+        end)
+    end
+
+    android.setScreenTimeout = function(timeout)
+        JNI:context(android.app.activity.vm, function(JNI)
+            JNI:callVoidMethod(
+                android.app.activity.clazz,
+                "setScreenTimeout",
+                "(I)V",
+                ffi.new('int32_t', timeout)
+            )
+        end)
+    end
+
     android.getBatteryLevel = function()
         return JNI:context(android.app.activity.vm, function(JNI)
             return JNI:callIntMethod(

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1407,21 +1407,21 @@ local function run(android_app_state)
         end)
     end
 
-    android.getScreenTimeout = function()
+    android.getScreenOffTimeout = function()
         return JNI:context(android.app.activity.vm, function(JNI)
             return JNI:callIntMethod(
                 android.app.activity.clazz,
-                "getScreenTimeout",
+                "getScreenOffTimeout",
                 "()I"
             )
         end)
     end
 
-    android.setScreenTimeout = function(timeout)
+    android.setScreenOffTimeout = function(timeout)
         JNI:context(android.app.activity.vm, function(JNI)
             JNI:callVoidMethod(
                 android.app.activity.clazz,
-                "setScreenTimeout",
+                "setScreenOffTimeout",
                 "(I)V",
                 ffi.new('int32_t', timeout)
             )

--- a/launcher/src/org/koreader/device/DeviceInfo.java
+++ b/launcher/src/org/koreader/device/DeviceInfo.java
@@ -1,10 +1,8 @@
-/**
- * Device info using Android build properties,
+/* Device info using Android build properties,
  * based on https://github.com/unwmun/refreshU
  *
  * Note: devices don't need to be declared here unless
- * they have known eink update routines and/or bug workarounds.
- */
+ * they have known eink update routines and/or bug workarounds. */
 
 package org.koreader.device;
 

--- a/launcher/src/org/koreader/device/EPDController.java
+++ b/launcher/src/org/koreader/device/EPDController.java
@@ -1,7 +1,5 @@
-/**
- * generic EPD Controller for Android devices,
- * based on https://github.com/unwmun/refreshU
- */
+/* generic EPD Controller for Android devices,
+ * based on https://github.com/unwmun/refreshU */
 
 package org.koreader.device;
 

--- a/launcher/src/org/koreader/device/EPDFactory.java
+++ b/launcher/src/org/koreader/device/EPDFactory.java
@@ -1,7 +1,5 @@
-/**
- * generic EPD Controller for Android devices,
- * based on https://github.com/unwmun/refreshU
- */
+/* generic EPD Controller for Android devices,
+ * based on https://github.com/unwmun/refreshU */
 
 package org.koreader.device;
 
@@ -22,7 +20,7 @@ public class EPDFactory {
 
         switch (DeviceInfo.CURRENT_DEVICE) {
 
-            /** Supported rk3026 devices */
+            /* Supported rk3026 devices */
             case BOYUE_T61:
             case BOYUE_T80S:
             case ONYX_C67:
@@ -32,13 +30,13 @@ public class EPDFactory {
                 epdController = new RK3026EPDController();
                 break;
 
-            /** supported rk3066 devices */
+            /* supported rk3066 devices */
             case BOYUE_T62:
                 controllerName = "Rockchip RK3066";
                 epdController = new RK3066EPDController();
                 break;
 
-            /** supported rk3368 devices */
+            /* supported rk3368 devices */
             case BOYUE_T80D:
             case BOYUE_T78D:
             case BOYUE_T103D:
@@ -46,7 +44,7 @@ public class EPDFactory {
                 epdController = new RK3368EPDController();
                 break;
 
-            /** devices using imx/ntx platform */
+            /* devices using imx/ntx platform */
             case CREMA:
             case TOLINO:
             case NOOK_V520:
@@ -54,7 +52,7 @@ public class EPDFactory {
                 epdController = new NTXNewEPDController();
                 break;
 
-            /** unsupported devices */
+            /* unsupported devices */
             case UNKNOWN:
                 epdController = new FakeEPDController();
                 break;
@@ -72,7 +70,7 @@ public class EPDFactory {
     private static class FakeEPDController implements EPDController {
         @Override
         public void setEpdMode(android.view.View targetView, int mode, long delay, int x, int y, int width, int height, String epdMode) {
-            /** do nothing */
+            /* do nothing */
         }
     }
 }

--- a/launcher/src/org/koreader/device/freescale/NTXEPDController.java
+++ b/launcher/src/org/koreader/device/freescale/NTXEPDController.java
@@ -1,5 +1,4 @@
-/**
- * generic EPD Controller for Android,
+/* generic EPD Controller for Android,
  *
  * interface for newer ntx devices.
  * based on https://github.com/koreader/koreader/issues/3517

--- a/launcher/src/org/koreader/device/rockchip/RK3026EPDController.java
+++ b/launcher/src/org/koreader/device/rockchip/RK3026EPDController.java
@@ -1,7 +1,5 @@
-/**
- * generic EPD Controller for Android devices,
- * based on https://github.com/unwmun/refreshU
- */
+/* generic EPD Controller for Android devices,
+ * based on https://github.com/unwmun/refreshU */
 
 package org.koreader.device.rockchip;
 

--- a/launcher/src/org/koreader/device/rockchip/RK3066EPDController.java
+++ b/launcher/src/org/koreader/device/rockchip/RK3066EPDController.java
@@ -1,7 +1,5 @@
-/**
- * generic EPD Controller for Android devices,
- * based on https://github.com/unwmun/refreshU
- */
+/* generic EPD Controller for Android devices,
+ * based on https://github.com/unwmun/refreshU */
 
 package org.koreader.device.rockchip;
 

--- a/launcher/src/org/koreader/device/rockchip/RK30xxEPDController.java
+++ b/launcher/src/org/koreader/device/rockchip/RK30xxEPDController.java
@@ -1,5 +1,4 @@
-/**
- * This file was created by unw on 15. 3. 25 as part of
+/* This file was created by unw on 15. 3. 25 as part of
  * https://github.com/unwmun/refreshU
  *
  * interface for Boyue T61/T62 clones

--- a/launcher/src/org/koreader/device/rockchip/RK3368EPDController.java
+++ b/launcher/src/org/koreader/device/rockchip/RK3368EPDController.java
@@ -1,7 +1,5 @@
-/**
- * generic EPD Controller for Android devices,
- * based on https://github.com/unwmun/refreshU
- */
+/* generic EPD Controller for Android devices,
+ * based on https://github.com/unwmun/refreshU */
 
 package org.koreader.device.rockchip;
 

--- a/launcher/src/org/koreader/device/rockchip/RK33xxEPDController.java
+++ b/launcher/src/org/koreader/device/rockchip/RK33xxEPDController.java
@@ -1,9 +1,7 @@
-/**
- * generic EPD Controller for Android devices
+/* generic EPD Controller for Android devices
  *
  * interface for boyue mimas and maybe others,
- * based on https://github.com/koreader/koreader/issues/4595
- */
+ * based on https://github.com/koreader/koreader/issues/4595 */
 
 package org.koreader.device.rockchip;
 

--- a/launcher/src/org/koreader/launcher/Device.java
+++ b/launcher/src/org/koreader/launcher/Device.java
@@ -22,9 +22,7 @@ public class Device {
         this.epd = EPDFactory.getEPDController(tag);
     }
 
-    /**
-     * Used on Rockchip devices
-     */
+    /* Used on Rockchip devices */
     public void einkUpdate(SurfaceView view, int mode) {
         String mode_name = "invalid mode";
 
@@ -44,9 +42,7 @@ public class Device {
         epd.setEpdMode(view, 0, 0, 0, 0, 0, 0, mode_name);
     }
 
-    /**
-     * Used on Freescale imx devices
-     */
+    /* Used on Freescale imx devices */
     public void einkUpdate(SurfaceView view, int mode, long delay, int x, int y, int width, int height) {
         Logger.v(tag, String.format("requesting epd update, mode:%d, delay:%d, [x:%d, y:%d, w:%d, h:%d]",
             mode, delay, x, y, width, height));

--- a/launcher/src/org/koreader/launcher/IntentUtils.java
+++ b/launcher/src/org/koreader/launcher/IntentUtils.java
@@ -6,13 +6,14 @@ import android.content.Intent;
 
 public class IntentUtils {
 
-    /* get intent by action type, used to do dict lookups on 3rd party apps.
+    /**
+     * get intent by action type, used to do dict lookups on 3rd party apps.
      *
      * @param text to search
      * @param package that receives the query
      * @param action associated to the package
      *
-     * @returns a Intent based on package/action ready to do a text lookup
+     * @return a Intent based on package/action ready to do a text lookup
      */
 
     public static Intent getByAction(String text, String pkg, String action) {

--- a/launcher/src/org/koreader/launcher/MainActivity.java
+++ b/launcher/src/org/koreader/launcher/MainActivity.java
@@ -350,7 +350,9 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
             power.setWakelockState(false);
         }
 
-        screen.setTimeout(timeout);
+        if (hasWriteSettingsEnabled()) {
+            screen.setTimeout(timeout);
+        }
     }
 
     public int getScreenAvailableHeight() {
@@ -522,7 +524,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
             sb.append(resumed);
             Logger.d(tag, sb.toString());
             power.setWakelock(resumed);
-        } else if ((screen.app_timeout > screen.TIMEOUT_SYSTEM) && (hasWriteSettingsEnabled())) {
+        } else if (screen.app_timeout > screen.TIMEOUT_SYSTEM) {
             sb.append("custom settings: ");
             sb.append(resumed);
             Logger.d(tag, sb.toString());

--- a/launcher/src/org/koreader/launcher/MainActivity.java
+++ b/launcher/src/org/koreader/launcher/MainActivity.java
@@ -19,6 +19,12 @@ import androidx.core.content.ContextCompat;
 
 import java.util.List;
 
+/* LuaJIT launcher main Activity, based on NativeActivity.
+   Most of the methods of this class are intended to be used
+   from lua using the JNI/FFI interface in assets/android.lua. */
+
+
+@SuppressWarnings("unused")
 public class MainActivity extends android.app.NativeActivity implements SurfaceHolder.Callback2,
     ActivityCompat.OnRequestPermissionsResultCallback {
 
@@ -66,7 +72,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         screen = new ScreenHelper(this);
         network = new NetworkManager(this);
 
-        /** Listen to visibility changes */
+        // listen to visibility changes
         if (SDK_INT >= Build.VERSION_CODES.KITKAT) {
             setFullscreenLayout();
             View decorView = getWindow().getDecorView();
@@ -88,7 +94,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         Logger.d(tag, "App resumed");
         setTimeout(true);
         super.onResume();
-        /** switch to fullscreen for older devices */
+        // switch to fullscreen for older devices
         if (SDK_INT < Build.VERSION_CODES.KITKAT) {
             final Handler handler = new Handler();
             handler.postDelayed(new Runnable() {
@@ -207,86 +213,69 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         }
     }
 
-    /* These functions are exposed to lua in assets/android.lua
-     * If you add a new function here remember to write the companion
-     * lua function in that file */
 
+    /* --- JNI/FFI interface begins --- */
 
-    /** build */
-    @SuppressWarnings("unused")
+    /* build */
     public int isDebuggable() {
         return (BuildConfig.DEBUG) ? 1 : 0;
     }
 
-    @SuppressWarnings("unused")
     public String getFlavor() {
         return getResources().getString(R.string.app_flavor);
     }
 
-    @SuppressWarnings("unused")
     public String getName() {
         return getResources().getString(R.string.app_name);
     }
 
     /* clipboard */
-    @SuppressWarnings("unused")
     public String getClipboardText() {
         return clipboard.getClipboardText();
     }
 
-    @SuppressWarnings("unused")
     public int hasClipboardTextIntResultWrapper() {
         return clipboard.hasClipboardText();
     }
 
-    @SuppressWarnings("unused")
     public void setClipboardText(final String text) {
         clipboard.setClipboardText(text);
     }
 
     /* device */
-    @SuppressWarnings("unused")
     public String getProduct() {
         return device.getProduct();
     }
 
-    @SuppressWarnings("unused")
     public String getVersion() {
         return android.os.Build.VERSION.RELEASE;
     }
 
-    @SuppressWarnings("unused")
     public int isEink() {
         return device.isEink();
     }
 
-    @SuppressWarnings("unused")
     public int isEinkFull() {
         return device.isFullEink();
     }
 
-    @SuppressWarnings("unused")
     public String getEinkPlatform() {
         return device.einkPlatform();
     }
 
-    @SuppressWarnings("unused")
     public int needsWakelocks() {
         return device.needsWakelock();
     }
 
-    @SuppressWarnings("unused")
     public void einkUpdate(int mode) {
         device.einkUpdate(surface, mode);
     }
 
-    @SuppressWarnings("unused")
     public void einkUpdate(int mode, long delay, int x, int y, int width, int height) {
         device.einkUpdate(surface, mode, delay, x, y, width, height);
     }
 
     /* external dictionaries */
-    @SuppressWarnings("unused")
     public void dictLookup(String text, String pkg, String action) {
         Intent intent = new Intent(intentUtils.getByAction(text, pkg, action));
         if (!startActivityIfSafe(intent)) {
@@ -295,7 +284,6 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
     }
 
     /* native dialogs and widgets run on UI Thread */
-    @SuppressWarnings("unused")
     public void showToast(final String message) {
         runOnUiThread(new Runnable() {
             @Override
@@ -306,7 +294,6 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         });
     }
 
-    @SuppressWarnings("unused")
     public void showProgress(final String title, final String message) {
         runOnUiThread(new Runnable() {
             @Override
@@ -317,7 +304,6 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         });
     }
 
-    @SuppressWarnings("unused")
     public void dismissProgress() {
         runOnUiThread(new Runnable() {
             @Override
@@ -330,7 +316,6 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
     }
 
     /* package manager */
-    @SuppressWarnings("unused")
     public int isPackageEnabled(String pkg) {
         try {
             // is the package available (installed and enabled) ?
@@ -346,28 +331,23 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
     }
 
     /* power */
-    @SuppressWarnings("unused")
     public int isCharging() {
         return power.batteryCharging();
     }
 
-    @SuppressWarnings("unused")
     public int getBatteryLevel() {
         return power.batteryPercent();
     }
 
-    @SuppressWarnings("unused")
     public void setWakeLock(final boolean enabled) {
         power.setWakelockState(enabled);
     }
 
     /* screen */
-    @SuppressWarnings("unused")
     public int getScreenBrightness() {
         return screen.getScreenBrightness();
     }
 
-    @SuppressWarnings("unused")
     public int getScreenHeight() {
         if (SDK_INT >= Build.VERSION_CODES.P) {
             return (screen.getScreenHeight() - notch_height);
@@ -376,12 +356,10 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         }
     }
 
-    @SuppressWarnings("unused")
     public int getScreenOffTimeout() {
         return screen.app_timeout;
     }
 
-    @SuppressWarnings("unused")
     public void setScreenOffTimeout(final int timeout) {
         if (timeout == screen.TIMEOUT_WAKELOCK) {
             power.setWakelockState(true);
@@ -392,22 +370,18 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         screen.setTimeout(timeout);
     }
 
-    @SuppressWarnings("unused")
     public int getScreenAvailableHeight() {
         return screen.getScreenAvailableHeight();
     }
 
-    @SuppressWarnings("unused")
     public int getScreenWidth() {
         return screen.getScreenWidth();
     }
 
-    @SuppressWarnings("unused")
     public int getStatusBarHeight() {
         return screen.getStatusBarHeight();
     }
 
-    @SuppressWarnings("unused")
     public int isFullscreen() {
         // for newer Jelly Bean devices (apis 17 - 18)
         if ((SDK_INT == Build.VERSION_CODES.JELLY_BEAN_MR2) ||
@@ -424,7 +398,6 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         }
     }
 
-    @SuppressWarnings("unused")
     public void setFullscreen(final boolean enabled) {
         // for newer Jelly Bean devices (apis 17 - 18)
         if ((SDK_INT == Build.VERSION_CODES.JELLY_BEAN_MR2) ||
@@ -437,7 +410,6 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         }
     }
 
-    @SuppressWarnings("unused")
     public void setScreenBrightness(final int brightness) {
         if (hasWriteSettingsEnabled()) {
             screen.setScreenBrightness(brightness);
@@ -445,34 +417,30 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
     }
 
     /* wifi */
-    @SuppressWarnings("unused")
     public void setWifiEnabled(final boolean enabled) {
         network.setWifi(enabled);
     }
 
-    @SuppressWarnings("unused")
     public int isWifiEnabled() {
         return network.isWifi();
     }
 
-    @SuppressWarnings("unused")
     public String getNetworkInfo() {
         return network.info();
     }
 
-    @SuppressWarnings("unused")
     public int download(final String url, final String name) {
         return network.download(url, name);
     }
 
-    @SuppressWarnings("unused")
     public int openLink(String url) {
         Uri webpage = Uri.parse(url);
         Intent intent = new Intent(Intent.ACTION_VIEW, webpage);
         return (startActivityIfSafe(intent)) ? 0 : 1;
     }
 
-    // --- end of public exported functions -------------
+    /* --- JNI/FFI interface ends --- */
+
 
     // WRITE_SETTINGS is a special permission and needs to be granted through a permission management screen.
     // see https://developer.android.com/reference/android/Manifest.permission.html#WRITE_SETTINGS

--- a/launcher/src/org/koreader/launcher/MainActivity.java
+++ b/launcher/src/org/koreader/launcher/MainActivity.java
@@ -57,6 +57,9 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         tag = getName();
         Logger.d(tag, "App created");
 
+        // (re)initialize helper classes.
+        initHelperClasses();
+
         // set the native window as an android surface. Useful in *some* eink devices,
         // where the epd driver is hooked in the View class framework.
         getWindow().takeSurface(null);
@@ -125,12 +128,6 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
     @Override
     protected void onDestroy() {
         Logger.d(tag, "App destroyed");
-        clipboard = null;
-        device = null;
-        power = null;
-        screen = null;
-        surface = null;
-        network = null;
         super.onDestroy();
     }
 
@@ -441,6 +438,15 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
 
     /* --- JNI/FFI interface ends --- */
 
+
+    private void initHelperClasses() {
+        clipboard = null;
+        device = null;
+        power = null;
+        screen = null;
+        surface = null;
+        network = null;
+    }
 
     // WRITE_SETTINGS is a special permission and needs to be granted through a permission management screen.
     // see https://developer.android.com/reference/android/Manifest.permission.html#WRITE_SETTINGS

--- a/launcher/src/org/koreader/launcher/MainActivity.java
+++ b/launcher/src/org/koreader/launcher/MainActivity.java
@@ -117,20 +117,6 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         super.onPause();
     }
 
-    /* Called when the activity is no longer visible. */
-    @Override
-    protected void onStop() {
-        Logger.d(tag, "App stopped");
-        super.onStop();
-    }
-
-    /* Called just before the activity is destroyed. */
-    @Override
-    protected void onDestroy() {
-        Logger.d(tag, "App destroyed");
-        super.onDestroy();
-    }
-
     /* Called just before the activity is resumed by an intent */
     @Override
     protected void onNewIntent(Intent intent) {

--- a/launcher/src/org/koreader/launcher/MainActivity.java
+++ b/launcher/src/org/koreader/launcher/MainActivity.java
@@ -377,12 +377,12 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
     }
 
     @SuppressWarnings("unused")
-    public int getScreenTimeout() {
-        return screen.getTimeout();
+    public int getScreenOffTimeout() {
+        return screen.app_timeout;
     }
 
     @SuppressWarnings("unused")
-    public void setScreenTimeout(final int timeout) {
+    public void setScreenOffTimeout(final int timeout) {
         if (timeout == screen.TIMEOUT_WAKELOCK) {
             power.setWakelockState(true);
         } else {
@@ -540,24 +540,31 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
 
 
     /** set screen timeout based on activity state. Intended to be hooked
-     *  in onResume / onPause activity callbacks.
+     *  in onResume/onPause activity callbacks.
      *
-     *  the method based on wakelocks works without problems.
-     *  the method based on modifying android system settings should work
-     *  but requires the special permission WRITE_SETTINGS.
+     *  TIMEOUT_SYSTEM does nothing!
+     *  TIMEOUT_WAKELOCK uses the standard permission WAKELOCKS.
+     *  Custom timeouts use the special permission WRITE_SETTINGS.
      *
-     *  @param focus - is the activity resumed and focused?
+     *  @param resumed - is the activity resumed and focused?
      */
-    private void setTimeout(final boolean focus) {
-        int current_timeout = screen.getTimeout();
-        if (current_timeout == screen.TIMEOUT_WAKELOCK) {
-            Logger.d(tag, String.format("timeout callback, focus: %b -> using wakelocks", focus));
-            power.setWakelock(focus);
-        } else if ((current_timeout > screen.TIMEOUT_SYSTEM) && (hasWriteSettingsEnabled())) {
-            Logger.d(tag, String.format("timeout callback, focus: %b -> using custom settings", focus));
-            screen.updateTimeout(focus);
-        } else if (current_timeout == screen.TIMEOUT_SYSTEM) {
-            Logger.d(tag, String.format("timeout callback, focus: %b -> using system settings", focus));
+    private void setTimeout(final boolean resumed) {
+        StringBuilder sb = new StringBuilder("timeout: ");
+        if (resumed)
+            sb.append("onResume callback -> ");
+        else
+            sb.append("onPause callback -> ");
+
+        if (screen.app_timeout == screen.TIMEOUT_WAKELOCK) {
+            sb.append("using wakelocks: ");
+            sb.append(resumed);
+            Logger.d(tag, sb.toString());
+            power.setWakelock(resumed);
+        } else if ((screen.app_timeout > screen.TIMEOUT_SYSTEM) && (hasWriteSettingsEnabled())) {
+            sb.append("custom settings: ");
+            sb.append(resumed);
+            Logger.d(tag, sb.toString());
+            screen.setTimeout(resumed);
         }
     }
 

--- a/launcher/src/org/koreader/launcher/MainActivity.java
+++ b/launcher/src/org/koreader/launcher/MainActivity.java
@@ -42,7 +42,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
     // size in pixels of the top notch, if any
     private int notch_height = 0;
 
-    /** Called when the activity is first created. */
+    /* Called when the activity is first created. */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -82,7 +82,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         requestPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE, REQUEST_WRITE_STORAGE);
     }
 
-    /** Called when the activity has become visible. */
+    /* Called when the activity has become visible. */
     @Override
     protected void onResume() {
         Logger.d(tag, "App resumed");
@@ -100,7 +100,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         }
     }
 
-    /** Called when another activity is taking focus. */
+    /* Called when another activity is taking focus. */
     @Override
     protected void onPause() {
         Logger.d(tag, "App paused");
@@ -108,14 +108,14 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         super.onPause();
     }
 
-    /** Called when the activity is no longer visible. */
+    /* Called when the activity is no longer visible. */
     @Override
     protected void onStop() {
         Logger.d(tag, "App stopped");
         super.onStop();
     }
 
-    /** Called just before the activity is destroyed. */
+    /* Called just before the activity is destroyed. */
     @Override
     protected void onDestroy() {
         Logger.d(tag, "App destroyed");
@@ -128,14 +128,14 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         super.onDestroy();
     }
 
-    /** Called just before the activity is resumed by an intent */
+    /* Called just before the activity is resumed by an intent */
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         setIntent(intent);
     }
 
-    /** Called when a new surface is created */
+    /* Called when a new surface is created */
     @Override
     public void surfaceCreated(SurfaceHolder holder) {
         Logger.d(tag, "Surface created");
@@ -143,7 +143,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         surface.setWillNotDraw(false);
     }
 
-    /** Called after a surface change */
+    /* Called after a surface change */
     @Override
     public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
         Logger.d(tag, String.format(
@@ -153,14 +153,14 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         super.surfaceChanged(holder,format,width,height);
     }
 
-    /** Called when the surface is destroyed */
+    /* Called when the surface is destroyed */
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
         Logger.d(tag, "Surface destroyed");
         super.surfaceDestroyed(holder);
     }
 
-    /** Called when the view is attached to a window */
+    /* Called when the view is attached to a window */
     @Override
     public void onAttachedToWindow() {
         super.onAttachedToWindow();
@@ -179,14 +179,14 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         }
     }
 
-    /** Called when the view is detached from its window */
+    /* Called when the view is detached from its window */
     @Override
     public void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         Logger.d(tag, "surface detached from its window");
     }
 
-    /** Called on permission result */
+    /* Called on permission result */
     @Override
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
@@ -207,9 +207,9 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         }
     }
 
-    /** These functions are exposed to lua in assets/android.lua
-     *  If you add a new function here remember to write the companion
-     *  lua function in that file */
+    /* These functions are exposed to lua in assets/android.lua
+     * If you add a new function here remember to write the companion
+     * lua function in that file */
 
 
     /** build */
@@ -228,7 +228,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         return getResources().getString(R.string.app_name);
     }
 
-    /** clipboard */
+    /* clipboard */
     @SuppressWarnings("unused")
     public String getClipboardText() {
         return clipboard.getClipboardText();
@@ -244,7 +244,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         clipboard.setClipboardText(text);
     }
 
-    /** device */
+    /* device */
     @SuppressWarnings("unused")
     public String getProduct() {
         return device.getProduct();
@@ -285,7 +285,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         device.einkUpdate(surface, mode, delay, x, y, width, height);
     }
 
-    /** external dictionaries */
+    /* external dictionaries */
     @SuppressWarnings("unused")
     public void dictLookup(String text, String pkg, String action) {
         Intent intent = new Intent(intentUtils.getByAction(text, pkg, action));
@@ -294,7 +294,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         }
     }
 
-    /** native dialogs and widgets run on UI Thread */
+    /* native dialogs and widgets run on UI Thread */
     @SuppressWarnings("unused")
     public void showToast(final String message) {
         runOnUiThread(new Runnable() {
@@ -329,7 +329,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         });
     }
 
-    /** package manager */
+    /* package manager */
     @SuppressWarnings("unused")
     public int isPackageEnabled(String pkg) {
         try {
@@ -345,7 +345,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         }
     }
 
-    /** power */
+    /* power */
     @SuppressWarnings("unused")
     public int isCharging() {
         return power.batteryCharging();
@@ -361,7 +361,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         power.setWakelockState(enabled);
     }
 
-    /** screen */
+    /* screen */
     @SuppressWarnings("unused")
     public int getScreenBrightness() {
         return screen.getScreenBrightness();
@@ -444,7 +444,7 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         }
     }
 
-    /** wifi */
+    /* wifi */
     @SuppressWarnings("unused")
     public void setWifiEnabled(final boolean enabled) {
         network.setWifi(enabled);
@@ -539,15 +539,17 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
     }
 
 
-    /** set screen timeout based on activity state. Intended to be hooked
-     *  in onResume/onPause activity callbacks.
+    /**
+     * set screen timeout based on activity state.
+     * Intended to be hooked in onResume/onPause activity callbacks.
      *
-     *  TIMEOUT_SYSTEM does nothing!
-     *  TIMEOUT_WAKELOCK uses the standard permission WAKELOCKS.
-     *  Custom timeouts use the special permission WRITE_SETTINGS.
+     * TIMEOUT_SYSTEM does nothing!
+     * TIMEOUT_WAKELOCK uses the standard permission WAKELOCKS.
+     * Custom timeouts use the special permission WRITE_SETTINGS.
      *
-     *  @param resumed - is the activity resumed and focused?
+     * @param resumed The state of this activity.
      */
+
     private void setTimeout(final boolean resumed) {
         StringBuilder sb = new StringBuilder("timeout: ");
         if (resumed)

--- a/launcher/src/org/koreader/launcher/NetworkManager.java
+++ b/launcher/src/org/koreader/launcher/NetworkManager.java
@@ -29,7 +29,8 @@ public class NetworkManager {
         wifi.setWifiEnabled(state);
     }
 
-    /** Basic network information
+    /**
+     * Basic network information
      *
      * @return a string containing wifi name, ip and gateway.
      */
@@ -44,7 +45,8 @@ public class NetworkManager {
         return String.format("%s;%s;%s", wi.getSSID(), ip_address, gw_address);
     }
 
-    /** Download a file
+    /**
+     * Download a file
      *
      * @param url   - the full qualified url to the file you'll want to download
      * @param name  - the name of the file with the extension (ie: "foo.mp4")
@@ -75,15 +77,3 @@ public class NetworkManager {
         }
     }
 }
-
-
-/*
-    public void setWifiEnabled(final boolean enabled) {
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                getWifiManager().setWifiEnabled(enabled);
-            }
-        });
-    }
- */

--- a/launcher/src/org/koreader/launcher/PowerHelper.java
+++ b/launcher/src/org/koreader/launcher/PowerHelper.java
@@ -40,11 +40,11 @@ public class PowerHelper {
     }
 
     public void setWakelockState(final boolean enabled) {
-        /** release wakelock first, if present and wakelocks are allowed */
+        /* release wakelock first, if present and wakelocks are allowed */
         if (isWakeLockAllowed && wakelock != null) wakelockRelease();
-        /** update wakelock settings */
+        /* update wakelock settings */
         isWakeLockAllowed = enabled;
-        /** acquire wakelock if we don't have one and wakelocks are allowed */
+        /* acquire wakelock if we don't have one and wakelocks are allowed */
         if (isWakeLockAllowed && wakelock == null) wakelockAcquire();
     }
 

--- a/launcher/src/org/koreader/launcher/ScreenHelper.java
+++ b/launcher/src/org/koreader/launcher/ScreenHelper.java
@@ -33,7 +33,7 @@ public class ScreenHelper {
         this.sys_timeout = readSettingScreenOffTimeout();
     }
 
-    /** Screen size */
+    /* Screen size */
     public int getScreenWidth() {
         return getScreenSize().x;
     }
@@ -54,7 +54,7 @@ public class ScreenHelper {
         return statusBarHeight;
     }
 
-    /** Screen brightness */
+    /* Screen brightness */
     public int getScreenBrightness() {
         final Box<Integer> result = new Box<Integer>();
         final CountDownLatch cd = new CountDownLatch(1);
@@ -105,14 +105,15 @@ public class ScreenHelper {
         });
     }
 
-    /** Screen timeout */
+    /* Screen timeout */
 
-    /** set the new timeout state
+    /**
+     * set the new timeout state
      *
-     *  @param new_timeout - new timeout state:
+     * known timeout states are TIMEOUT_SYSTEM, TIMEOUT_WAKELOCK
+     * and values greater than 0 (milliseconds of the new timeout).
      *
-     *  known timeout states are TIMEOUT_SYSTEM, TIMEOUT_WAKELOCK
-     *  and values greater than 0 (milliseconds of the new timeout).
+     * @param new_timeout - new timeout state:
      */
 
     public void setTimeout(final int new_timeout) {
@@ -130,9 +131,10 @@ public class ScreenHelper {
         }
     }
 
-    /** set timeout based on activity state
+    /**
+     * set timeout based on activity state
      *
-     *  @param resumed - is the activity resumed and focused?
+     * @param resumed - is the activity resumed and focused?
      */
 
     public void setTimeout(final boolean resumed) {
@@ -162,7 +164,7 @@ public class ScreenHelper {
         }
     }
 
-    /** Screen layout */
+    /* Screen layout */
     public int isFullscreen() {
         return (is_fullscreen) ? 1 : 0;
     }


### PR DESCRIPTION
Until now we relied on android wide settings or use wakelocks to disable the timeout.

This PR adds other timeout options, which are embedded on the activity lifecycle:

- when the app is resumed use a custom timeout , if any, or acquire a new wakelock.
- when the app is paused restore default timeout or release the wakelock.

Since users can modify the screen timeout from android settings we need to update system timeout on resume too.

Some logs to show how this is integrated into the lifecycle of the activity:

#### activity pause/resume with no custom option

```adb logcat
D/KOReader( 3758): timeout callback, focus: false -> using system settings
D/KOReader( 3758): timeout callback, focus: true -> using system settings
```

#### activity pause/resume with custom option

```adb logcat
D/KOReader( 3758): set timeout for KOReader: 600 seconds
D/KOReader( 3758): timeout callback, focus: false -> using custom settings
D/KOReader( 3758): restoring system timeout: 600 -> 30 seconds
D/KOReader( 3758): timeout callback, focus: true -> using custom settings
D/KOReader( 3758): restoring KOReader timeout: 30 -> 600 seconds
```

Please feel free to suggest more descriptive names for the new methods. I'm clueless about it :man_facepalming: 