### PR TITLE
Add support for the android vibration engine & make some strings non nullable properties.

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
 
     <application

--- a/app/src/org/koreader/launcher/JNILuaInterface.kt
+++ b/app/src/org/koreader/launcher/JNILuaInterface.kt
@@ -4,6 +4,7 @@ package org.koreader.launcher
  * See https://github.com/koreader/android-luajit-launcher/blob/master/assets/android.lua */
 
 internal interface JNILuaInterface {
+    fun canVibrate(): Int
     fun dictLookup(text: String, pkg: String, action: String)
     fun download(url: String, name: String): Int
     fun einkUpdate(mode: Int)
@@ -42,4 +43,5 @@ internal interface JNILuaInterface {
     fun setWifiEnabled(enabled: Boolean)
     fun showToast(message: String)
     fun showToast(message: String, longTimeout: Boolean)
+    fun vibrate(milliseconds: Int)
 }

--- a/app/src/org/koreader/launcher/MainApp.kt
+++ b/app/src/org/koreader/launcher/MainApp.kt
@@ -7,13 +7,14 @@ import android.util.Log
 class MainApp : android.app.Application() {
 
     companion object {
-        var name: String? = null
-            private set
-        private var assets_path: String? = null
-        private var library_path: String? = null
-        private var storage_path: String? = null
+        private const val UNKNOWN_STRING = "unknown"
         private var debuggable: Boolean = false
         private var is_system_app: Boolean = false
+        private lateinit var assets_path: String
+        private lateinit var library_path: String
+        private lateinit var storage_path: String
+        lateinit var name: String
+            private set
     }
 
     override fun onCreate() {
@@ -50,10 +51,10 @@ class MainApp : android.app.Application() {
             if (ai.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) debuggable = true
             if (ai.flags and ApplicationInfo.FLAG_SYSTEM == 1) is_system_app = true
         } catch (e: Exception) {
-            name = "MainApp"
-            assets_path = "?"
-            library_path = "?"
-            storage_path = "?"
+            name = UNKNOWN_STRING
+            assets_path = UNKNOWN_STRING
+            library_path = UNKNOWN_STRING
+            storage_path = UNKNOWN_STRING
         }
     }
 }

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1439,6 +1439,29 @@ local function run(android_app_state)
         end)
     end
 
+    android.canVibrate = function()
+        return JNI:context(android.app.activity.vm, function(JNI)
+            return JNI:callIntMethod(
+                android.app.activity.clazz,
+                "canVibrate",
+                "()I"
+            ) == 1
+        end)
+    end
+
+    android.vibrate = function(milliseconds)
+        if android.prop.vibration and type(milliseconds) == "number" then
+            JNI:context(android.app.activity.vm, function(JNI)
+                JNI:callVoidMethod(
+                    android.app.activity.clazz,
+                    "vibrate",
+                    "(I)V",
+                    ffi.new("int32_t", milliseconds)
+                )
+            end)
+        end
+    end
+
     -- input settings
     android.input = {}
 
@@ -1487,6 +1510,7 @@ local function run(android_app_state)
     -- device properties
     android.prop.product = android.getProduct()
     android.prop.version = android.getVersion()
+    android.prop.vibration = android.canVibrate()
 
     -- update logger name
     android.log_name = android.prop.name


### PR DESCRIPTION
Needs to be tested in Android 4.0 - 7.1. Can't be tested on the emulator AFAIK
Needs to be tweaked in Android Oreo and higher because default intensity is to much to be considered haptic feedback.