### PR TITLE
wip: send/share files

### DIFF
--- a/app/src/org/koreader/launcher/BaseActivity.kt
+++ b/app/src/org/koreader/launcher/BaseActivity.kt
@@ -285,6 +285,22 @@ abstract class BaseActivity : NativeActivity(), JNILuaInterface,
         } ?: Logger.e(TAG, "invalid lookup: no text")
     }
 
+    override fun sendFile(path: String?, title: String?) {
+        val chooserTitle = title ?: "share file"
+
+        path?.let {
+            val file = File(it)
+            if (!file.canRead()) {
+                Logger.e(TAG, "invalid file: $it")
+                return
+            }
+            val uri = Uri.fromFile(file)
+            val sendFileIntent = IntentUtils.getSendIntentFromUri(this@BaseActivity, uri)
+            val chooser = Intent.createChooser(sendFileIntent, chooserTitle)
+            startActivityIfSafe(chooser)
+        }
+    }
+
     override fun sendText(text: String?) {
         text?.let {
             startActivityIfSafe(IntentUtils.getSendIntent(it, null))

--- a/app/src/org/koreader/launcher/JNILuaInterface.kt
+++ b/app/src/org/koreader/launcher/JNILuaInterface.kt
@@ -43,6 +43,7 @@ internal interface JNILuaInterface {
     fun openLink(url: String): Int
     fun performHapticFeedback(constant: Int)
     fun requestWriteSystemSettings()
+    fun sendFile(path: String?, title: String?)
     fun sendText(text: String?)
     fun setFullscreen(enabled: Boolean)
     fun setClipboardText(text: String)

--- a/app/src/org/koreader/launcher/MainApp.kt
+++ b/app/src/org/koreader/launcher/MainApp.kt
@@ -40,6 +40,9 @@ class MainApp : android.app.Application() {
             val vmPolicy = StrictMode.VmPolicy.Builder().detectAll().penaltyLog().build()
             StrictMode.setThreadPolicy(threadPolicy)
             StrictMode.setVmPolicy(vmPolicy)
+        } else {
+            /* workaround for sending files outside process boundaries on API24+ */
+            StrictMode.setVmPolicy(StrictMode.VmPolicy.LAX)
         }
     }
 

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1953,6 +1953,21 @@ local function run(android_app_state)
         end)
     end
 
+    android.sendFile = function(path, title)
+        JNI:context(android.app.activity.vm, function(JNI)
+            local path = JNI.env[0].NewStringUTF(JNI.env, path)
+            local title = JNI.env[0].NewStringUTF(JNI.env, title)
+            JNI:callVoidMethod(
+                android.app.activity.clazz,
+                "sendFile",
+                "(Ljava/lang/String;Ljava/lang/String;)V",
+                path, title
+            )
+            JNI.env[0].DeleteLocalRef(JNI.env, path)
+            JNI.env[0].DeleteLocalRef(JNI.env, title)
+        end)
+    end
+
     android.sendText = function(text)
         JNI:context(android.app.activity.vm, function(JNI)
             local text = JNI.env[0].NewStringUTF(JNI.env, text)


### PR DESCRIPTION
Allow to send binary files via bluetooth, social apps or any other app that supports a given mimetype.

WIP: it uses a workaround, works fine **only** if the receiver has filesystem permissions to reach the file. A proper implementation would be written a custom fileProvider and share as content instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/218)
<!-- Reviewable:end -->
