### PR TITLE
wip: avoid WRITE_SETTINGS permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test: update
 	find tests/einkTest/build/outputs/apk/ -type f -name '*.apk' -exec mv -v {} bin/ \;
 	@echo "WARNING: You'll need to sign this application to be able to install it"
 
-example: update clean build-luajit
+example: update build-luajit
 	@echo "Building HelloWorld example"
 	@echo "#define LOGGER_NAME \"HelloFromLua\"" > jni/logger.h
 	mkdir -p assets/module/

--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -5,7 +5,6 @@
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,9 +62,6 @@ android {
         // reflection
         disable 'PrivateApi'
 
-        // WRITE_SETTINGS permission
-        disable 'ProtectedPermissions'
-
         // Some application flags were introduced on newer API levels and they
         // won't be used when targeting low level apis.
         // This applies to android:resizeableActivity and android:usesClearTextTraffic,

--- a/app/src/org/koreader/launcher/JNILuaInterface.java
+++ b/app/src/org/koreader/launcher/JNILuaInterface.java
@@ -15,7 +15,6 @@ interface JNILuaInterface {
     void setFullscreen(boolean enabled);
     void setScreenBrightness(int brightness);
     void setScreenOffTimeout(int timeout);
-    void setWakeLock(boolean enabled);
     void setWifiEnabled(boolean enabled);
     void showToast(String message);
 
@@ -28,9 +27,9 @@ interface JNILuaInterface {
     int getScreenHeight();
     int getScreenWidth();
     int getStatusBarHeight();
+    int getSystemTimeout();
     int hasClipboardTextIntResultWrapper();
     int hasExternalStoragePermission();
-    int hasWriteSettingsPermission();
     int isCharging();
     int isDebuggable();
     int isEink();

--- a/app/src/org/koreader/launcher/helper/PowerHelper.java
+++ b/app/src/org/koreader/launcher/helper/PowerHelper.java
@@ -4,7 +4,6 @@ package org.koreader.launcher.helper;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.os.BatteryManager;
 import android.os.PowerManager;
 
 import org.koreader.launcher.Logger;
@@ -12,81 +11,19 @@ import org.koreader.launcher.Logger;
 
 public class PowerHelper extends BaseHelper {
 
-    private static final String WAKELOCK_ID = "wakelock:screen_bright";
-    private final IntentFilter filter;
-
-    private PowerManager.WakeLock wakelock;
-    private boolean isWakeLockAllowed = false;
-
-    public PowerHelper(Context context) {
-        super(context);
-        this.filter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
+    public int getWakelockDuration() {
+        return wakelock_duration;
     }
 
-    public int batteryPercent() {
-        return getBatteryState(true);
+    public void setWakelockDuration(final int milliseconds) {
+        wakelock_duration = milliseconds;
     }
 
-    public int batteryCharging() {
-        return getBatteryState(false);
-    }
-
-    public void setWakelock(final boolean enable) {
+    public void setWakelockEnabled(final boolean enable) {
         if (enable) {
             wakelockAcquire();
         } else {
             wakelockRelease();
-        }
-    }
-
-    public void setWakelockState(final boolean enabled) {
-        /* release wakelock first, if present and wakelocks are allowed */
-        if (isWakeLockAllowed && wakelock != null) wakelockRelease();
-        /* update wakelock settings */
-        isWakeLockAllowed = enabled;
-        /* acquire wakelock if we don't have one and wakelocks are allowed */
-        if (isWakeLockAllowed && wakelock == null) wakelockAcquire();
-    }
-
-    private int getBatteryState(boolean isPercent) {
-        Intent intent = getApplicationContext().registerReceiver(null, filter);
-
-        if (intent != null) {
-            final int level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, 0);
-            final int scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, 100);
-            final int plugged = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
-            final int percent = (level * 100) / scale;
-
-            if (isPercent) {
-                return percent;
-            } else if (plugged == BatteryManager.BATTERY_PLUGGED_AC ||
-                       plugged == BatteryManager.BATTERY_PLUGGED_USB) {
-                return (percent != 100) ? 1 : 0;
-            } else {
-                return 0;
-            }
-        } else {
-            return 0;
-        }
-    }
-
-    private void wakelockAcquire() {
-        if (isWakeLockAllowed) {
-            wakelockRelease();
-            PowerManager pm = (PowerManager) getApplicationContext().getSystemService(Context.POWER_SERVICE);
-            wakelock = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK, WAKELOCK_ID);
-            Logger.v(getTag(), "acquiring " + WAKELOCK_ID);
-            // release the wakelock after 30 minutes running in the foreground without inputs.
-            // it will be acquired again on the next resume callback.
-            wakelock.acquire( 30 * 60 * 1000);
-        }
-    }
-
-    private void wakelockRelease() {
-        if (isWakeLockAllowed && wakelock != null) {
-            Logger.v(getTag(), "releasing " + WAKELOCK_ID);
-            wakelock.release();
-            wakelock = null;
         }
     }
 }


### PR DESCRIPTION
Work in progress

Fixes #179 

Repurposes screen_bright wakelock to do all custom timeout without touching system settings. The wakelock duration will be the difference between the timeout the user wants and the global screen off timeout setting.

This needs a few changes on the frontend.

