### PR TITLE
Implement EPD Controller for newer Onyx Boox devices (Qualcomm)

### DIFF
--- a/app/res/layout/main.xml
+++ b/app/res/layout/main.xml
@@ -77,6 +77,24 @@
 
         <TextView
             android:layout_width="fill_parent"
+            android:layout_height="12dp" />
+
+        <TextView
+            android:id="@+id/qualcommText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:textSize="18sp" />
+
+        <Button
+            android:id="@+id/qualcommButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="qualcomm/onyx update"
+            android:textSize="28sp" />
+
+        <TextView
+            android:layout_width="fill_parent"
             android:layout_height="18dp" />
 
         <TextView

--- a/app/src/org/koreader/launcher/EPDTestActivity.kt
+++ b/app/src/org/koreader/launcher/EPDTestActivity.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.Button
 import android.widget.TextView
 import org.koreader.launcher.device.epd.freescale.NTXEPDController
+import org.koreader.launcher.device.epd.qualcomm.QualcommEPDController
 import org.koreader.launcher.device.epd.rockchip.RK30xxEPDController
 import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController
 import java.util.*
@@ -26,9 +27,11 @@ class EPDTestActivity : Activity() {
         val rk30xxDescription: TextView = findViewById(R.id.rk30xxText)
         val rk33xxDescription: TextView = findViewById(R.id.rk33xxText)
         val ntxNewDescription: TextView = findViewById(R.id.ntxNewText)
+        val qualcommDescription: TextView = findViewById(R.id.qualcommText)
         val rk30xxButton: Button = findViewById(R.id.rk30xxButton)
         val rk33xxButton: Button = findViewById(R.id.rk33xxButton)
         val ntxNewButton: Button = findViewById(R.id.ntxNewButton)
+        val qualcommButton: Button = findViewById(R.id.qualcommButton)
         val shareButton: Button = findViewById(R.id.shareButton)
 
         /* current device info */
@@ -66,6 +69,10 @@ class EPDTestActivity : Activity() {
         ntxNewDescription.text = "This button should work on modern Tolinos/Nooks and other ntx boards"
         ntxNewButton.setOnClickListener { runEinkTest(NTXTEST) }
 
+        /* qualcomm - At least Onyx Boox Nova 2 */
+        qualcommDescription.text = "This button should work on some Onyx Boox devices. At least qualcomm ones"
+        qualcommButton.setOnClickListener { runEinkTest(QUALCOMMTEST) }
+
         /* share button */
         shareButton.setOnClickListener { shareText(info.text.toString()) }
     }
@@ -82,15 +89,20 @@ class EPDTestActivity : Activity() {
             } else if (test == RK33xxTEST) {
                 info.append("rk33xx: ")
                 if (RK33xxEPDController.requestEpdMode("EPD_FULL")) success = true
-            } else if (test == NTXTEST) {
+            } else if (test == NTXTEST || test == QUALCOMMTEST) {
                 // get screen width and height
                 val display = windowManager.defaultDisplay
                 val size = Point()
                 display.getSize(size)
                 val width = size.x
                 val height = size.y
-                info.append("tolino: ")
-                if (NTXEPDController.requestEpdMode(v, 34, 50, 0, 0, width, height)) success = true
+                if (test == NTXTEST) {
+                    info.append("tolino: ")
+                    if (NTXEPDController.requestEpdMode(v, 34, 50, 0, 0, width, height)) success = true
+                } else if (test == QUALCOMMTEST) {
+                    info.append("qualcomm: ")
+                    if (QualcommEPDController.requestEpdMode(v, 98, 50, 0, 0, width, height)) success = true
+                }
             }
         } catch (e: Exception) {
             e.printStackTrace()
@@ -113,6 +125,7 @@ class EPDTestActivity : Activity() {
         private const val RK30xxTEST = 1
         private const val RK33xxTEST = 2
         private const val NTXTEST = 3
+        private const val QUALCOMMTEST = 4
         private val MANUFACTURER = android.os.Build.MANUFACTURER
         private val BRAND = android.os.Build.BRAND
         private val MODEL = android.os.Build.MODEL

--- a/app/src/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/org/koreader/launcher/device/DeviceInfo.kt
@@ -14,6 +14,7 @@ object DeviceInfo {
     val PRODUCT: String
     val EINK_FREESCALE: Boolean
     val EINK_ROCKCHIP: Boolean
+    val EINK_QCOM: Boolean
     val EINK_SUPPORT: Boolean
     val EINK_FULL_SUPPORT: Boolean
     val BUG_WAKELOCKS: Boolean
@@ -65,6 +66,7 @@ object DeviceInfo {
         CREMA,
         CREMA_0650L,
         ONYX_C67,
+        ONYX_NOVA2,
         ENERGY,
         INKBOOK,
         TOLINO,
@@ -149,6 +151,7 @@ object DeviceInfo {
                 && PRODUCT.contentEquals("nova2")
                 && DEVICE.contentEquals("nova2"))
         lightsMap[LightsDevice.ONYX_NOVA2] = ONYX_NOVA2
+        deviceMap[EinkDevice.ONYX_NOVA2] = ONYX_NOVA2
 
         // Onyx C67
         ONYX_C67 = (MANUFACTURER.contentEquals("onyx")
@@ -243,11 +246,13 @@ object DeviceInfo {
             INKBOOK ||
             ONYX_C67
 
+        EINK_QCOM = ONYX_NOVA2
+
         // basic eink support
-        EINK_SUPPORT = EINK_FREESCALE || EINK_ROCKCHIP
+        EINK_SUPPORT = EINK_FREESCALE || EINK_ROCKCHIP || EINK_QCOM
 
         // full eink support
-        EINK_FULL_SUPPORT = CREMA || TOLINO
+        EINK_FULL_SUPPORT = CREMA || TOLINO || ONYX_NOVA2
 
         // need wakelocks
         BUG_WAKELOCKS = BUG == BugDevice.SONY_RP1
@@ -256,7 +261,7 @@ object DeviceInfo {
         BUG_SCREEN_ROTATION = BUG == BugDevice.EMULATOR
 
         // needs a surfaceView to do epd updates
-        NEEDS_VIEW = EINK_FREESCALE
+        NEEDS_VIEW = EINK_FREESCALE || EINK_QCOM
     }
 
     private fun getBuildField(fieldName: String): String {

--- a/app/src/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/org/koreader/launcher/device/EPDFactory.kt
@@ -7,6 +7,7 @@ import org.koreader.launcher.Logger
 import org.koreader.launcher.device.epd.freescale.NTXNewEPDController
 import org.koreader.launcher.device.epd.rockchip.RK3026EPDController
 import org.koreader.launcher.device.epd.rockchip.RK3368EPDController
+import org.koreader.launcher.device.epd.qualcomm.QualcommOnyxEPDController
 import org.koreader.launcher.interfaces.EPDInterface
 import java.util.*
 
@@ -38,6 +39,10 @@ object EPDFactory {
                 DeviceInfo.EinkDevice.NOOK_V520 -> {
                     logController("Freescale NTX")
                     NTXNewEPDController()
+                }
+                DeviceInfo.EinkDevice.ONYX_NOVA2 -> {
+                    logController("QualcommEPDController")
+                    QualcommOnyxEPDController()
                 }
                 else -> {
                     FakeEPDController()

--- a/app/src/org/koreader/launcher/device/epd/qualcomm/QualcommEPDController.kt
+++ b/app/src/org/koreader/launcher/device/epd/qualcomm/QualcommEPDController.kt
@@ -1,0 +1,67 @@
+package org.koreader.launcher.device.epd.qualcomm
+
+import java.lang.Thread
+import java.util.Locale
+
+import android.view.View
+import android.util.Log
+
+import org.koreader.launcher.interfaces.EPDInterface
+
+// More information including epd mode values
+// https://github.com/koreader/android-luajit-launcher/pull/250#issuecomment-711443457
+abstract class QualcommEPDController : EPDInterface {
+    companion object  {
+        private const val TAG = "epd"
+
+        fun preventSystemRefresh() : Boolean{
+            // Sets UpdateMode and UpdateScheme to None
+            // this function is called EpdController.setSystemUpdateModeAndScheme in onyxsdk
+            return try{
+                Class.forName("android.view.View").getMethod("setWaveformAndScheme",
+                    Integer.TYPE,
+                    Integer.TYPE,
+                    Integer.TYPE).invoke(null, 5, 1, 0)
+                true
+            } catch (e: Exception) {
+                Log.e(TAG, e.toString())
+                false
+            }
+        }
+
+        fun requestEpdMode(targetView: android.view.View,
+                                mode: Int, delay: Long,
+                                x: Int, y: Int, width: Int, height: Int) : Boolean
+        {
+            return try{
+                // We need to always call this, not sure why, if it's not called before
+                // system will refresh after us, it'll refresh anyway if user set
+                // Normal mode, or Regal mode works flawlessly otherwise
+                preventSystemRefresh()
+                // EpdController.refreshScreenRegion in onyxsdk
+                var refreshScreen = Class.forName("android.view.View").getMethod("refreshScreen",
+                                        Integer.TYPE,
+                                        Integer.TYPE,
+                                        Integer.TYPE,
+                                        Integer.TYPE,
+                                        Integer.TYPE)
+                object: Thread(){
+                    override fun run(){
+                        Thread.sleep(delay)
+                        try {
+                            refreshScreen.invoke(targetView, x, y, width, height, mode)
+                            Log.i(TAG, String.format(Locale.US,
+                                "requested eink refresh, type: %d x:%d y:%d w:%d h:%d",
+                                mode, x, y, width, height))
+                        } catch(e: Exception) {
+                            Log.e(TAG, e.toString())
+                        }
+                    }
+                }.start()
+                true
+            } catch(e: Exception) {
+                false
+            }
+        }
+    }
+}

--- a/app/src/org/koreader/launcher/device/epd/qualcomm/QualcommOnyxEPDController.kt
+++ b/app/src/org/koreader/launcher/device/epd/qualcomm/QualcommOnyxEPDController.kt
@@ -1,0 +1,14 @@
+/* Tested on Onyx Boox Nova 2 */
+
+package org.koreader.launcher.device.epd.qualcomm
+
+import org.koreader.launcher.interfaces.EPDInterface
+
+class QualcommOnyxEPDController : QualcommEPDController(), EPDInterface {
+    override fun setEpdMode(targetView: android.view.View,
+                            mode: Int, delay: Long,
+                            x: Int, y: Int, width: Int, height: Int, epdMode: String?)
+    {
+        requestEpdMode(targetView, mode, delay, x, y, width, height)
+    }
+}

--- a/app/src/org/koreader/launcher/device/epd/qualcomm/QualcommOnyxEPDController.kt
+++ b/app/src/org/koreader/launcher/device/epd/qualcomm/QualcommOnyxEPDController.kt
@@ -5,6 +5,8 @@ package org.koreader.launcher.device.epd.qualcomm
 import org.koreader.launcher.interfaces.EPDInterface
 
 class QualcommOnyxEPDController : QualcommEPDController(), EPDInterface {
+    override fun resume() {}
+    override fun pause() {}
     override fun setEpdMode(targetView: android.view.View,
                             mode: Int, delay: Long,
                             x: Int, y: Int, width: Int, height: Int, epdMode: String?)


### PR DESCRIPTION
Currently onyx devices rely on system controller, which doesn't work as well as it could with KOReader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/250)
<!-- Reviewable:end -->
