### PR TITLE
Disable large heap for managed (java) memory and add some tools to debug builds to detect issues.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,9 +5,9 @@ apply plugin: 'kotlin-android-extensions'
 android {
     defaultConfig {
         applicationId "org.koreader.launcher"
-        minSdkVersion rootProject.ext.minSdk
-        targetSdkVersion rootProject.ext.targetSdk
-        compileSdkVersion rootProject.ext.targetSdk
+        minSdkVersion minSdk
+        targetSdkVersion targetSdk
+        compileSdkVersion targetSdk
         versionCode versCode as Integer
         versionName versName
     }
@@ -75,7 +75,7 @@ android {
         checkReleaseBuilds true
         abortOnError false
 
-        // reflection
+        // reflection (used for EPD updates)
         disable 'PrivateApi'
 
         // WRITE_SETTINGS permission
@@ -86,6 +86,7 @@ android {
         // And requestLegacyExternalStorage, available on API 29
         disable 'UnusedAttribute'
 
+        // EPDTestActivity has strings hardcoded in english
         disable 'SetTextI18n'
     }
 
@@ -100,13 +101,17 @@ android {
     }
 }
 
-dependencies {
-    implementation 'androidx.core:core-ktx:1.1.0'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.1'
+repositories {
+    google()
+    jcenter()
+    mavenCentral()
 }
 
-repositories {
-    mavenCentral()
+dependencies {
+    implementation "androidx.core:core-ktx:$androidx_core_version"
+    implementation "androidx.legacy:legacy-support-v4:$androidx_supportv4_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_plugin_version"
+
+    // add Leak Canary on debug variants.
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,6 +104,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.1'
 }
 
 repositories {

--- a/app/manifest/base.xml
+++ b/app/manifest/base.xml
@@ -14,7 +14,7 @@
         android:name=".MainApp"
         android:icon="@drawable/icon"
         android:label="@string/app_name"
-        android:largeHeap="true"
+        android:largeHeap="false"
         android:vmSafeMode="true"
         android:allowBackup="false"
         android:fullBackupContent="false"

--- a/app/src/org/koreader/launcher/MainApp.kt
+++ b/app/src/org/koreader/launcher/MainApp.kt
@@ -2,6 +2,8 @@ package org.koreader.launcher
 
 import java.io.File
 
+import android.app.ActivityManager
+import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.os.Environment
 import android.util.Log
@@ -22,6 +24,8 @@ class MainApp : android.app.Application() {
         private lateinit var library_path: String
         private var debuggable: Boolean = false
         private var is_system_app: Boolean = false
+        private var large_heap: Boolean = false
+        private var managed_heap: Int = 0
     }
 
     override fun onCreate() {
@@ -33,15 +37,20 @@ class MainApp : android.app.Application() {
     /* app info into a String */
     private fun formatAppInfo(): String {
         val sb = StringBuilder(400)
-        sb.append("Application info {\n  Flags: ")
+        sb.append("Application info {")
+        sb.append("\n  VM heap: ")
+            .append(managed_heap)
+            .append("MB ")
+            .append(if (large_heap) "(large)" else "(normal)")
+        sb.append("\n  Flags: ")
         sb.append(if (is_system_app) "system" else "user")
         sb.append(if (LEGACY_STORAGE) ", legacy" else ", scoped").append(" storage")
         sb.append(if (debuggable) ", debuggable" else ".")
         sb.append("\n  Paths {")
-                .append("\n    Assets: ").append(assets_path)
-                .append("\n    Library: ").append(library_path)
-                .append("\n    Storage: ").append(storage_path)
-                .append("\n  }\n}")
+            .append("\n    Assets: ").append(assets_path)
+            .append("\n    Library: ").append(library_path)
+            .append("\n    Storage: ").append(storage_path)
+            .append("\n  }\n}")
         return sb.toString()
     }
 
@@ -49,6 +58,7 @@ class MainApp : android.app.Application() {
     private fun getAppInfo() {
         try {
             val pm = packageManager
+            val am = this.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
             val pi = pm.getPackageInfo(packageName, 0)
             val ai = pm.getApplicationInfo(packageName, 0)
 
@@ -67,6 +77,10 @@ class MainApp : android.app.Application() {
 
             if (ai.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) debuggable = true
             if (ai.flags and ApplicationInfo.FLAG_SYSTEM == 1) is_system_app = true
+            if (ai.flags and ApplicationInfo.FLAG_LARGE_HEAP != 0) large_heap = true
+
+            managed_heap = getManagedMemory(am)
+
         } catch (e: Exception) {
             /* early exception, never reached.
                Use "unknown" to let the user face the crash via logcat */
@@ -74,6 +88,15 @@ class MainApp : android.app.Application() {
             assets_path = UNKNOWN_STRING
             library_path = UNKNOWN_STRING
             storage_path = UNKNOWN_STRING
+        }
+    }
+
+    /* get managed heap size */
+    private fun getManagedMemory(am: ActivityManager): Int {
+        return if (large_heap) {
+            am.largeMemoryClass
+        } else {
+            am.memoryClass
         }
     }
 }

--- a/app/src/org/koreader/launcher/MainApp.kt
+++ b/app/src/org/koreader/launcher/MainApp.kt
@@ -6,6 +6,7 @@ import android.app.ActivityManager
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.os.Environment
+import android.os.StrictMode
 import android.util.Log
 
 @Suppress("ConstantConditionIf")
@@ -32,6 +33,14 @@ class MainApp : android.app.Application() {
         super.onCreate()
         getAppInfo()
         Log.i(name, "Application started\n" + formatAppInfo())
+
+        if (debuggable) {
+            Log.d(name, "StrictMode will detect all potential violations and log them")
+            val threadPolicy = StrictMode.ThreadPolicy.Builder().detectAll().penaltyLog().build()
+            val vmPolicy = StrictMode.VmPolicy.Builder().detectAll().penaltyLog().build()
+            StrictMode.setThreadPolicy(threadPolicy)
+            StrictMode.setVmPolicy(vmPolicy)
+        }
     }
 
     /* app info into a String */

--- a/app/src/org/koreader/launcher/MainApp.kt
+++ b/app/src/org/koreader/launcher/MainApp.kt
@@ -89,7 +89,6 @@ class MainApp : android.app.Application() {
             if (ai.flags and ApplicationInfo.FLAG_LARGE_HEAP != 0) large_heap = true
 
             managed_heap = getManagedMemory(am)
-
         } catch (e: Exception) {
             /* early exception, never reached.
                Use "unknown" to let the user face the crash via logcat */

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1237,6 +1237,11 @@ local android = {
 function android.LOG(level, message)
     ffi.C.__android_log_print(level, android.log_name, "%s", message)
 end
+
+function android.LOGVV(tag, message)
+    ffi.C.__android_log_print(ffi.C.ANDROID_LOG_VERBOSE, tag, "%s", message)
+end
+
 function android.LOGV(message)
     android.LOG(ffi.C.ANDROID_LOG_VERBOSE, message)
 end

--- a/assets/dl.lua
+++ b/assets/dl.lua
@@ -16,6 +16,7 @@ and as such:
 local ffi = require("ffi")
 local A = require("android")
 local Elf = require("elf")
+local log = "dlopen"
 
 ffi.cdef[[
 void *dlopen(const char *filename, int flag);
@@ -32,7 +33,7 @@ local dl = {
 }
 
 local function sys_dlopen(library)
-    A.LOGV(string.format("dl.lua - sys_dlopen - loading library %s", library))
+    A.LOGVV(log, string.format("sys_dlopen - loading library %s", library))
     local p = ffi.C.dlopen(library, ffi.C.RTLD_LOCAL)
     if p == nil then
         local err_msg = ffi.C.dlerror()
@@ -73,7 +74,7 @@ function dl.dlopen(library, load_func)
             ok, lib = pcall(Elf.open, lname)
         end
         if ok then
-            A.LOGV(string.format("dl.lua - dl.dlopen - library lname detected %s", lname))
+            A.LOGVV(log, string.format("dl.dlopen - library lname detected %s", lname))
             -- we found a library, now load its requirements
             -- we do _not_ pass the load_func to the cascaded
             -- calls, so those will always use sys_dlopen()
@@ -87,7 +88,7 @@ function dl.dlopen(library, load_func)
                     -- liblog, libm, libmediandk, libOpenMAXAL, libOpenSLES, libstdc++,
                     -- libvulkan, and libz
                     -- However, we have our own dl implementation and don't need the rest.
-                    A.LOGV(string.format("         dl.dlopen - opening needed %s for %s", needed, lname))
+                    A.LOGVV(log, string.format("         dl.dlopen - opening needed %s for %s", needed, lname))
                     dl.dlopen(needed)
                 end
             end

--- a/build.gradle
+++ b/build.gradle
@@ -1,30 +1,23 @@
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.gradle_plugin_version = '3.5.3'
+    ext.kotlin_plugin_version = '1.3.50'
+    ext.androidx_core_version = '1.1.0'
+    ext.androidx_supportv4_version = '1.0.0'
+    ext.minSdk = 14
+    ext.safSdk = 19
+    ext.targetSdk = 28
+    ext.latestSdk = 29
+
     repositories {
         google()
         jcenter()
-        
     }
+
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.android.tools.build:gradle:$gradle_plugin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_plugin_version"
     }
 }
-
-allprojects {
-    repositories {
-        google()
-        jcenter()
-    }
-}
-
-ext {
-    minSdk = 14
-    safSdk = 19
-    targetSdk = 28
-    latestSdk = 29
-}
-
 
 task clean(type: Delete) {
     delete rootProject.buildDir

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jun 22 02:03:23 CEST 2019
+#Thu Jan 09 00:29:09 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
VM large heap flag isn't needed AFAICT. In the days android was introduced it was hardcoded to 16MB for "normal" apps and a bit more for apps that use the large heap flag. Nowadays most modern devices report the same value with or without the flag: 384MB~.

the large heap flag is useful for activities that load a bunch of java libraries or that have big drawable objects . That's not our case. We run with about 2-3mb of -vm managed- heap usage and almost 0 allocations.

Anyways, I added a function to retrieve that info and log it.

The other changes: move dlopen to their own log tag.
Log policy violations on debug builds
Add leakCanary to debug builds

So, a catch-em-all log will be: `pidcat org.koreader.launcher -t KOReader -t dlopen -t LeakCanary -t StrictMode` while `adb logcat KOReader:* *:S` is related to the activity lifecycle and normal logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/217)
<!-- Reviewable:end -->
