### PR TITLE
add aarch64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 ifdef ANDROID_ARCH
-	ifeq ($(ANDROID_ARCH), x86)
+	ifeq ($(ANDROID_ARCH), arm64)
+		ANDROID_FULL_ARCH?=arm64-v8a
+		ARCH?=Arm64
+	else ifeq ($(ANDROID_ARCH), x86)
 		ANDROID_FULL_ARCH?=$(ANDROID_ARCH)
 		ARCH?=X86
+	else ifeq($(ANDROID_ARCH), x86_64)
+		ANDROID_FULL_ARCH?=$(ANDROID_ARCH)
+		ARCH?=X86_64
 	endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -123,4 +123,6 @@ clean:
 	rm -rf assets/module/ bin/ jni/luajit/build
 	cd jni/luajit && \
 		./mk-luajit.sh clean
+
+mrproper: clean
 	-./gradlew clean --continue

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,10 +51,21 @@ android {
             ndk { abiFilters "x86" }
             dimension = 'ABI'
         }
+        x86_64 {
+            ndk { abiFilters "x86_64" }
+            dimension = 'ABI'
+            minSdkVersion = 21
+        }
         arm {
             ndk { abiFilters "armeabi-v7a" }
             dimension = 'ABI'
         }
+        arm64 {
+            ndk { abiFilters "arm64-v8a" }
+            dimension = 'ABI'
+            minSdkVersion = 21
+        }
+
         fdroid {
             dimension = 'CHANNEL'
         }

--- a/jni/luajit/mk-luajit.sh
+++ b/jni/luajit/mk-luajit.sh
@@ -2,10 +2,11 @@
 # see http://luajit.org/install.html for details
 # there, a call like one of the following is recommended
 
-# NDKABI=21  # Android 5.0+
-# NDKABI=19  # Android 4.4+
-NDKABI=${NDKABI:-14} # Android 4.0+
-#NDKABI=${NDKABI:-9} # Android 2.3+
+# We use NDK r15c for all architectures.
+
+# For 32 bits (armeabi-v7a and x86) we built against platform-14 (ICS)
+# For 64 bits (arm64-v8a and x86_64) we built against platform-21 (Lollipop)
+
 DEST=$(cd "$(dirname "$0")" && pwd)/build/$1
 # might be linux-x86_64 or darwin-x86-64
 HOST_ARCH="*"
@@ -46,17 +47,9 @@ case "$1" in
     clean)
         make -C luajit clean
         ;;
-    armeabi)
-        # Android/ARM, armeabi (ARMv5TE soft-float)
-        check_NDK
-        TCVER=("${NDK}"/toolchains/arm-linux-androideabi-4.*)
-        NDKP=${TCVER[0]}/prebuilt/${HOST_ARCH}/bin/arm-linux-androideabi-
-        NDKF="--sysroot ${NDK}/platforms/android-${NDKABI}/arch-arm"
-        rm -rf "$DEST"
-        make -C luajit install HOST_CC="gcc -m32" CFLAGS="-O2 -pipe" HOST_CFLAGS="-O2 -pipe -mtune=generic" LDFLAGS="" HOST_LDFLAGS="" TARGET_CFLAGS="${CFLAGS}" TARGET_LDFLAGS="${LDFLAGS}" CROSS="$NDKP" TARGET_FLAGS="$NDKF" TARGET_SYS=Linux DESTDIR="$DEST" PREFIX=
-        ;;
     armeabi-v7a)
         # Android/ARM, armeabi-v7a (ARMv7 VFP)
+        NDKABI=${NDKABI:-14}
         check_NDK
         TCVER=("${NDK}"/toolchains/arm-linux-androideabi-4.*)
         NDKP=${TCVER[0]}/prebuilt/${HOST_ARCH}/bin/arm-linux-androideabi-
@@ -64,24 +57,35 @@ case "$1" in
         NDKARCH="-march=armv7-a -mfloat-abi=softfp -Wl,--fix-cortex-a8"
         make -C luajit install HOST_CC="gcc -m32" CFLAGS="-O2 -pipe" HOST_CFLAGS="-O2 -pipe -mtune=generic" LDFLAGS="" HOST_LDFLAGS="" TARGET_CFLAGS="${CFLAGS}" TARGET_LDFLAGS="${LDFLAGS}" CROSS="$NDKP" TARGET_FLAGS="${NDKF} ${NDKARCH}" TARGET_SYS=Linux DESTDIR="$DEST" PREFIX=
         ;;
