### PR TITLE
replace WifiManager with ConnectivityManager

### DIFF
--- a/app/manifest/base.xml
+++ b/app/manifest/base.xml
@@ -4,8 +4,7 @@
     package="org.koreader.launcher" >
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
-    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />

--- a/app/src/org/koreader/launcher/JNILuaInterface.kt
+++ b/app/src/org/koreader/launcher/JNILuaInterface.kt
@@ -38,9 +38,9 @@ internal interface JNILuaInterface {
     fun isFullscreen(): Int
     fun isPackageEnabled(pkg: String): Int
     fun isPathInsideSandbox(path: String?): Int
-    fun isWifiEnabled(): Int
     fun needsWakelocks(): Int
     fun openLink(url: String): Int
+    fun openWifiSettings()
     fun performHapticFeedback(constant: Int)
     fun requestWriteSystemSettings()
     fun sendText(text: String?)
@@ -49,7 +49,6 @@ internal interface JNILuaInterface {
     fun setHapticOverride(enabled: Boolean)
     fun setScreenBrightness(brightness: Int)
     fun setScreenOffTimeout(timeout: Int)
-    fun setWifiEnabled(enabled: Boolean)
     fun startEPDTestActivity()
     fun showToast(message: String)
     fun showToast(message: String, longTimeout: Boolean)

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -334,6 +334,15 @@ enum {
     AHAPTIC_TEXT_HANDLE_MOVE = 9,
 };
 
+enum {
+    ANETWORK_NONE = 0,
+    ANETWORK_WIFI = 1,
+    ANETWORK_MOBILE = 2,
+    ANETWORK_ETHERNET = 3,
+    ANETWORK_BLUETOOTH = 4,
+    ANETWORK_VPN = 5,
+};
+
 int32_t AInputEvent_getType(const AInputEvent* event);
 int32_t AInputEvent_getDeviceId(const AInputEvent* event);
 int32_t AInputEvent_getSource(const AInputEvent* event);
@@ -1863,28 +1872,17 @@ local function run(android_app_state)
                 "getNetworkInfo",
                 "()Ljava/lang/String;"
             )
-            return string.match(JNI:to_string(network_info), "(.*);(.*);(.*)")
+            return string.match(JNI:to_string(network_info), "(.*);(.*)")
         end)
     end
 
-    android.isWifiEnabled = function()
-        return JNI:context(android.app.activity.vm, function(JNI)
-            return JNI:callIntMethod(
-                android.app.activity.clazz,
-                "isWifiEnabled",
-                "()I"
-            ) == 1
-        end)
-    end
-
-    android.setWifiEnabled = function(wifiEnabled)
-        android.DEBUG("setting wifi to: " .. tostring(wifiEnabled))
+    android.openWifiSettings = function()
+        android.DEBUG("open android settings")
         JNI:context(android.app.activity.vm, function(JNI)
             JNI:callVoidMethod(
                 android.app.activity.clazz,
-                "setWifiEnabled",
-                "(Z)V",
-                ffi.new("bool", wifiEnabled)
+                "openWifiSettings",
+                "()V"
             )
         end)
     end


### PR DESCRIPTION
Sample solution for https://github.com/koreader/koreader/issues/5787
Send to android wifi settings instead of dealing with wifi state. Update permissions.

Should work on 99'9999% of android devices, but should be tested against corner cases (aka 4.0.? e-ink devices)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/221)
<!-- Reviewable:end -->
