### PR TITLE
do not destroy activity on keyboard changes

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -26,6 +26,7 @@
             android:screenOrientation="sensorPortrait"
             android:resizeableActivity="false"
             android:launchMode="singleInstance"
+            android:configChanges="keyboard|keyboardHidden"
             android:theme="@style/SplashScreen">
             <!--add android:requestLegacyExternalStorage="true" when bumping targetApi to 29+
 


### PR DESCRIPTION
Fix for https://github.com/koreader/koreader/issues/5698

I have the feeling that this flag was already included at some point and I missed it after some refactor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/206)
<!-- Reviewable:end -->
