### PR TITLE
More JIT trickery...

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -37,6 +37,9 @@ end
 jit.opt.start("sizemcode=64", "maxmcode=64")
 for _ = 1, 20000 do end
 
+-- Disable the JIT for now, we'll enable it again when actually starting KOReader.
+jit.off(true, true)
+
 ffi.cdef[[
 // logging:
 int __android_log_print(int prio, const char *tag,  const char *fmt, ...);

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -11,6 +11,7 @@ Java Native Interface (JNI) wrapper.
 -- and move the mmap hackery in jni/android-main.c before a dlopen of the luaJIT lib...
 -- Without it, the most reliable results we can get are with a *single* 64K mcode block:
 -- trying that with a single 512K block (as that's the default maxmcode) doesn't yield great results...
+-- Upstream issue: https://github.com/LuaJIT/LuaJIT/issues/285
 
 local ffi = require("ffi")
 

--- a/assets/dl.lua
+++ b/assets/dl.lua
@@ -13,6 +13,9 @@ and as such:
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
 --]]
 
+-- Disable the JIT in this module, in an attempt to avoid weird issues when loading libraries
+jit.off(true, true)
+
 local ffi = require("ffi")
 local A = require("android")
 local Elf = require("elf")
@@ -83,7 +86,7 @@ function dl.dlopen(library, load_func)
                     -- load the luajit-launcher libluajit with sys_dlopen
                     load_func("libluajit.so")
                 elseif needed ~= "libdl.so" and pspec ~= "/system/lib" then
-                    -- For Android >= 6.0, you the list of safe system libraries is:
+                    -- For Android >= 6.0, the list of safe system libraries is:
                     -- libandroid, libc, libcamera2ndk, libdl, libGLES, libjnigraphics,
                     -- liblog, libm, libmediandk, libOpenMAXAL, libOpenSLES, libstdc++,
                     -- libvulkan, and libz

--- a/assets/dl.lua
+++ b/assets/dl.lua
@@ -83,8 +83,12 @@ function dl.dlopen(library, load_func)
             -- calls, so those will always use sys_dlopen()
             for _, needed in pairs(lib:dlneeds()) do
                 if needed == "libluajit.so" then
+                    --[[
                     -- load the luajit-launcher libluajit with sys_dlopen
                     load_func("libluajit.so")
+                    --]]
+                    -- Do *NOT* load libluajit if it's needed by something: we're already linked against a static copy!
+                    A.LOGVV(log, string.format("         dl.dlopen - skipping needed %s for %s", needed, lname))
                 elseif needed ~= "libdl.so" and pspec ~= "/system/lib" then
                     -- For Android >= 6.0, the list of safe system libraries is:
                     -- libandroid, libc, libcamera2ndk, libdl, libGLES, libjnigraphics,

--- a/assets/elf.lua
+++ b/assets/elf.lua
@@ -14,6 +14,9 @@ and as such:
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
 --]]
 
+-- Disable the JIT in this module
+jit.off(true, true)
+
 local ffi = require("ffi")
 
 ffi.cdef[[

--- a/assets/launcher.lua
+++ b/assets/launcher.lua
@@ -1,3 +1,6 @@
+-- Disable the JIT in this module
+jit.off(true, true)
+
 local ffi = require("ffi")
 local A = require("android")
 
@@ -39,6 +42,9 @@ else
 end
 
 local function launch()
+    -- Ignition!
+    jit.on(true, true)
+
     dofile(A.dir.."/llapp_main.lua")
 end
 


### PR DESCRIPTION
* Basically disable the JIT for every Lua bits in *this* repo (they're mostly wrapping JNI/system stuff, so the JIT is not terribly helpful here anyway).
* Also prevents dlopen'ing LuaJIT twice: we're already linked against a static copy. (I don't quite know *why* we build a shared libluajit in base (and ship it!), actually?).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/281)
<!-- Reviewable:end -->
