### PR TITLE
Some runtime permission fixes

### DIFF
--- a/app/src/org/koreader/launcher/JNILuaInterface.java
+++ b/app/src/org/koreader/launcher/JNILuaInterface.java
@@ -29,6 +29,8 @@ interface JNILuaInterface {
     int getScreenWidth();
     int getStatusBarHeight();
     int hasClipboardTextIntResultWrapper();
+    int hasExternalStoragePermission();
+    int hasWriteSettingsPermission();
     int isCharging();
     int isDebuggable();
     int isEink();

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1877,7 +1877,7 @@ local function run(android_app_state)
     android.notification = function(message, is_long)
         return JNI:context(android.app.activity.vm, function(JNI)
             local text = JNI.env[0].NewStringUTF(JNI.env, message)
-            if duration ~= nil then
+            if is_long ~= nil then
                 JNI:callVoidMethod(
                     android.app.activity.clazz,
                     "showToast",

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -308,6 +308,8 @@ enum {
     AKEYCODE_MEDIA_PREVIOUS = 88,
     AKEYCODE_MEDIA_REWIND = 89,
     AKEYCODE_MEDIA_FAST_FORWARD = 90,
+    AKEYCODE_MUTE = 91,
+    AKEYCODE_VOLUME_MUTE = 164,
 };
 
 int32_t AInputEvent_getType(const AInputEvent* event);


### PR DESCRIPTION
Related to https://github.com/koreader/koreader/issues/5205 and  https://github.com/koreader/koreader/issues/5206

- destroy native activity if we don't have rw permissions on external storage (shows an untranslatable message to the user because it is better than nothing).
- add functions to check runtime permissions from lua.
- update comments.