### PR TITLE
clear intents onPause() to avoid replaying them onResume()

### DIFF
--- a/app/src/org/koreader/launcher/MainActivity.kt
+++ b/app/src/org/koreader/launcher/MainActivity.kt
@@ -131,6 +131,7 @@ class MainActivity : BaseActivity() {
         Logger.d(TAG_MAIN, "onPause()")
         super.onPause()
         applyCustomTimeout(false)
+        setIntent(null)
     }
 
     /* Called just before the activity is resumed by an intent


### PR DESCRIPTION
Probably related to our unorthodox way of dealing with content schemes, because the intent gets cleaned automagically on file schemes.

Fixes https://github.com/koreader/koreader/issues/5877

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/225)
<!-- Reviewable:end -->
