### PR TITLE
return to target API28

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion targetSdk
+    compileSdkVersion compileSdk
 
     defaultConfig {
         applicationId "org.koreader.launcher"
@@ -54,7 +54,7 @@ android {
         x86_64 {
             ndk { abiFilters "x86_64" }
             dimension = 'ABI'
-            minSdkVersion = 21
+            minSdkVersion = min64Sdk
         }
         arm {
             ndk { abiFilters "armeabi-v7a" }
@@ -63,7 +63,7 @@ android {
         arm64 {
             ndk { abiFilters "arm64-v8a" }
             dimension = 'ABI'
-            minSdkVersion = 21
+            minSdkVersion = min64Sdk
         }
 
         fdroid {

--- a/app/manifest/base.xml
+++ b/app/manifest/base.xml
@@ -12,13 +12,14 @@
     <!-- common android permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!--
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+    -->
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
-        android:maxSdkVersion="29" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        tools:ignore="ScopedStorage" android:maxSdkVersion="29" />
+        tools:ignore="ScopedStorage"/>
 
     <application
         android:name=".MainApp"

--- a/app/src/org/koreader/launcher/utils/Permissions.kt
+++ b/app/src/org/koreader/launcher/utils/Permissions.kt
@@ -1,6 +1,7 @@
 package org.koreader.launcher.utils
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -14,11 +15,12 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import org.koreader.launcher.R
 
+@SuppressLint("NewApi")
 object Permissions {
     private const val STORAGE_WRITE_ID = 1001
 
     fun hasStoragePermission(activity: Activity): Boolean {
-        return if (Build.VERSION.SDK_INT >= 30) {
+        return if (newStoragePermissions(activity)) {
             Environment.isExternalStorageManager()
         } else {
             hasPermissionGranted(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)
@@ -26,20 +28,20 @@ object Permissions {
     }
 
     fun hasWriteSettingsPermission(context: Context): Boolean {
-        return if (Build.VERSION.SDK_INT >= 23) {
+        return if (newSettingsPermission())  {
             Settings.System.canWrite(context)
         } else true
     }
 
     fun isIgnoringBatteryOptimizations(context: Context): Boolean {
-        return if (Build.VERSION.SDK_INT >= 23) {
+        return if (newSettingsPermission()) {
             val pm = context.applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
             pm.isIgnoringBatteryOptimizations(context.packageName)
         } else false
     }
 
     fun requestStoragePermission(activity: Activity) {
-        if (Build.VERSION.SDK_INT >= 30) {
+        return if (newStoragePermissions(activity)) {
             val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
             val rationale = activity.resources.getString(R.string.warning_manage_storage)
             requestSpecialPermission(activity, intent, rationale, null, null)
@@ -50,23 +52,26 @@ object Permissions {
     }
 
     fun requestWriteSettingsPermission(activity: Activity, rationale: String, okButton: String, cancelButton: String) {
-        if (Build.VERSION.SDK_INT >= 23) {
+        if (newSettingsPermission()) {
             val intent = Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS)
             requestSpecialPermission(activity, intent, rationale, okButton, cancelButton)
         }
     }
 
     fun requestIgnoreBatteryOptimizations(activity: Activity, rationale: String, okButton: String, cancelButton: String) {
-        if (Build.VERSION.SDK_INT >= 23) {
+        if (newSettingsPermission()) {
             val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
             requestSpecialPermission(activity, intent, rationale, okButton, cancelButton)
         }
     }
+
+    @Suppress("SameParameterValue")
     private fun hasPermissionGranted(activity: Activity, perm: String): Boolean {
         val state = ContextCompat.checkSelfPermission(activity, perm)
         return (state == PackageManager.PERMISSION_GRANTED)
     }
 
+    @Suppress("SameParameterValue")
     private fun requestPermission(activity: Activity, perm: String, code: Int) {
         ActivityCompat.requestPermissions(activity, arrayOf(perm), code)
     }
@@ -87,5 +92,18 @@ object Permissions {
             }
             builder.create().show()
         }
+    }
+
+    private fun newStoragePermissions(activity: Activity): Boolean {
+        val targetSdk = activity.applicationContext.applicationInfo.targetSdkVersion
+        val runtimeSdk = Build.VERSION.SDK_INT
+        val minApi = Build.VERSION_CODES.R
+        return ((runtimeSdk >= minApi) and (targetSdk >= minApi))
+    }
+
+    private fun newSettingsPermission(): Boolean {
+        val runtimeSdk = Build.VERSION.SDK_INT
+        val minApi = Build.VERSION_CODES.M
+        return (runtimeSdk >= minApi)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,11 @@ buildscript {
     ext.androidx_appcompat_version = '1.2.0'
     ext.androidx_supportv4_version = '1.0.0'
     ext.leakcanary_version = '2.5'
+
     ext.minSdk = 14
-    ext.targetSdk = 30
+    ext.min64Sdk = 21
+    ext.targetSdk = 28
+    ext.compileSdk = 30
 
     repositories {
         google()


### PR DESCRIPTION
Keeping compileSdk in 30, to repurpose parts of the code, the new docker image and keep updated tools. 

Related to https://github.com/koreader/koreader/issues/6953
We can't bump targetSdk until `sdcv` is replaced by a library.

Refs:

https://developer.android.com/about/versions/10/behavior-changes-10#execute-permission

Somehow this is not enforced on some emulator versions and doesn't apply to custom LineageOS builds which set selinux to permissive. :facepalm: :man_facepalming: :woman_facepalming:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/271)
<!-- Reviewable:end -->
