### PR TITLE
Generic intents

### DIFF
--- a/app/src/org/koreader/launcher/BaseActivity.kt
+++ b/app/src/org/koreader/launcher/BaseActivity.kt
@@ -274,7 +274,11 @@ abstract class BaseActivity : NativeActivity(), JNILuaInterface,
         return if (startActivityIfSafe(intent)) 0 else 1
     }
 
-    override fun dictLookup(text: String, pkg: String, action: String) {
+    override fun dictLookup(text: String, action: String) {
+        dictLookup(text, null, action)
+    }
+
+    override fun dictLookup(text: String, pkg: String?, action: String) {
         val intent = Intent(IntentUtils.getByAction(text, pkg, action))
         if (!startActivityIfSafe(intent)) {
             Logger.e(TAG,

--- a/app/src/org/koreader/launcher/DeviceInfo.kt
+++ b/app/src/org/koreader/launcher/DeviceInfo.kt
@@ -6,9 +6,8 @@
 
 package org.koreader.launcher
 
-import java.util.HashMap
-
 import android.os.Build
+import java.util.*
 
 internal object DeviceInfo {
 
@@ -41,8 +40,8 @@ internal object DeviceInfo {
     private val IS_BOYUE: Boolean
 
     // default values for generic devices.
-    internal var EINK = DeviceInfo.EinkDevice.UNKNOWN
-    private var BUG = DeviceInfo.BugDevice.NONE
+    internal var EINK = EinkDevice.UNKNOWN
+    private var BUG = BugDevice.NONE
 
     enum class EinkDevice {
         UNKNOWN,
@@ -68,13 +67,12 @@ internal object DeviceInfo {
     }
 
     init {
-        MANUFACTURER = getBuildField("MANUFACTURER")
-        BRAND = getBuildField("BRAND")
-        MODEL = getBuildField("MODEL")
-        DEVICE = getBuildField("DEVICE")
-        PRODUCT = getBuildField("PRODUCT")
-        IS_BOYUE = MANUFACTURER.toLowerCase().contentEquals("boeye")
-            || MANUFACTURER.toLowerCase().contentEquals("boyue")
+        MANUFACTURER = lowerCase(getBuildField("MANUFACTURER"))
+        BRAND = lowerCase(getBuildField("BRAND"))
+        MODEL = lowerCase(getBuildField("MODEL"))
+        DEVICE = lowerCase(getBuildField("DEVICE"))
+        PRODUCT = lowerCase(getBuildField("PRODUCT"))
+        IS_BOYUE = MANUFACTURER.contentEquals("boeye") || MANUFACTURER.contentEquals("boyue")
 
         // --------------- device probe --------------- //
         val deviceMap = HashMap<EinkDevice, Boolean>()
@@ -82,75 +80,75 @@ internal object DeviceInfo {
 
         // Boyue T62, manufacturer uses both "boeye" and "boyue" ids.
         BOYUE_T62 = (IS_BOYUE
-                && (PRODUCT.toLowerCase().startsWith("t62") || MODEL.contentEquals("rk30sdk"))
-                && DEVICE.toLowerCase().startsWith("t62"))
-        deviceMap[DeviceInfo.EinkDevice.BOYUE_T62] = BOYUE_T62
+                && (PRODUCT.startsWith("t62") || MODEL.contentEquals("rk30sdk"))
+                && DEVICE.startsWith("t62"))
+        deviceMap[EinkDevice.BOYUE_T62] = BOYUE_T62
 
         // Boyue T61, uses RK3066 chipset
         BOYUE_T61 = (IS_BOYUE
-                && (PRODUCT.toLowerCase().startsWith("t61") || MODEL.contentEquals("rk30sdk"))
-                && DEVICE.toLowerCase().startsWith("t61"))
-        deviceMap[DeviceInfo.EinkDevice.BOYUE_T61] = BOYUE_T61
+                && (PRODUCT.startsWith("t61") || MODEL.contentEquals("rk30sdk"))
+                && DEVICE.startsWith("t61"))
+        deviceMap[EinkDevice.BOYUE_T61] = BOYUE_T61
 
         // Boyue Likebook Plus
-        BOYUE_T80S = IS_BOYUE && PRODUCT.toLowerCase().contentEquals("t80s")
-        deviceMap[DeviceInfo.EinkDevice.BOYUE_T80S] = BOYUE_T80S
+        BOYUE_T80S = IS_BOYUE && PRODUCT.contentEquals("t80s")
+        deviceMap[EinkDevice.BOYUE_T80S] = BOYUE_T80S
 
         // Boyue Likebook Mars
-        BOYUE_T80D = IS_BOYUE && PRODUCT.toLowerCase().contentEquals("t80d")
-        deviceMap[DeviceInfo.EinkDevice.BOYUE_T80D] = BOYUE_T80D
+        BOYUE_T80D = IS_BOYUE && PRODUCT.contentEquals("t80d")
+        deviceMap[EinkDevice.BOYUE_T80D] = BOYUE_T80D
 
         // Boyue Likebook Muses
-        BOYUE_T78D = IS_BOYUE && PRODUCT.toLowerCase().contentEquals("t78d")
-        deviceMap[DeviceInfo.EinkDevice.BOYUE_T78D] = BOYUE_T78D
+        BOYUE_T78D = IS_BOYUE && PRODUCT.contentEquals("t78d")
+        deviceMap[EinkDevice.BOYUE_T78D] = BOYUE_T78D
 
         // Boyue Likebook Mimas
-        BOYUE_T103D = IS_BOYUE && PRODUCT.toLowerCase().contentEquals("t103d")
-        deviceMap[DeviceInfo.EinkDevice.BOYUE_T103D] = BOYUE_T103D
+        BOYUE_T103D = IS_BOYUE && PRODUCT.contentEquals("t103d")
+        deviceMap[EinkDevice.BOYUE_T103D] = BOYUE_T103D
 
         // Boyue Likebook Alita
-        BOYUE_K103 = IS_BOYUE && PRODUCT.toLowerCase().contentEquals("k103")
-        deviceMap[DeviceInfo.EinkDevice.BOYUE_K103] = BOYUE_K103
+        BOYUE_K103 = IS_BOYUE && PRODUCT.contentEquals("k103")
+        deviceMap[EinkDevice.BOYUE_K103] = BOYUE_K103
 
         // Crema Note (1010P)
-        CREMA = BRAND.toLowerCase().contentEquals("crema") && PRODUCT.toLowerCase().contentEquals("note")
-        deviceMap[DeviceInfo.EinkDevice.CREMA] = CREMA
+        CREMA = BRAND.contentEquals("crema") && PRODUCT.contentEquals("note")
+        deviceMap[EinkDevice.CREMA] = CREMA
 
         // Onyx C67
-        ONYX_C67 = (MANUFACTURER.toLowerCase().contentEquals("onyx")
-                && (PRODUCT.toLowerCase().startsWith("c67") || MODEL.contentEquals("rk30sdk"))
-                && DEVICE.toLowerCase().startsWith("c67"))
-        deviceMap[DeviceInfo.EinkDevice.ONYX_C67] = ONYX_C67
+        ONYX_C67 = (MANUFACTURER.contentEquals("onyx")
+                && (PRODUCT.startsWith("c67") || MODEL.contentEquals("rk30sdk"))
+                && DEVICE.startsWith("c67"))
+        deviceMap[EinkDevice.ONYX_C67] = ONYX_C67
 
         // Energy Sistem eReaders. Tested on Energy Ereader Pro 4
-        ENERGY = (BRAND.toLowerCase().contentEquals("energysistem") || BRAND.toLowerCase().contentEquals("energy_sistem"))
-            && MODEL.toLowerCase().startsWith("ereader")
-        deviceMap[DeviceInfo.EinkDevice.ENERGY] = ENERGY
+        ENERGY = (BRAND.contentEquals("energysistem") || BRAND.contentEquals("energy_sistem"))
+            && MODEL.startsWith("ereader")
+        deviceMap[EinkDevice.ENERGY] = ENERGY
 
         // Artatech Inkbook Prime/Prime HD.
-        INKBOOK = (MANUFACTURER.toLowerCase().contentEquals("artatech")
-                && BRAND.toLowerCase().contentEquals("inkbook")
-                && MODEL.toLowerCase().startsWith("prime"))
-        deviceMap[DeviceInfo.EinkDevice.INKBOOK] = INKBOOK
+        INKBOOK = (MANUFACTURER.contentEquals("artatech")
+                && BRAND.contentEquals("inkbook")
+                && MODEL.startsWith("prime"))
+        deviceMap[EinkDevice.INKBOOK] = INKBOOK
 
         // Tolino
-        TOLINO = BRAND.toLowerCase().contentEquals("tolino") && MODEL.toLowerCase().contentEquals("imx50_rdp")
-                || MODEL.toLowerCase().contentEquals("tolino") && (DEVICE.toLowerCase().contentEquals("tolino_vision2")
-                || DEVICE.toLowerCase().contentEquals("ntx_6sl"))
-        deviceMap[DeviceInfo.EinkDevice.TOLINO] = TOLINO
+        TOLINO = BRAND.contentEquals("tolino") && MODEL.contentEquals("imx50_rdp")
+                || MODEL.contentEquals("tolino") && (DEVICE.contentEquals("tolino_vision2")
+                || DEVICE.contentEquals("ntx_6sl"))
+        deviceMap[EinkDevice.TOLINO] = TOLINO
 
         // Nook Glowlight 3
-        NOOK_V520 = MANUFACTURER.toLowerCase().contentEquals("barnesandnoble")
-                && MODEL.toLowerCase().contentEquals("bnrv520")
-        deviceMap[DeviceInfo.EinkDevice.NOOK_V520] = NOOK_V520
+        NOOK_V520 = MANUFACTURER.contentEquals("barnesandnoble")
+                && MODEL.contentEquals("bnrv520")
+        deviceMap[EinkDevice.NOOK_V520] = NOOK_V520
 
         // Sony DPT-RP1
-        SONY_RP1 = MANUFACTURER.toLowerCase().contentEquals("sony") && MODEL.toLowerCase().contentEquals("dpt-rp1")
-        bugMap[DeviceInfo.BugDevice.SONY_RP1] = SONY_RP1
+        SONY_RP1 = MANUFACTURER.contentEquals("sony") && MODEL.contentEquals("dpt-rp1")
+        bugMap[BugDevice.SONY_RP1] = SONY_RP1
 
         // Android emulator for x86
         EMULATOR_X86 = MODEL.contentEquals("Android SDK built for x86")
-        bugMap[DeviceInfo.BugDevice.EMULATOR] = EMULATOR_X86
+        bugMap[BugDevice.EMULATOR] = EMULATOR_X86
 
         // find current eink device.
         val einkIter = deviceMap.keys.iterator()
@@ -197,7 +195,7 @@ internal object DeviceInfo {
         EINK_FULL_SUPPORT = CREMA || TOLINO
 
         // need wakelocks
-        BUG_WAKELOCKS = BUG == DeviceInfo.BugDevice.SONY_RP1
+        BUG_WAKELOCKS = BUG == BugDevice.SONY_RP1
     }
 
     private fun getBuildField(fieldName: String): String {
@@ -206,5 +204,9 @@ internal object DeviceInfo {
         } catch (e: Exception) {
              ""
         }
+    }
+
+    private fun lowerCase(text: String): String {
+        return text.toLowerCase(Locale.US)
     }
 }

--- a/app/src/org/koreader/launcher/IntentUtils.kt
+++ b/app/src/org/koreader/launcher/IntentUtils.kt
@@ -10,21 +10,20 @@ internal object IntentUtils {
      * get intent by action type, used to do dict lookups on 3rd party apps.
      *
      * @param text to search
-     * @param pkg that receives the query
+     * @param pkg that receives the query - null to show the app picker
      * @param action associated to the package
      *
      * @return a Intent based on package/action ready to do a text lookup
      */
 
-    fun getByAction(text: String, pkg: String, action: String): Intent {
+    fun getByAction(text: String, pkg: String?, action: String): Intent {
         var intent = Intent()
         when (action) {
+            // generic actions used by a lot of apps
             "send" -> intent = Intent(getSendIntent(text, pkg))
             "search" -> intent = Intent(getSearchIntent(text, pkg))
             "text" -> intent = Intent(getTextIntent(text, pkg))
-            "picker-send" -> intent = Intent(getSendIntent(text))
-            "picker-search" -> intent = Intent(getSearchIntent(text))
-            "picker-text" -> intent = Intent(getTextIntent(text))
+            // actions for specific apps
             "aard2" -> intent = Intent(getAard2Intent(text))
             "colordict" -> intent = Intent(getColordictIntent(text, pkg))
             "quickdic" -> intent = Intent(getQuickdicIntent(text))
@@ -43,7 +42,7 @@ internal object IntentUtils {
         return if (intent == null) "" else "\naction: " + intent.action + "\ndata: " + intent.dataString + "\n"
     }
 
-    // Intent.ACTION_SEND with a specific package
+    // Intent.ACTION_SEND
     private fun getSendIntent(text: String, pkg: String? = null): Intent {
         val intent = Intent(Intent.ACTION_SEND)
         intent.putExtra(Intent.EXTRA_TEXT, text)
@@ -52,7 +51,7 @@ internal object IntentUtils {
         return intent
     }
 
-    // Intent.ACTION_SEARCH with a specific package
+    // Intent.ACTION_SEARCH
     private fun getSearchIntent(text: String, pkg: String? = null): Intent {
         val intent = Intent(Intent.ACTION_SEARCH)
         intent.putExtra(SearchManager.QUERY, text)
@@ -61,7 +60,7 @@ internal object IntentUtils {
         return intent
     }
 
-    // Intent.ACTION_PROCESS_TEXT with a specific package (available on api23+)
+    // Intent.ACTION_PROCESS_TEXT (available on api23+)
     private fun getTextIntent(text: String, pkg: String? = null): Intent {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             val intent = Intent(Intent.ACTION_PROCESS_TEXT)
@@ -85,11 +84,11 @@ internal object IntentUtils {
         return intent
     }
 
-    private fun getColordictIntent(text: String, pkg: String): Intent {
+    private fun getColordictIntent(text: String, pkg: String?): Intent {
         val intent = Intent("colordict.intent.action.SEARCH")
         intent.putExtra("EXTRA_QUERY", text)
         intent.putExtra("EXTRA_FULLSCREEN", true)
-        intent.setPackage(pkg)
+        if (pkg != null) intent.setPackage(pkg)
         return intent
     }
 

--- a/app/src/org/koreader/launcher/JNILuaInterface.kt
+++ b/app/src/org/koreader/launcher/JNILuaInterface.kt
@@ -5,7 +5,8 @@ package org.koreader.launcher
 
 internal interface JNILuaInterface {
     fun canWriteSystemSettings(): Int
-    fun dictLookup(text: String, pkg: String, action: String)
+    fun dictLookup(text: String, action: String)
+    fun dictLookup(text: String, pkg: String?, action: String)
     fun download(url: String, name: String): Int
     fun einkUpdate(mode: Int)
     fun einkUpdate(mode: Int, delay: Long, x: Int, y: Int, width: Int, height: Int)

--- a/app/src/org/koreader/launcher/Logger.kt
+++ b/app/src/org/koreader/launcher/Logger.kt
@@ -54,11 +54,11 @@ internal object Logger {
     /* log using application name as the logger tag */
     private fun doLog(message: String, level: LogLevel) {
         when (level) {
-            Logger.LogLevel.ERROR -> Log.e(MainApp.name, message)
-            Logger.LogLevel.WARNING -> Log.w(MainApp.name, message)
-            Logger.LogLevel.INFO -> Log.i(MainApp.name, message)
-            Logger.LogLevel.DEBUG -> Log.d(MainApp.name, message)
-            Logger.LogLevel.VERBOSE -> Log.v(MainApp.name, message)
+            LogLevel.ERROR -> Log.e(MainApp.name, message)
+            LogLevel.WARNING -> Log.w(MainApp.name, message)
+            LogLevel.INFO -> Log.i(MainApp.name, message)
+            LogLevel.DEBUG -> Log.d(MainApp.name, message)
+            LogLevel.VERBOSE -> Log.v(MainApp.name, message)
         }
     }
 }

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1887,6 +1887,7 @@ local function run(android_app_state)
     end
 
     android.isPackageEnabled = function(package)
+        if not package then return true end
         return JNI:context(android.app.activity.vm, function(JNI)
             local package = JNI.env[0].NewStringUTF(JNI.env, package)
             local enabled = JNI:callIntMethod(
@@ -1901,20 +1902,35 @@ local function run(android_app_state)
     end
 
     android.dictLookup = function(text, package, action)
-        JNI:context(android.app.activity.vm, function(JNI)
-            local text = JNI.env[0].NewStringUTF(JNI.env, text)
-            local package = JNI.env[0].NewStringUTF(JNI.env, package)
-            local action = JNI.env[0].NewStringUTF(JNI.env, action)
-            JNI:callVoidMethod(
-                android.app.activity.clazz,
-                "dictLookup",
-                "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
-                text, package, action
-            )
-            JNI.env[0].DeleteLocalRef(JNI.env, text)
-            JNI.env[0].DeleteLocalRef(JNI.env, package)
-            JNI.env[0].DeleteLocalRef(JNI.env, action)
-        end)
+        if not package then
+            JNI:context(android.app.activity.vm, function(JNI)
+                local text = JNI.env[0].NewStringUTF(JNI.env, text)
+                local action = JNI.env[0].NewStringUTF(JNI.env, action)
+                JNI:callVoidMethod(
+                    android.app.activity.clazz,
+                    "dictLookup",
+                    "(Ljava/lang/String;Ljava/lang/String;)V",
+                    text, action
+                )
+                JNI.env[0].DeleteLocalRef(JNI.env, text)
+                JNI.env[0].DeleteLocalRef(JNI.env, action)
+            end)
+        else
+            JNI:context(android.app.activity.vm, function(JNI)
+                local text = JNI.env[0].NewStringUTF(JNI.env, text)
+                local package = JNI.env[0].NewStringUTF(JNI.env, package)
+                local action = JNI.env[0].NewStringUTF(JNI.env, action)
+                JNI:callVoidMethod(
+                    android.app.activity.clazz,
+                    "dictLookup",
+                    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+                    text, package, action
+                )
+                JNI.env[0].DeleteLocalRef(JNI.env, text)
+                JNI.env[0].DeleteLocalRef(JNI.env, package)
+                JNI.env[0].DeleteLocalRef(JNI.env, action)
+            end)
+        end
     end
 
     android.notification = function(message, is_long)

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1887,7 +1887,7 @@ local function run(android_app_state)
     end
 
     android.isPackageEnabled = function(package)
-        if not package then return true end
+        if not package then return false end
         return JNI:context(android.app.activity.vm, function(JNI)
             local package = JNI.env[0].NewStringUTF(JNI.env, package)
             local enabled = JNI:callIntMethod(


### PR DESCRIPTION
ACTION_SEND, ACTION_SEARCH and ACTION_PROCESS_TEXT when called without an explicit package will be opened with the application picker if there is more than one alternative to open them.

Also fixed some warnings thrown by Android Studio linter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/200)
<!-- Reviewable:end -->
