### PR TITLE
initial support for scoped storage

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -27,6 +27,12 @@
             android:resizeableActivity="false"
             android:launchMode="singleInstance"
             android:theme="@style/SplashScreen">
+            <!--add android:requestLegacyExternalStorage="true" when bumping targetApi to 29+
+
+                This will allow upgrades from previous versions keeping the legacy storage model.
+                New installations won't be affected and will use scoped storage instead on
+                compatible devices. -->
+
             <meta-data android:name="android.app.lib_name" android:value="luajit" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,8 +68,8 @@ android {
         disable 'ProtectedPermissions'
 
         // Some application flags cannot be used when targeting low level apis.
-        // This applies to android:resizeableActivity and android:usesClearTextTraffic,
-        // both available on API level 23 or higher.
+        // This applies to resizeableActivity and usesClearTextTraffic, both available on API level 23 or higher.
+        // And requestLegacyExternalStorage, available on API 29
         disable 'UnusedAttribute'
     }
 

--- a/app/src/org/koreader/launcher/BaseActivity.kt
+++ b/app/src/org/koreader/launcher/BaseActivity.kt
@@ -221,7 +221,7 @@ abstract class BaseActivity : NativeActivity(), JNILuaInterface,
         runOnUiThread {
             try {
                 val clip = ClipData.newPlainText("KOReader_clipboard", text)
-                clipboard.primaryClip = clip
+                clipboard.setPrimaryClip(clip)
             } catch (e: Exception) {
                 Logger.w(TAG, e.toString())
             }

--- a/app/src/org/koreader/launcher/MainActivity.kt
+++ b/app/src/org/koreader/launcher/MainActivity.kt
@@ -101,7 +101,11 @@ class MainActivity : BaseActivity() {
             val decorView = window.decorView
             decorView.setOnSystemUiVisibilityChangeListener { setFullscreenLayout() }
         }
-        requestExternalStoragePermission()
+
+        if (MainApp.legacy_storage) {
+            requestExternalStoragePermission()
+        }
+
         systemTimeout = SystemSettings.getSystemScreenOffTimeout(this)
     }
 
@@ -213,9 +217,11 @@ class MainActivity : BaseActivity() {
     }
 
     override fun hasExternalStoragePermission(): Int {
-        return if (ContextCompat.checkSelfPermission(this@MainActivity,
-            android.Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
-            1 else 0
+        return if (MainApp.legacy_storage) {
+            if (ContextCompat.checkSelfPermission(this@MainActivity,
+                android.Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
+                1 else 0
+        } else 1
     }
 
     override fun performHapticFeedback(constant: Int) {

--- a/app/src/org/koreader/launcher/MainApp.kt
+++ b/app/src/org/koreader/launcher/MainApp.kt
@@ -20,7 +20,7 @@ class MainApp : android.app.Application() {
 
         // change to false if you want to experiment with the sandbox
         // Switch to Environment.isExternalStorageLegacy() when bumping api to 29+
-        private val legacy_storage: Boolean = true
+        val legacy_storage: Boolean = true
 
         private const val UNKNOWN_STRING = "Unknown"
     }

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1650,21 +1650,6 @@ local function run(android_app_state)
         end)
     end
 
-    android.externalStorage = function()
-        return JNI:context(android.app.activity.vm, function(JNI)
-            local dir = JNI:callObjectMethod(
-                JNI:callStaticObjectMethod(
-                    "android/os/Environment",
-                    "getExternalStorageDirectory",
-                    "()Ljava/io/File;"
-                ),
-                "getAbsolutePath",
-                "()Ljava/lang/String;"
-            )
-            return JNI:to_string(dir)
-        end)
-    end
-
     android.isFullscreen = function()
         return JNI:context(android.app.activity.vm, function(JNI)
             return JNI:callIntMethod(


### PR DESCRIPTION
It includes a minor fix to build ok against targetApi 29

Scoped storage won't affect android 10 unless we use targetApi 29. Current targetApi is still untouched, using level 28.


Basically it replaces storage_path on versions where [getExternalStorageDirectory()](https://developer.android.com/reference/android/os/Environment#getExternalStorageDirectory()) is deprecated, with a known path where RW permissions are granted.

From Android 11 onwards everything outside that directory needs to be accesed using SAF.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/201)
<!-- Reviewable:end -->
