### PR TITLE
Re-tune the mcode hack

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -4,12 +4,14 @@ Java Native Interface (JNI) wrapper.
 @module android
 ]]
 
--- Attempt to grab the full 512K of maxmcode in one go on startup,
+-- Attempt to grab the full maxmcode region in one go on startup,
 -- to avoid mcode_alloc failures later on at runtime...
 -- c.f., https://www.freelists.org/post/luajit/Android-performance-drop-moving-from-LuaJIT201-LuaJIT202
 -- The other workaround mentioned earlier in that thread would require moving to a shared LuaJIT build,
 -- and move the mmap hackery in jni/android-main.c before a dlopen of the luaJIT lib...
-jit.opt.start("sizemcode=512")
+-- Without it, the most reliable results we can get are with a *single* 64K mcode block:
+-- trying that with a single 512K block (as that's the default maxmcode) doesn't yield great results...
+jit.opt.start("sizemcode=64", "maxmcode=64")
 for _ = 1, 100 do end  -- Force allocation of one large segment
 
 local ffi = require("ffi")

--- a/jni/android-main.c
+++ b/jni/android-main.c
@@ -72,6 +72,9 @@ void android_main(struct android_app* state) {
 
     LOGD("%s: starting", TAG);
 
+    // Shitty hack so that base can discriminate Android...
+    setenv("IS_ANDROID", "true", 1);
+
     // wait until the activity is initialized before launching LuaJIT assets
     state->onAppCmd = handle_cmd;
     LOGV("%s: waiting for activity", TAG);


### PR DESCRIPTION
Because 512K really doesn't work :/.

Also include a stupid hack so that base can detect Android -_-".

----

As the commit log says, I may ultimately try the mmap trick the proper way, but since it requires a shared lib and I'm not at all familiar with all that would entail, not today.

For now, this should just make sure performance doesn't regress because of #278 ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/279)
<!-- Reviewable:end -->
