### PR TITLE
resolve file paths delivered as content without importing the file

### DIFF
--- a/app/manifest/base.xml
+++ b/app/manifest/base.xml
@@ -35,6 +35,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="file" />
+                <data android:scheme="content" />
                 <data android:mimeType="application/epub+zip" />
                 <data android:mimeType="application/fb2" />
                 <data android:mimeType="application/fb3" />

--- a/app/src/org/koreader/launcher/MainActivity.kt
+++ b/app/src/org/koreader/launcher/MainActivity.kt
@@ -187,7 +187,7 @@ class MainActivity : BaseActivity() {
     }
 
     override fun getFilePathFromIntent(): String? {
-        return FileUtils.getPathFromFileUri(intent.data)
+        return FileUtils.getPathFromUri(this@MainActivity, intent.data)
     }
 
     override fun getLastImportedPath(): String? {


### PR DESCRIPTION
Tested with Simple Mobile Tools FM, Root Explorer and Solid Explorer.

It could lead to a false positive if the intent.VIEW contains data other than a file (a pipe, a socket). A false positive would start KOReader in the FM (or whatever the user configured) so it shouldn't hurt.

While this workaround still works on scoped storage devices is totally useless because we won't be able to read the file from the resolved path.

Some background in https://www.mobileread.com/forums/showpost.php?p=3932733&postcount=14 and following posts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/208)
<!-- Reviewable:end -->
