### PR TITLE
get absolute path of external sdcard

### DIFF
--- a/app/src/org/koreader/launcher/MainActivity.kt
+++ b/app/src/org/koreader/launcher/MainActivity.kt
@@ -328,6 +328,10 @@ class MainActivity : NativeActivity(), JNILuaInterface,
         return device.externalStorage
     }
 
+    override fun getExternalSdPath(): String {
+        return FileUtils.getExtSdcardPath(this)
+    }
+
     override fun getFilePathFromIntent(): String? {
         return intent?.let {
             if (it.action == Intent.ACTION_VIEW) {
@@ -487,10 +491,12 @@ class MainActivity : NativeActivity(), JNILuaInterface,
     }
 
     @SuppressLint("SdCardPath")
-    override fun isPathInsideSandbox(path: String?): Int {
-        return path?.let {
-            if (it.startsWith("/sdcard") or it.startsWith(device.externalStorage)) 1 else 0
-        } ?: 0
+    override fun isPathInsideSandbox(path: String): Int {
+        return when {
+            path.startsWith("/sdcard") -> 1
+            path.startsWith(device.externalStorage) -> 1
+            else -> 0
+        }
     }
 
     override fun isTv(): Int {

--- a/app/src/org/koreader/launcher/interfaces/JNILuaInterface.kt
+++ b/app/src/org/koreader/launcher/interfaces/JNILuaInterface.kt
@@ -15,6 +15,7 @@ interface JNILuaInterface {
     fun getClipboardText(): String
     fun getEinkPlatform(): String
     fun getExternalPath(): String
+    fun getExternalSdPath(): String
     fun getFilePathFromIntent(): String?
     fun getFlavor(): String
     fun getLastImportedPath(): String?
@@ -47,7 +48,7 @@ interface JNILuaInterface {
     fun isEinkFull(): Int
     fun isFullscreen(): Int
     fun isPackageEnabled(pkg: String): Int
-    fun isPathInsideSandbox(path: String?): Int
+    fun isPathInsideSandbox(path: String): Int
     fun isTv(): Int
     fun isWarmthDevice(): Int
     fun needsWakelocks(): Int

--- a/app/src/org/koreader/launcher/utils/FileUtils.kt
+++ b/app/src/org/koreader/launcher/utils/FileUtils.kt
@@ -4,9 +4,11 @@ import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import android.os.Build
+import android.os.Environment
 import android.os.ParcelFileDescriptor
 import android.provider.MediaStore
 import android.system.Os
+import androidx.core.content.ContextCompat
 import org.koreader.launcher.Logger
 import java.io.*
 import java.util.*
@@ -56,6 +58,27 @@ object FileUtils {
                 }
                 else -> null
             }
+        }
+    }
+
+    /**
+     * gets the absolute path of an external sdcard if there's one inserted
+     *
+     * @param context
+     * @return absolute path or "null"
+     */
+
+    fun getExtSdcardPath(context: Context): String {
+        val ctx = context.applicationContext
+        val volumes: Array<out File> = ContextCompat.getExternalFilesDirs(ctx, null)
+        return if (Environment.getExternalStorageState() == Environment.MEDIA_MOUNTED) {
+            try {
+                volumes[1].absolutePath.replace("/Android/data/${ctx.packageName}/files", "")
+            } catch (e: Exception) {
+                "null"
+            }
+        } else {
+            "null"
         }
     }
 

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1429,6 +1429,24 @@ local function run(android_app_state)
         end)
     end
 
+    android.getExternalSdPath = function()
+        return JNI:context(android.app.activity.vm, function(jni)
+                local ext_sd_path = jni:callObjectMethod(
+                    android.app.activity.clazz,
+                    "getExternalSdPath",
+                    "()Ljava/lang/String;"
+                )
+
+                local res = jni:to_string(ext_sd_path)
+
+                if res == "null" then
+                    return false
+                else
+                    return true, res
+                end
+            end)
+        end
+
     android.importFile = function(path)
         return JNI:context(android.app.activity.vm, function(jni)
             local import_path = jni.env[0].NewStringUTF(jni.env, path)
@@ -1458,6 +1476,7 @@ local function run(android_app_state)
     end
 
     android.isPathInsideSandbox = function(path)
+        if not path then return end
         return JNI:context(android.app.activity.vm, function(jni)
             local import_path = jni.env[0].NewStringUTF(jni.env, path)
             local ok = jni:callIntMethod(


### PR DESCRIPTION
Based on a hack, but it is the only way to get the path and it is extensively used elsewhere.

It should be reliable enough on 4.4+ and should produce a catched exception on 4.0 - 4.3.
At the same time on 4.0 - 4.3 probably there're no restrictions to move between volumes using our filemanager.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/266)
<!-- Reviewable:end -->
