### PR TITLE
bump to API 30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,4 @@ clean:
 	rm -rf assets/module/ bin/ jni/luajit/build
 	cd jni/luajit && \
 		./mk-luajit.sh clean
-
-mrproper: clean
-	@echo "Cleaning Gradle, this could fail if some tasks were never triggered before"
 	-./gradlew clean --continue

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,11 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
+    compileSdkVersion targetSdk
+
     defaultConfig {
         applicationId "org.koreader.launcher"
         minSdkVersion minSdk
         targetSdkVersion targetSdk
-        compileSdkVersion targetSdk
         versionCode versCode as Integer
         versionName versName
     }

--- a/app/fdroid/org/koreader/launcher/ApkUpdater.kt
+++ b/app/fdroid/org/koreader/launcher/ApkUpdater.kt
@@ -2,8 +2,8 @@ package org.koreader.launcher
 
 import android.app.Activity
 
+@SuppressWarnings("unused")
 object ApkUpdater {
-    @SuppressWarnings("unused")
     fun download(activity: Activity, url: String, name: String): Int {
         return -1
     }

--- a/app/manifest/base.xml
+++ b/app/manifest/base.xml
@@ -12,10 +12,13 @@
     <!-- common android permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        tools:ignore="ScopedStorage" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" android:maxSdkVersion="29" />
 
     <application
         android:name=".MainApp"
@@ -26,7 +29,7 @@
         android:allowBackup="false"
         android:fullBackupContent="false"
         android:usesCleartextTraffic="true"
-        tools:replace="android:label" >
+        android:requestLegacyExternalStorage="true" >
         <meta-data android:name="android.max_aspect" android:value="3.1" />
         <activity
             android:name=".MainActivity"

--- a/app/manifest/rocks.xml
+++ b/app/manifest/rocks.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" >
+    <uses-permission tools:node="merge" android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 </manifest>

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="warning_manage_storage">Please allow the app to manage all files.</string>
+</resources>

--- a/app/rocks/org/koreader/launcher/ApkUpdater.kt
+++ b/app/rocks/org/koreader/launcher/ApkUpdater.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.os.Environment
 import java.io.File
 
+@Suppress("DEPRECATION")
 object ApkUpdater {
     fun download(activity: Activity, url: String, name: String): Int {
         val request = DownloadManager.Request(Uri.parse(url))

--- a/app/src/org/koreader/launcher/EPDTestActivity.kt
+++ b/app/src/org/koreader/launcher/EPDTestActivity.kt
@@ -16,6 +16,7 @@ import java.util.*
    If the device in question doesn't play nice with the main NativeActivity it can be called from
    commandline using `adb shell am start -n org.koreader.launcher/.EPDTestActivity` */
 
+@Suppress("DEPRECATION")
 class EPDTestActivity : Activity() {
     private lateinit var info: TextView
 

--- a/app/src/org/koreader/launcher/MainApp.kt
+++ b/app/src/org/koreader/launcher/MainApp.kt
@@ -38,6 +38,7 @@ class MainApp : android.app.Application() {
             if (isSystemApp) "system" else "user"
         }
 
+        @Suppress("DEPRECATION")
         storage_path = Environment.getExternalStorageDirectory().absolutePath
         platform_type = if (pm.hasSystemFeature("org.chromium.arc.device_management")) {
             "chrome"

--- a/app/src/org/koreader/launcher/utils/Permissions.kt
+++ b/app/src/org/koreader/launcher/utils/Permissions.kt
@@ -6,17 +6,23 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Environment
 import android.os.PowerManager
 import android.provider.Settings
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import org.koreader.launcher.R
 
 object Permissions {
     private const val STORAGE_WRITE_ID = 1001
 
     fun hasStoragePermission(activity: Activity): Boolean {
-        return hasPermissionGranted(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        return if (Build.VERSION.SDK_INT >= 30) {
+            Environment.isExternalStorageManager()
+        } else {
+            hasPermissionGranted(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        }
     }
 
     fun hasWriteSettingsPermission(context: Context): Boolean {
@@ -33,8 +39,14 @@ object Permissions {
     }
 
     fun requestStoragePermission(activity: Activity) {
-        val perm = Manifest.permission.WRITE_EXTERNAL_STORAGE
-        requestPermission(activity, perm, STORAGE_WRITE_ID)
+        if (Build.VERSION.SDK_INT >= 30) {
+            val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
+            val rationale = activity.resources.getString(R.string.warning_manage_storage)
+            requestSpecialPermission(activity, intent, rationale, null, null)
+        } else {
+            val perm = Manifest.permission.WRITE_EXTERNAL_STORAGE
+            requestPermission(activity, perm, STORAGE_WRITE_ID)
+        }
     }
 
     fun requestWriteSettingsPermission(activity: Activity, rationale: String, okButton: String, cancelButton: String) {

--- a/app/src/org/koreader/launcher/utils/ScreenUtils.kt
+++ b/app/src/org/koreader/launcher/utils/ScreenUtils.kt
@@ -9,6 +9,7 @@ import android.view.WindowManager
 import org.koreader.launcher.Logger
 import java.util.concurrent.CountDownLatch
 
+@Suppress("DEPRECATION")
 object ScreenUtils {
     private const val TAG = "ScreenUtils"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.gradle_plugin_version = '3.4.2'
-    ext.kotlin_plugin_version = '1.3.72'
+    ext.gradle_plugin_version = '3.6.4'
+    ext.kotlin_plugin_version = '1.4.10'
     ext.androidx_core_version = '1.3.2'
     ext.androidx_appcompat_version = '1.2.0'
     ext.androidx_supportv4_version = '1.0.0'
     ext.leakcanary_version = '2.5'
     ext.minSdk = 14
-    ext.targetSdk = 28
+    ext.targetSdk = 30
 
     repositories {
         google()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 09 00:29:09 CET 2020
+#Thu Nov 12 01:37:04 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
So Google changed his scoped storage enforcement for Android 11+. It is indeed cool because killing the File API was nosense: https://developer.android.com/training/data-storage/manage-all-files

It is a draft, as it requires changes in the build server and the toolchain:

```diff
diff --git a/toolchain/Makefile b/toolchain/Makefile
index 684b51e..3e12a83 100644
--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -19,7 +19,7 @@ android-sdk:
        pushd $(SDK_DIR)/tools/bin && \
                yes | ./sdkmanager --update && \
                yes | ./sdkmanager --licenses && \
-               ./sdkmanager "platform-tools" "build-tools;28.0.3" "platforms;android-28" "patcher;v4" && \
+               ./sdkmanager "platform-tools" "build-tools;30.0.2" "platforms;android-30" "patcher;v4" && \
                popd
        rm -f $(SDK_DIR)/$(SDK_TARBALL)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/253)
<!-- Reviewable:end -->
