### PR TITLE
add method to check frontlight switch state, correct return value of enableFrontlightState

### DIFF
--- a/app/src/org/koreader/launcher/MainActivity.kt
+++ b/app/src/org/koreader/launcher/MainActivity.kt
@@ -222,8 +222,8 @@ class MainActivity : BaseActivity() {
      *             override methods used by lua/JNI                *
      *--------------------------------------------------------------*/
 
-    override fun getFrontlightSwitch(): Int {
-        return lights.getFrontlightSwitch(this@MainActivity)
+    override fun getFrontlightSwitchState(): Int {
+        return lights.getFrontlightSwitchState(this@MainActivity)
     }
 
     override fun enableFrontlightSwitch(): Int {

--- a/app/src/org/koreader/launcher/MainActivity.kt
+++ b/app/src/org/koreader/launcher/MainActivity.kt
@@ -222,6 +222,10 @@ class MainActivity : BaseActivity() {
      *             override methods used by lua/JNI                *
      *--------------------------------------------------------------*/
 
+    override fun getFrontlightSwitch(): Int {
+        return lights.getFrontlightSwitch(this@MainActivity)
+    }
+
     override fun enableFrontlightSwitch(): Int {
         return lights.enableFrontlightSwitch(this@MainActivity)
     }

--- a/app/src/org/koreader/launcher/device/lights/GenericController.kt
+++ b/app/src/org/koreader/launcher/device/lights/GenericController.kt
@@ -27,7 +27,7 @@ class GenericController : LightInterface {
         return false
     }
 
-    override fun getFrontlightSwitch(activity: Activity): Int {
+    override fun getFrontlightSwitchState(activity: Activity): Int {
         return 1
     }
 

--- a/app/src/org/koreader/launcher/device/lights/GenericController.kt
+++ b/app/src/org/koreader/launcher/device/lights/GenericController.kt
@@ -27,6 +27,10 @@ class GenericController : LightInterface {
         return false
     }
 
+    override fun getFrontlightSwitch(activity: Activity): Int {
+        return 1
+    }
+
     override fun enableFrontlightSwitch(activity: Activity): Int {
         return 1
     }

--- a/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
+++ b/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
@@ -41,8 +41,7 @@ class TolinoWarmthController : LightInterface {
         return false
     }
 
-    // try to toggle on frontlight switch on Tolinos, returns the former switch state
-    override fun enableFrontlightSwitch(activity: Activity): Int {
+    override fun getFrontlightSwitch(activity: Activity): Int {
         // ATTENTION: getBrightness, setBrightness use the Android range 0..255
         // in the brightness files the used range is 0..100
         val startBrightness = getBrightness(activity)
@@ -74,14 +73,22 @@ class TolinoWarmthController : LightInterface {
 
         setBrightness(activity, startBrightness)
 
-        if (startBrightnessFromFile == actualBrightnessFromFile) {
-            return try { // try to send keyevent to system to turn on frontlight, needs extended permissions
-                Runtime.getRuntime().exec("su -c input keyevent KEYCODE_BUTTON_A && echo OK")
-                1
+        if (actualBrightnessFromFile == startBrightnessFromFile)
+            return 0 // switch is off
+        else
+            return 1 // switch is on
+}
+
+    // try to toggle on frontlight switch on Tolinos, returns the former switch state
+    override fun enableFrontlightSwitch(activity: Activity): Int {
+
+        if (getFrontlightSwitch(activity) == 0) {
+            try { // try to send keyevent to system to turn on frontlight, needs extended permissions
+                Runtime.getRuntime().exec("su -c input keyevent KEYCODE_BUTTON_A");
             } catch (e: Exception) {
                 Logger.w("Exception in enableFrontlightSwitch", e.toString());
-                0
             }
+            return 0 // former switch state
         }
 
         return 1

--- a/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
+++ b/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
@@ -41,7 +41,7 @@ class TolinoWarmthController : LightInterface {
         return false
     }
 
-    override fun getFrontlightSwitch(activity: Activity): Int {
+    override fun getFrontlightSwitchState(activity: Activity): Int {
         // ATTENTION: getBrightness, setBrightness use the Android range 0..255
         // in the brightness files the used range is 0..100
         val startBrightness = getBrightness(activity)
@@ -73,16 +73,20 @@ class TolinoWarmthController : LightInterface {
 
         setBrightness(activity, startBrightness)
 
-        if (actualBrightnessFromFile == startBrightnessFromFile)
+        if (actualBrightnessFromFile == startBrightnessFromFile) {
+            Logger.w(TAG, "frontlight Switch off")
             return 0 // switch is off
-        else
+        }
+        else {
+            Logger.w(TAG, "frontlight Switch off")
             return 1 // switch is on
+        }
 }
 
     // try to toggle on frontlight switch on Tolinos, returns the former switch state
     override fun enableFrontlightSwitch(activity: Activity): Int {
 
-        if (getFrontlightSwitch(activity) == 0) {
+        if (getFrontlightSwitchState(activity) == 0) {
             try { // try to send keyevent to system to turn on frontlight, needs extended permissions
                 Runtime.getRuntime().exec("su -c input keyevent KEYCODE_BUTTON_A");
             } catch (e: Exception) {

--- a/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
+++ b/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
@@ -140,7 +140,7 @@ class TolinoWarmthController : LightInterface {
     }
 
     override fun setWarmth(activity: Activity, warmth: Int) {
-        if (warmth < MIN || warmth > BRIGHTNESS_MAX) {
+        if (warmth < MIN || warmth > WARMTH_MAX) {
             Logger.w(TAG, "warmth value of of range: $warmth")
             return
         }

--- a/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
+++ b/app/src/org/koreader/launcher/device/lights/TolinoWarmthController.kt
@@ -44,6 +44,12 @@ class TolinoWarmthController : LightInterface {
     override fun getFrontlightSwitchState(activity: Activity): Int {
         // ATTENTION: getBrightness, setBrightness use the Android range 0..255
         // in the brightness files the used range is 0..100
+
+        // As we don`t know, if the frontlightSwitch was pressed just before this method
+        // was called, we have to wait until the android changes seep through to the file,
+        // 50ms is to less, 60ms seems to work, so use 80 to have some safety
+        Thread.sleep(80)
+
         val startBrightness = getBrightness(activity)
 
         val actualBrightnessFile = File(ACTUAL_BRIGHTNESS_FILE)
@@ -55,10 +61,12 @@ class TolinoWarmthController : LightInterface {
         }
 
         // change the brightness through android. Be aware one step in Android is less than one step in the file
+        var actualBrightness = startBrightness
         if (startBrightness > BRIGHTNESS_MAX/2)
-            setBrightness(activity, startBrightness - (BRIGHTNESS_MAX/100+1).toInt())
+            actualBrightness -= (BRIGHTNESS_MAX/100+1).toInt()
         else
-            setBrightness(activity, startBrightness + (BRIGHTNESS_MAX/100+1).toInt())
+            actualBrightness +=  (BRIGHTNESS_MAX/100+1).toInt()
+        setBrightness(activity, actualBrightness)
 
         // we have to wait until the android changes seep through to the file,
         // 50ms is to less, 60ms seems to work, so use 80 to have some safety
@@ -68,7 +76,6 @@ class TolinoWarmthController : LightInterface {
             actualBrightnessFile.readText().trim().toInt()
         } catch (e: Exception) {
             Logger.w(TAG, "$e")
-            -1
         }
 
         setBrightness(activity, startBrightness)
@@ -78,7 +85,7 @@ class TolinoWarmthController : LightInterface {
             return 0 // switch is off
         }
         else {
-            Logger.w(TAG, "frontlight Switch off")
+            Logger.w(TAG, "frontlight Switch on")
             return 1 // switch is on
         }
 }

--- a/app/src/org/koreader/launcher/interfaces/JNILuaInterface.kt
+++ b/app/src/org/koreader/launcher/interfaces/JNILuaInterface.kt
@@ -68,6 +68,6 @@ interface JNILuaInterface {
     fun showFrontlightDialog(title: String, dim: String, warmth: String, okButton: String, cancelButton: String): Int
     fun showToast(message: String)
     fun showToast(message: String, longTimeout: Boolean)
-    fun getFrontlightSwitch(): Int
+    fun getFrontlightSwitchState(): Int
     fun enableFrontlightSwitch(): Int
 }

--- a/app/src/org/koreader/launcher/interfaces/JNILuaInterface.kt
+++ b/app/src/org/koreader/launcher/interfaces/JNILuaInterface.kt
@@ -68,5 +68,6 @@ interface JNILuaInterface {
     fun showFrontlightDialog(title: String, dim: String, warmth: String, okButton: String, cancelButton: String): Int
     fun showToast(message: String)
     fun showToast(message: String, longTimeout: Boolean)
+    fun getFrontlightSwitch(): Int
     fun enableFrontlightSwitch(): Int
 }

--- a/app/src/org/koreader/launcher/interfaces/LightInterface.kt
+++ b/app/src/org/koreader/launcher/interfaces/LightInterface.kt
@@ -14,6 +14,6 @@ interface LightInterface {
     fun getMaxWarmth(): Int
     fun getMinBrightness(): Int
     fun getMaxBrightness(): Int
-    fun getFrontlightSwitch(activity: Activity): Int
+    fun getFrontlightSwitchState(activity: Activity): Int
     fun enableFrontlightSwitch(activity: Activity): Int
 }

--- a/app/src/org/koreader/launcher/interfaces/LightInterface.kt
+++ b/app/src/org/koreader/launcher/interfaces/LightInterface.kt
@@ -14,5 +14,6 @@ interface LightInterface {
     fun getMaxWarmth(): Int
     fun getMinBrightness(): Int
     fun getMaxBrightness(): Int
+    fun getFrontlightSwitch(activity: Activity): Int
     fun enableFrontlightSwitch(activity: Activity): Int
 }

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1763,11 +1763,11 @@ local function run(android_app_state)
         end
     end
 
-    android.getFrontlightSwitch = function()
+    android.getFrontlightSwitchState = function()
         return JNI:context(android.app.activity.vm, function(jni)
             return jni:callIntMethod(
                 android.app.activity.clazz,
-                "getFrontlightSwitch",
+                "getFrontlightSwitchState",
                 "()I"
             ) == 1
         end)

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1763,6 +1763,16 @@ local function run(android_app_state)
         end
     end
 
+    android.getFrontlightSwitch = function()
+        return JNI:context(android.app.activity.vm, function(jni)
+            return jni:callIntMethod(
+                android.app.activity.clazz,
+                "getFrontlightSwitch",
+                "()I"
+            ) == 1
+        end)
+    end
+
     android.enableFrontlightSwitch = function()
         return JNI:context(android.app.activity.vm, function(jni)
             return jni:callIntMethod(


### PR DESCRIPTION

This method will be necessary to give a correct light status in the status line on startup.

The return value of enableFrontlightState was wrong (did not correspond to the comment above the method).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/249)
<!-- Reviewable:end -->
