### PR TITLE
Load LuaJIT before the native entry point

### DIFF
--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -58,7 +58,9 @@ class MainActivity : NativeActivity(), JNILuaInterface,
         }
         override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
             Logger.v(tag, String.format(Locale.US,
-                "surface changed {\n  width:  %d\n  height: %d\n}", width, height))
+                "surface changed {\n  width:  %d\n  height: %d\n format: %s\n}",
+                width, height, ScreenUtils.pixelFormatName(format))
+            )
         }
         override fun surfaceDestroyed(holder: SurfaceHolder) {
             Logger.v(tag, "surface destroyed")
@@ -133,6 +135,10 @@ class MainActivity : NativeActivity(), JNILuaInterface,
     }
 
     override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
+        Logger.v(TAG_MAIN, String.format(Locale.US,
+            "surface changed {\n  width:  %d\n  height: %d\n format: %s\n}",
+            width, height, ScreenUtils.pixelFormatName(format))
+        )
         super.surfaceChanged(holder, format, width, height)
         drawSplashScreen(holder)
     }

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -65,13 +65,15 @@ class MainActivity : NativeActivity(), JNILuaInterface,
         }
     }
 
-
-
     companion object {
         private const val TAG_MAIN = "MainActivity"
         private const val ACTION_SAF_FILEPICKER = 2
         private val BATTERY_FILTER = IntentFilter(Intent.ACTION_BATTERY_CHANGED)
         private val RUNTIME_VERSION = Build.VERSION.RELEASE
+    }
+
+    init {
+        System.loadLibrary("luajit")
     }
 
     /*---------------------------------------------------------------

--- a/app/src/main/java/org/koreader/launcher/utils/ScreenUtils.kt
+++ b/app/src/main/java/org/koreader/launcher/utils/ScreenUtils.kt
@@ -1,12 +1,14 @@
 package org.koreader.launcher.utils
 
 import android.app.Activity
+import android.graphics.PixelFormat
 import android.graphics.Point
 import android.graphics.Rect
 import android.os.Build
 import android.util.DisplayMetrics
 import android.view.WindowManager
 import org.koreader.launcher.Logger
+import java.util.Locale
 import java.util.concurrent.CountDownLatch
 
 @Suppress("DEPRECATION")
@@ -61,6 +63,16 @@ object ScreenUtils {
             cd.await()
         } catch (ex: InterruptedException) {
             Logger.e(TAG, ex.toString())
+        }
+    }
+
+    fun pixelFormatName(format: Int): String {
+        return when(format) {
+            PixelFormat.RGBA_8888 -> "RGBA_8888"
+            PixelFormat.RGBX_8888 -> "RGBX_8888"
+            PixelFormat.RGB_888 -> "RGB_888"
+            PixelFormat.RGB_565 -> "RGB_565"
+            else -> String.format(Locale.US, "Unknown: %d", format)
         }
     }
 


### PR DESCRIPTION
Need confirmation in https://github.com/koreader/koreader/issues/7193#issuecomment-766717114

Also: log pixel format on each surface change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/292)
<!-- Reviewable:end -->
