### PR TITLE
avoid the JNI/Java overhead on input events

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1407,46 +1407,27 @@ local function run(android_app_state)
         end)
     end
 
+    -- input settings
+    android.input = {}
+
+    -- ignore some events
+    android.input.ignore_touchscreen = false
+    android.input.ignore_volume_keys = false
+
     android.getVolumeKeysIgnored = function()
-        return JNI:context(android.app.activity.vm, function(JNI)
-            return JNI:callIntMethod(
-                android.app.activity.clazz,
-                "getVolumeKeysIgnored",
-                "()I"
-            ) == 1
-        end)
+        return android.input.ignore_volume_keys
     end
 
     android.setVolumeKeysIgnored = function(ignored)
-        android.DEBUG("ignoring volume keys: " .. tostring(ignored))
-        JNI:context(android.app.activity.vm, function(JNI)
-            JNI:callVoidMethod(
-                android.app.activity.clazz,
-                "setVolumeKeysIgnored",
-                "(Z)V",
-                ffi.new("bool", ignored)
-            )
-        end)
+        android.input.ignore_volume_keys = ignored
     end
 
     android.isTouchscreenIgnored = function()
-        return JNI:context(android.app.activity.vm, function(JNI)
-            return JNI:callIntMethod(
-                android.app.activity.clazz,
-                "isTouchscreenIgnored",
-                "()I"
-            ) == 1
-        end)
+        return android.input.ignore_touchscreen
     end
 
     android.toggleTouchscreenIgnored = function()
-        JNI:context(android.app.activity.vm, function(JNI)
-            JNI:callVoidMethod(
-                android.app.activity.clazz,
-                "toggleTouchscreenIgnored",
-                "()V"
-            )
-        end)
+        android.input.ignore_touchscreen = not android.input.ignore_touchscreen
     end
 
     -- properties that don't change during the execution of the program.

--- a/launcher/src/org/koreader/launcher/MainActivity.java
+++ b/launcher/src/org/koreader/launcher/MainActivity.java
@@ -48,9 +48,6 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
     // size in pixels of the top notch, if any
     private int notch_height = 0;
 
-    private boolean touchscreen_ignored = false;
-    private boolean volume_keys_ignored = false;
-
     /* Called when the activity is first created. */
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -267,23 +264,6 @@ public class MainActivity extends android.app.NativeActivity implements SurfaceH
         if (!startActivityIfSafe(intent)) {
             Logger.e(tag, "dictionary lookup: can't find a package able to resolve action " + action);
         }
-    }
-
-    /* input */
-    public int isTouchscreenIgnored() {
-        return touchscreen_ignored ? 1 : 0;
-    }
-
-    public int getVolumeKeysIgnored() {
-        return volume_keys_ignored ? 1 : 0;
-    }
-
-    public void toggleTouchscreenIgnored() {
-        touchscreen_ignored = !touchscreen_ignored;
-    }
-
-    public void setVolumeKeysIgnored(boolean ignored) {
-        volume_keys_ignored = ignored;
     }
 
     /* native dialogs and widgets run on UI Thread */


### PR DESCRIPTION
JNI calls cost a little in terms of user experience (<=1ms) but introduce a delay when used in a motion event pool. Is the delay noticeable? YMMV. 

This fixed broken behaviour introduced in #162 and #163: choosing the JNI/Java thingy instead of keeping everything on lua land.
