### PR TITLE
/sdcard should be a symbolic link to external storage path in sane de…

### DIFF
--- a/app/src/org/koreader/launcher/MainActivity.kt
+++ b/app/src/org/koreader/launcher/MainActivity.kt
@@ -483,9 +483,10 @@ class MainActivity : NativeActivity(), JNILuaInterface,
         }
     }
 
+    @SuppressLint("SdCardPath")
     override fun isPathInsideSandbox(path: String?): Int {
         return path?.let {
-            if (it.startsWith(device.externalStorage)) 1 else 0
+            if (it.startsWith("/sdcard") or it.startsWith(device.externalStorage)) 1 else 0
         } ?: 0
     }
 


### PR DESCRIPTION
…vices

cf, https://github.com/koreader/koreader/pull/6813

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/260)
<!-- Reviewable:end -->
