### PR TITLE
add warmth for Tolino Vision 4

### DIFF
--- a/app/src/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/org/koreader/launcher/device/DeviceInfo.kt
@@ -165,7 +165,7 @@ object DeviceInfo {
                 || DEVICE.contentEquals("ntx_6sl"))
         deviceMap[EinkDevice.TOLINO] = TOLINO
 
-        // Tolino Epos 2 also has warmth lights
+        // Tolino Epos 2 and Tolino Vision 4 also have warmth lights
         TOLINO_EPOS = BRAND.contentEquals("rakutenkobo") && MODEL.contentEquals("tolino")
             && DEVICE.contentEquals("ntx_6sl")
         lightsMap[LightsDevice.TOLINO_EPOS] = TOLINO_EPOS

--- a/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
+++ b/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
@@ -30,7 +30,7 @@ class TolinoWarmthController : LightInterface {
                 if (File(COLOR_FILE_VISION4HD).exists()) {
                     COLOR_FILE = COLOR_FILE_VISION4HD
                 }
-                else if (File(COLOR_FILE_EPOS2).exists()) {
+                else { // if (File(COLOR_FILE_EPOS2).exists())
                     COLOR_FILE = COLOR_FILE_EPOS2
                 }
                 Logger.v(TAG, "using $COLOR_FILE")

--- a/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
+++ b/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
@@ -22,10 +22,10 @@ class TolinoWarmthController : LightInterface {
         private const val MIN = 0
         private const val COLOR_FILE_EPOS2 = "/sys/class/backlight/tlc5947_bl/color"
         private const val COLOR_FILE_VISION4HD = "/sys/class/backlight/lm3630a_led/color"
-	private val COLOR_FILE = if (File(COLOR_FILE_VISION4HD).exists())
-	    COLOR_FILE_VISION4HD
-	else 
-	    COLOR_FILE_EPOS2
+        private val COLOR_FILE = if (File(COLOR_FILE_VISION4HD).exists())
+            COLOR_FILE_VISION4HD
+        else
+            COLOR_FILE_EPOS2
     }
 
     override fun hasFallback(): Boolean {

--- a/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
+++ b/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
@@ -22,7 +22,7 @@ class TolinoWarmthController : LightInterface {
         private const val MIN = 0
         private const val COLOR_FILE_EPOS2 = "/sys/class/backlight/tlc5947_bl/color"
         private const val COLOR_FILE_VISION4HD = "/sys/class/backlight/lm3630a_led/color"
-        private var COLOR_FILE = "" // gets initialized before first write access
+        private lateinit var COLOR_FILE : String // gets initialized before first write access
     }
 
     override fun hasFallback(): Boolean {
@@ -78,18 +78,18 @@ class TolinoWarmthController : LightInterface {
         }
 
         // on the first call, we check on which Tolino we are running
-        if (COLOR_FILE=="") { 
+        if (COLOR_FILE == "") {
             if (File(COLOR_FILE_VISION4HD).exists()) {
-                COLOR_FILE=COLOR_FILE_VISION4HD
+                COLOR_FILE = COLOR_FILE_VISION4HD
             }
             else if (File(COLOR_FILE_EPOS2).exists()) {
-                COLOR_FILE=COLOR_FILE_EPOS2
+                COLOR_FILE = COLOR_FILE_EPOS2
             }
             Logger.v(TAG, "using $COLOR_FILE")
         }
 
         val colorFile = File(COLOR_FILE)
-        Logger.v(TAG, "Setting warmth to $warmth")        
+        Logger.v(TAG, "Setting warmth to $warmth")
         try {
             if (!colorFile.canWrite()) {
                 Runtime.getRuntime().exec("su -c chmod 666 $COLOR_FILE")

--- a/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
+++ b/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
@@ -22,20 +22,10 @@ class TolinoWarmthController : LightInterface {
         private const val MIN = 0
         private const val COLOR_FILE_EPOS2 = "/sys/class/backlight/tlc5947_bl/color"
         private const val COLOR_FILE_VISION4HD = "/sys/class/backlight/lm3630a_led/color"
-        private lateinit var COLOR_FILE : String // gets initialized before first write access
-
-        fun initColorFile() {
-            // on the first call, we check on which Tolino we are running
-            if (!::COLOR_FILE.isInitialized) {
-                if (File(COLOR_FILE_VISION4HD).exists()) {
-                    COLOR_FILE = COLOR_FILE_VISION4HD
-                }
-                else { // if (File(COLOR_FILE_EPOS2).exists())
-                    COLOR_FILE = COLOR_FILE_EPOS2
-                }
-                Logger.v(TAG, "using $COLOR_FILE")
-            }
-        }
+	private val COLOR_FILE = if (File(COLOR_FILE_VISION4HD).exists())
+	    COLOR_FILE_VISION4HD
+	else 
+	    COLOR_FILE_EPOS2
     }
 
     override fun hasFallback(): Boolean {
@@ -61,7 +51,6 @@ class TolinoWarmthController : LightInterface {
     }
 
     override fun getWarmth(activity: Activity): Int {
-        initColorFile()
         val colorFile = File(COLOR_FILE)
         return try {
             WARMTH_MAX - colorFile.readText().toInt()
@@ -91,7 +80,6 @@ class TolinoWarmthController : LightInterface {
             return
         }
 
-        initColorFile()
         val colorFile = File(COLOR_FILE)
         Logger.v(TAG, "Setting warmth to $warmth")
         try {

--- a/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
+++ b/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
@@ -23,6 +23,19 @@ class TolinoWarmthController : LightInterface {
         private const val COLOR_FILE_EPOS2 = "/sys/class/backlight/tlc5947_bl/color"
         private const val COLOR_FILE_VISION4HD = "/sys/class/backlight/lm3630a_led/color"
         private lateinit var COLOR_FILE : String // gets initialized before first write access
+
+        fun initColorFile() {
+            // on the first call, we check on which Tolino we are running
+            if (!::COLOR_FILE.isInitialized) {
+                if (File(COLOR_FILE_VISION4HD).exists()) {
+                    COLOR_FILE = COLOR_FILE_VISION4HD
+                }
+                else if (File(COLOR_FILE_EPOS2).exists()) {
+                    COLOR_FILE = COLOR_FILE_EPOS2
+                }
+                Logger.v(TAG, "using $COLOR_FILE")
+            }
+        }
     }
 
     override fun hasFallback(): Boolean {
@@ -48,6 +61,7 @@ class TolinoWarmthController : LightInterface {
     }
 
     override fun getWarmth(activity: Activity): Int {
+        initColorFile()
         val colorFile = File(COLOR_FILE)
         return try {
             WARMTH_MAX - colorFile.readText().toInt()
@@ -77,17 +91,7 @@ class TolinoWarmthController : LightInterface {
             return
         }
 
-        // on the first call, we check on which Tolino we are running
-        if (COLOR_FILE == "") {
-            if (File(COLOR_FILE_VISION4HD).exists()) {
-                COLOR_FILE = COLOR_FILE_VISION4HD
-            }
-            else if (File(COLOR_FILE_EPOS2).exists()) {
-                COLOR_FILE = COLOR_FILE_EPOS2
-            }
-            Logger.v(TAG, "using $COLOR_FILE")
-        }
-
+        initColorFile()
         val colorFile = File(COLOR_FILE)
         Logger.v(TAG, "Setting warmth to $warmth")
         try {


### PR DESCRIPTION
The Vision 4 and the Epos 2 use the same DEVICE, BRAND and MODEL identifiers.
For accessing the warmth file, both use different files in /sys/class/backlight/

This PR allows changing warmth on both devices.

Internal: `setLastModified` does not work as expected (i.e. it does not throw an exception), therefore it is better to use `canWrite`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/244)
<!-- Reviewable:end -->
