### PR TITLE
move splash screen to BaseActivity

### DIFF
--- a/app/src/org/koreader/launcher/JNILuaInterface.kt
+++ b/app/src/org/koreader/launcher/JNILuaInterface.kt
@@ -39,7 +39,6 @@ internal interface JNILuaInterface {
     fun setClipboardText(text: String)
     fun setScreenBrightness(brightness: Int)
     fun setScreenOffTimeout(timeout: Int)
-    fun setShowSplashScreen(show: Boolean)
     fun setWifiEnabled(enabled: Boolean)
     fun showToast(message: String)
     fun showToast(message: String, longTimeout: Boolean)

--- a/app/src/org/koreader/launcher/MainActivity.kt
+++ b/app/src/org/koreader/launcher/MainActivity.kt
@@ -27,18 +27,10 @@ class MainActivity : BaseActivity() {
     private val epd = EPDFactory.epdController
     private var view: NativeSurfaceView? = null
     private var takesWindowOwnership: Boolean = false
-    private var showSplashScreen: Boolean = true
 
     companion object {
         private const val TAG = "MainActivity"
         private const val REQUEST_WRITE_STORAGE = 1
-    }
-
-    override fun surfaceCreated(holder: SurfaceHolder) {
-        super.surfaceCreated(holder)
-        if (showSplashScreen == true) {
-            drawSplashScreen(holder)
-        }
     }
 
     /* dumb surface used on Tolinos and other ntx boards to refresh the e-ink screen */
@@ -67,9 +59,6 @@ class MainActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         Logger.d(TAG, "onCreate()")
         super.onCreate(savedInstanceState)
-        setTheme(R.style.Fullscreen)
-        // Window background must be black for vertical and horizontal lines to be visible
-        getWindow().setBackgroundDrawableResource(android.R.color.black)
         if ("freescale" == getEinkPlatform()) {
             /* take control of the native window from the java framework
                as it seems the only option to forward screen refreshes */
@@ -191,10 +180,6 @@ class MainActivity : BaseActivity() {
             1 else 0
     }
 
-    override fun setShowSplashScreen(show: Boolean) {
-        showSplashScreen = show
-    }
-
     /*---------------------------------------------------------------
      *                       private methods                        *
      *--------------------------------------------------------------*/
@@ -208,21 +193,6 @@ class MainActivity : BaseActivity() {
             ActivityCompat.requestPermissions(this,
                     arrayOf(android.Manifest.permission.WRITE_EXTERNAL_STORAGE),
                     REQUEST_WRITE_STORAGE)
-        }
-    }
-
-    /* draw splash screen to surface */
-    private fun drawSplashScreen(holder: SurfaceHolder) {
-        holder.lockCanvas()?.let { canvas ->
-            try {
-                ContextCompat.getDrawable(this, R.drawable.splash_icon)?.let { splashDrawable ->
-                    splashDrawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight())
-                    splashDrawable.draw(canvas)
-                }
-            } catch (e: Exception) {
-                Logger.w(TAG, "Failed to draw splash screen:\n$e")
-            }
-            holder.unlockCanvasAndPost(canvas)
         }
     }
 

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1809,17 +1809,6 @@ local function run(android_app_state)
         end)
     end
 
-    android.setShowSplashScreen = function(show)
-        JNI:context(android.app.activity.vm, function(JNI)
-            JNI:callVoidMethod(
-                android.app.activity.clazz,
-                "setShowSplashScreen",
-                "(Z)V",
-                ffi.new("bool", show)
-            )
-        end)
-    end
-
     android.download = function(url, name)
         return JNI:context(android.app.activity.vm, function(JNI)
             local uri_string = JNI.env[0].NewStringUTF(JNI.env, url)
@@ -2063,7 +2052,6 @@ local function run(android_app_state)
     end
     local launch = android.asset_loader("launcher")
     if type(launch) == "function" then
-        android.setShowSplashScreen(false)
         return launch()
     else
         error("error loading launcher.lua")


### PR DESCRIPTION
Just because it looks simpler and applies to all android devices. This implementation avoids the jni/lua overhead.

Splash screen gets updated on every surface change as suggested in https://github.com/koreader/android-luajit-launcher/pull/187#issuecomment-536233247.
When the assets are extracted (or skipped if already installed) we disable the flag to avoid splash screen on each resume.