### PR TITLE
suppress known deprecation warnings

### DIFF
--- a/app/src/org/koreader/launcher/BaseActivity.kt
+++ b/app/src/org/koreader/launcher/BaseActivity.kt
@@ -286,6 +286,8 @@ abstract class BaseActivity : NativeActivity(), JNILuaInterface,
     }
 
     /* network */
+
+    @Suppress("DEPRECATION")
     override fun download(url: String, name: String): Int {
         val manager: DownloadManager? = applicationContext.getSystemService(
             Context.DOWNLOAD_SERVICE) as? DownloadManager
@@ -324,6 +326,7 @@ abstract class BaseActivity : NativeActivity(), JNILuaInterface,
         return if (wifi?.isWifiEnabled == true) 1 else 0
     }
 
+    @Suppress("DEPRECATION")
     override fun setWifiEnabled(enabled: Boolean) {
         val wifi: WifiManager? = applicationContext.getSystemService(
             Context.WIFI_SERVICE) as? WifiManager
@@ -459,6 +462,12 @@ abstract class BaseActivity : NativeActivity(), JNILuaInterface,
     }
 
     /* network */
+
+    /* Formatter.formatIpAddress is deprecated in API15 because
+       it does not support IPv6. Is still handy to format ip and
+       gateway addresses given by most LAN routers */
+
+    @Suppress("DEPRECATION")
     private fun formatIp(number: Int): String {
         return if (number > 0) {
             Formatter.formatIpAddress(number)

--- a/app/src/org/koreader/launcher/MainApp.kt
+++ b/app/src/org/koreader/launcher/MainApp.kt
@@ -56,6 +56,7 @@ class MainApp : android.app.Application() {
             library_path = ai.nativeLibraryDir
             assets_path = filesDir.absolutePath
 
+            @Suppress("DEPRECATION")
             storage_path = if (LEGACY_STORAGE) {
                 // deprecated in API 29
                 Environment.getExternalStorageDirectory().absolutePath


### PR DESCRIPTION
Related to #213 

Disable annoying warnings. The project can be built against API29+ without problems. Is just that some things won't be available anymore: toggle wifi & read permission on /sdcard or not needed: request media server scan for downloads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/214)
<!-- Reviewable:end -->
