### PR TITLE
Methods to check if frontlight is changeable

### DIFF
--- a/app/src/org/koreader/launcher/MainActivity.kt
+++ b/app/src/org/koreader/launcher/MainActivity.kt
@@ -222,8 +222,8 @@ class MainActivity : BaseActivity() {
      *             override methods used by lua/JNI                *
      *--------------------------------------------------------------*/
 
-    override fun canChangeFrontlight(): Int {
-        return lights.canChangeFrontlight(this@MainActivity)
+    override fun toggleFrontlightSwitchOn(): Int {
+        return lights.toggleFrontlightSwitchOn(this@MainActivity)
     }
 
     override fun getScreenBrightness(): Int {

--- a/app/src/org/koreader/launcher/MainActivity.kt
+++ b/app/src/org/koreader/launcher/MainActivity.kt
@@ -222,8 +222,8 @@ class MainActivity : BaseActivity() {
      *             override methods used by lua/JNI                *
      *--------------------------------------------------------------*/
 
-    override fun toggleFrontlightSwitchOn(): Int {
-        return lights.toggleFrontlightSwitchOn(this@MainActivity)
+    override fun enableFrontlightSwitch(): Int {
+        return lights.enableFrontlightSwitch(this@MainActivity)
     }
 
     override fun getScreenBrightness(): Int {

--- a/app/src/org/koreader/launcher/MainActivity.kt
+++ b/app/src/org/koreader/launcher/MainActivity.kt
@@ -222,6 +222,10 @@ class MainActivity : BaseActivity() {
      *             override methods used by lua/JNI                *
      *--------------------------------------------------------------*/
 
+    override fun canChangeFrontlight(): Int {
+        return lights.canChangeFrontlight(this@MainActivity)
+    }
+
     override fun getScreenBrightness(): Int {
         return lights.getBrightness(this@MainActivity)
     }

--- a/app/src/org/koreader/launcher/device/lights/GenericController.kt
+++ b/app/src/org/koreader/launcher/device/lights/GenericController.kt
@@ -27,7 +27,7 @@ class GenericController : LightInterface {
         return false
     }
 
-    override fun toggleFrontlightSwitchOn(activity: Activity): Int {
+    override fun enableFrontlightSwitch(activity: Activity): Int {
         return 1
     }
 

--- a/app/src/org/koreader/launcher/device/lights/GenericController.kt
+++ b/app/src/org/koreader/launcher/device/lights/GenericController.kt
@@ -27,7 +27,7 @@ class GenericController : LightInterface {
         return false
     }
 
-    override fun canChangeFrontlight(activity: Activity): Int {
+    override fun toggleFrontlightSwitchOn(activity: Activity): Int {
         return 1
     }
 

--- a/app/src/org/koreader/launcher/device/lights/GenericController.kt
+++ b/app/src/org/koreader/launcher/device/lights/GenericController.kt
@@ -27,6 +27,10 @@ class GenericController : LightInterface {
         return false
     }
 
+    override fun canChangeFrontlight(activity: Activity): Int {
+        return 1
+    }
+
     override fun getBrightness(activity: Activity): Int {
         val brightness = (activity.window.attributes.screenBrightness * (BRIGHTNESS_MAX - BRIGHTNESS_MIN) / 1.0f).toInt() + BRIGHTNESS_MIN
         return if (brightness < 0) {

--- a/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
+++ b/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
@@ -20,6 +20,7 @@ class TolinoWarmthController : LightInterface {
         private const val BRIGHTNESS_MAX = 255
         private const val WARMTH_MAX = 10
         private const val MIN = 0
+        private const val ACTUAL_BRIGHTNESS_FILE = "/sys/class/backlight/mxc_msp430_fl.0/actual_brightness" // always readable, same for Epos2 and Vision4
         private const val COLOR_FILE_EPOS2 = "/sys/class/backlight/tlc5947_bl/color"
         private const val COLOR_FILE_VISION4HD = "/sys/class/backlight/lm3630a_led/color"
         private val COLOR_FILE = if (File(COLOR_FILE_VISION4HD).exists())
@@ -38,6 +39,43 @@ class TolinoWarmthController : LightInterface {
 
     override fun needsPermission(): Boolean {
         return false
+    }
+
+    override fun canChangeFrontlight(activity: Activity): Int {
+        // ATTENTION: getBrightness, setBrightness use the Android range 0..255
+        // in the brightness files the used range is 0..100
+        val startBrightness = getBrightness(activity)
+
+        val actualBrightnessFile = File(ACTUAL_BRIGHTNESS_FILE)
+        val startBrightnessFromFile = try {
+            actualBrightnessFile.readText().trim().toInt()
+        } catch (e: Exception) {
+            Logger.w(TAG, "$e")
+            -1
+        }
+
+        // change the brightness through android. Be aware one step in Android is less than one step in the file
+        if (startBrightness > BRIGHTNESS_MAX/2)
+            setBrightness(activity, startBrightness - (BRIGHTNESS_MAX/4).toInt())
+        else
+            setBrightness(activity, startBrightness + (BRIGHTNESS_MAX/4).toInt())
+
+        // we have to wait until the android changes seep through to the file,
+        // 50ms is to less, 60ms seems to work, so use 80 to have some safety
+        Thread.sleep(80)
+
+        val actualBrightnessFromFile = try {
+            actualBrightnessFile.readText().trim().toInt()
+        } catch (e: Exception) {
+            Logger.w(TAG, "$e")
+            -1
+        }
+
+        if (startBrightnessFromFile == actualBrightnessFromFile)
+            return 0
+
+        setBrightness(activity, startBrightness)
+        return 1
     }
 
     override fun getBrightness(activity: Activity): Int {

--- a/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
+++ b/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
@@ -42,7 +42,7 @@ class TolinoWarmthController : LightInterface {
     }
 
     // try to toggle on frontlight switch on Tolinos, returns the former switch state
-    override fun toggleFrontlightSwitchOn(activity: Activity): Int {
+    override fun enableFrontlightSwitch(activity: Activity): Int {
         // ATTENTION: getBrightness, setBrightness use the Android range 0..255
         // in the brightness files the used range is 0..100
         val startBrightness = getBrightness(activity)
@@ -79,7 +79,7 @@ class TolinoWarmthController : LightInterface {
                 Runtime.getRuntime().exec("su -c input keyevent KEYCODE_BUTTON_A && echo OK")
                 1
             } catch (e: Exception) {
-                Logger.w("Exception in toggleFrontlightSwitchOn", e.toString());
+                Logger.w("Exception in enableFrontlightSwitch", e.toString());
                 0
             }
         }

--- a/app/src/org/koreader/launcher/interfaces/JNILuaInterface.kt
+++ b/app/src/org/koreader/launcher/interfaces/JNILuaInterface.kt
@@ -22,7 +22,6 @@ interface JNILuaInterface {
     fun getNetworkInfo(): String
     fun getPlatformName(): String
     fun getProduct(): String
-    fun canChangeFrontlight(): Int
     fun getScreenBrightness(): Int
     fun getScreenMinBrightness(): Int
     fun getScreenMaxBrightness(): Int
@@ -69,4 +68,5 @@ interface JNILuaInterface {
     fun showFrontlightDialog(title: String, dim: String, warmth: String, okButton: String, cancelButton: String): Int
     fun showToast(message: String)
     fun showToast(message: String, longTimeout: Boolean)
+    fun toggleFrontlightSwitchOn(): Int
 }

--- a/app/src/org/koreader/launcher/interfaces/JNILuaInterface.kt
+++ b/app/src/org/koreader/launcher/interfaces/JNILuaInterface.kt
@@ -22,6 +22,7 @@ interface JNILuaInterface {
     fun getNetworkInfo(): String
     fun getPlatformName(): String
     fun getProduct(): String
+    fun canChangeFrontlight(): Int
     fun getScreenBrightness(): Int
     fun getScreenMinBrightness(): Int
     fun getScreenMaxBrightness(): Int

--- a/app/src/org/koreader/launcher/interfaces/JNILuaInterface.kt
+++ b/app/src/org/koreader/launcher/interfaces/JNILuaInterface.kt
@@ -68,5 +68,5 @@ interface JNILuaInterface {
     fun showFrontlightDialog(title: String, dim: String, warmth: String, okButton: String, cancelButton: String): Int
     fun showToast(message: String)
     fun showToast(message: String, longTimeout: Boolean)
-    fun toggleFrontlightSwitchOn(): Int
+    fun enableFrontlightSwitch(): Int
 }

--- a/app/src/org/koreader/launcher/interfaces/LightInterface.kt
+++ b/app/src/org/koreader/launcher/interfaces/LightInterface.kt
@@ -6,6 +6,7 @@ interface LightInterface {
     fun hasFallback(): Boolean
     fun hasWarmth(): Boolean
     fun needsPermission(): Boolean
+    fun canChangeFrontlight(activity: Activity): Int
     fun getBrightness(activity: Activity): Int
     fun getWarmth(activity: Activity): Int
     fun setBrightness(activity: Activity, brightness: Int)

--- a/app/src/org/koreader/launcher/interfaces/LightInterface.kt
+++ b/app/src/org/koreader/launcher/interfaces/LightInterface.kt
@@ -14,5 +14,5 @@ interface LightInterface {
     fun getMaxWarmth(): Int
     fun getMinBrightness(): Int
     fun getMaxBrightness(): Int
-    fun toggleFrontlightSwitchOn(activity: Activity): Int
+    fun enableFrontlightSwitch(activity: Activity): Int
 }

--- a/app/src/org/koreader/launcher/interfaces/LightInterface.kt
+++ b/app/src/org/koreader/launcher/interfaces/LightInterface.kt
@@ -6,7 +6,6 @@ interface LightInterface {
     fun hasFallback(): Boolean
     fun hasWarmth(): Boolean
     fun needsPermission(): Boolean
-    fun canChangeFrontlight(activity: Activity): Int
     fun getBrightness(activity: Activity): Int
     fun getWarmth(activity: Activity): Int
     fun setBrightness(activity: Activity, brightness: Int)
@@ -15,4 +14,5 @@ interface LightInterface {
     fun getMaxWarmth(): Int
     fun getMinBrightness(): Int
     fun getMaxBrightness(): Int
+    fun toggleFrontlightSwitchOn(activity: Activity): Int
 }

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1764,7 +1764,6 @@ local function run(android_app_state)
     end
 
     android.canChangeFrontlight = function()
-        android.DEBUG("calling jni canChangeFrontligh")
         return JNI:context(android.app.activity.vm, function(jni)
             return jni:callIntMethod(
                 android.app.activity.clazz,

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1763,11 +1763,11 @@ local function run(android_app_state)
         end
     end
 
-    android.canChangeFrontlight = function()
+    android.toggleFrontlightSwitchOn = function()
         return JNI:context(android.app.activity.vm, function(jni)
             return jni:callIntMethod(
                 android.app.activity.clazz,
-                "canChangeFrontlight",
+                "toggleFrontlightSwitchOn",
                 "()I"
             ) == 1
         end)

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1735,6 +1735,7 @@ local function run(android_app_state)
     android.orientation.mode = function()
         return android.screen.orientation
     end
+
     android.orientation.get = function()
         return JNI:context(android.app.activity.vm, function(jni)
             return jni:callIntMethod(
@@ -1744,6 +1745,7 @@ local function run(android_app_state)
             )
         end)
     end
+
     android.orientation.set = function(new_orientation)
         if new_orientation >= ffi.C.ASCREEN_ORIENTATION_UNSPECIFIED and
                 new_orientation <= ffi.C.ASCREEN_ORIENTATION_FULL_SENSOR then
@@ -1759,6 +1761,17 @@ local function run(android_app_state)
         else
             android.LOGW("ignoring invalid orientation", new_orientation)
         end
+    end
+
+    android.canChangeFrontlight = function()
+        android.DEBUG("calling jni canChangeFrontligh")
+        return JNI:context(android.app.activity.vm, function(jni)
+            return jni:callIntMethod(
+                android.app.activity.clazz,
+                "canChangeFrontlight",
+                "()I"
+            ) == 1
+        end)
     end
 
     android.getScreenBrightness = function()

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1763,11 +1763,11 @@ local function run(android_app_state)
         end
     end
 
-    android.toggleFrontlightSwitchOn = function()
+    android.enableFrontlightSwitch = function()
         return JNI:context(android.app.activity.vm, function(jni)
             return jni:callIntMethod(
                 android.app.activity.clazz,
-                "toggleFrontlightSwitchOn",
+                "enableFrontlightSwitch",
                 "()I"
             ) == 1
         end)


### PR DESCRIPTION
Check if frontlight is changeable or locked by system settings, on Tolino.
On Generic Android assume frontlight is always changeable.

It was tested on Tolino Epos2, Vision4, a Phone and on the kodev emulator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/247)
<!-- Reviewable:end -->