-    mips)
-        # Android/MIPS, mips (MIPS32R1 hard-float)
+    arm64-v8a)
+        # Android/ARM, arm64-v8a (ARM64 VFP4, NEON)
+        NDKABI=${NDKABI:-21}
         check_NDK
-        TCVER=("${NDK}"/toolchains/mipsel-linux-android-4.*)
-        NDKP=${TCVER[0]}/prebuilt/${HOST_ARCH}/bin/mipsel-linux-android-
-        NDKF="--sysroot ${NDK}/platforms/android-${NDKABI}/arch-mips"
-        make -C luajit install HOST_CC="gcc -m32" CFLAGS="-O2 -pipe" HOST_CFLAGS="-O2 -pipe -mtune=generic" LDFLAGS="" HOST_LDFLAGS="" TARGET_CFLAGS="${CFLAGS}" TARGET_LDFLAGS="${LDFLAGS}" CROSS="${NDKP}" TARGET_FLAGS="$NDKF" TARGET_SYS=Linux DESTDIR="$DEST" PREFIX=
+        TCVER=("${NDK}"/toolchains/aarch64-linux-android-4.*)
+        NDKP=${TCVER[0]}/prebuilt/${HOST_ARCH}/bin/aarch64-linux-android-
+        NDKF="--sysroot ${NDK}/platforms/android-${NDKABI}/arch-arm64"
+        make -C luajit install HOST_CC="gcc" CFLAGS="-O2 -pipe" HOST_CFLAGS="-O2 -pipe -mtune=generic" LDFLAGS="" HOST_LDFLAGS="" TARGET_CFLAGS="${CFLAGS}" TARGET_LDFLAGS="${LDFLAGS}" CROSS="$NDKP" TARGET_FLAGS="${NDKF}" TARGET_SYS=Linux DESTDIR="$DEST" PREFIX=
         ;;
     x86)
         # Android/x86, x86 (i686 SSE3)
+        NDKABI=${NDKABI:-14}
         check_NDK
         TCVER=("${NDK}"/toolchains/x86-4.*)
         NDKP=${TCVER[0]}/prebuilt/${HOST_ARCH}/bin/i686-linux-android-
         NDKF="--sysroot ${NDK}/platforms/android-${NDKABI}/arch-x86"
         make -C luajit install HOST_CC="gcc -m32" CFLAGS="-O2 -pipe" HOST_CFLAGS="-O2 -pipe -mtune=generic" LDFLAGS="" HOST_LDFLAGS="" TARGET_CFLAGS="${CFLAGS}" TARGET_LDFLAGS="${LDFLAGS}" CROSS="$NDKP" TARGET_FLAGS="$NDKF" TARGET_SYS=Linux DESTDIR="$DEST" PREFIX=
         ;;
+    x86_64)
+        # Android/x86_64, x86_64
+        NDKABI=${NDKABI:-21}
+        check_NDK
+        TCVER=("${NDK}"/toolchains/x86_64-4.*)
+        NDKP=${TCVER[0]}/prebuilt/${HOST_ARCH}/bin/x86_64-linux-android-
+        NDKF="--sysroot ${NDK}/platforms/android-${NDKABI}/arch-x86_64"
+        make -C luajit install HOST_CC="gcc" CFLAGS="-O2 -pipe" HOST_CFLAGS="-O2 -pipe -mtune=generic" LDFLAGS="" HOST_LDFLAGS="" TARGET_CFLAGS="${CFLAGS}" TARGET_LDFLAGS="${LDFLAGS}" CROSS="$NDKP" TARGET_FLAGS="${NDKF}" TARGET_SYS=Linux DESTDIR="$DEST" PREFIX=
+        ;;
     *)
-        echo 'specify one of "armeabi", "armeabi-v7a", "mips", "x86" or "clean" as first argument'
+        echo 'specify one of "armeabi-v7a", "arm64-v8a", "x86", "x86_64" or "clean" as first argument'
         exit 1
         ;;
 esac


### PR DESCRIPTION
Add a new abi, called arm64-v8a by Google, based on ARMv8a instruction set architecture. This is 64bits, FPU and SIMD/NEON or whatever the hell that means.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/196)
<!-- Reviewable:end -->
