### PR TITLE
Broadcast Receiver class

### DIFF
--- a/app/src/main/java/org/koreader/launcher/EventReceiver.kt
+++ b/app/src/main/java/org/koreader/launcher/EventReceiver.kt
@@ -1,0 +1,68 @@
+// A broadcast receiver that writes event codes to a named pipe,
+// so they can be consumed by a lua loop.
+
+package org.koreader.launcher
+
+import android.app.DownloadManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import java.io.File
+import java.io.FileWriter
+import kotlin.collections.HashMap
+
+class EventReceiver : BroadcastReceiver() {
+
+    private val tag = "Broadcast Receiver"
+    private val eventMap = HashMap<String, Int>()
+    private val fifoPath: String = File(MainApp.assets_path, "alooper.fifo").path
+
+    init {
+        eventMap[Intent.ACTION_POWER_CONNECTED] = 100
+        eventMap[Intent.ACTION_POWER_DISCONNECTED] = 101
+        eventMap[DownloadManager.ACTION_DOWNLOAD_COMPLETE] = 110
+    }
+
+    // write messages to a named pipe.
+    private fun post(code: Int?) {
+        code?.let {
+            try {
+                // 32-bit event code, low byte first
+                val msg  = CharArray(4)
+                msg[0] = (it and 0xFF).toChar()
+                msg[1] = ((it ushr 8) and 0xFF).toChar()
+                msg[2] = ((it ushr 16) and 0xFF).toChar()
+                msg[3] = ((it ushr 24) and 0xFF).toChar()
+                val writer = FileWriter(fifoPath, true)
+                writer.write(msg, 0, 4)
+                writer.close()
+            } catch (e: Exception) {
+                Logger.e(tag, "Cannot write to file $fifoPath: \n$e")
+            }
+        }
+
+    }
+
+    // event filter
+    fun filter(): IntentFilter {
+        val info = StringBuilder()
+        val filter = IntentFilter()
+        for ((key, _) in eventMap) {
+            info.append("$key\n")
+            filter.addAction(key)
+        }
+
+        Logger.v(tag, "Filtering ${eventMap.size} events: \n$info")
+        return filter
+    }
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        intent?.let { event ->
+            if (eventMap.containsKey(event.action)) {
+                Logger.v(tag, "Received event ${event.action}")
+                post(eventMap[event.action])
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/koreader/launcher/EventReceiver.kt
+++ b/app/src/main/java/org/koreader/launcher/EventReceiver.kt
@@ -6,10 +6,12 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.annotation.Keep
 import java.io.File
 import java.io.FileWriter
 import kotlin.collections.HashMap
 
+@Keep
 class EventReceiver : BroadcastReceiver() {
     private val tag = this::class.java.simpleName
     private val eventMap = HashMap<String, Int>()

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -29,6 +29,7 @@ class MainActivity : NativeActivity(), JNILuaInterface,
     private lateinit var assets: Assets
     private lateinit var clipboard: Clipboard
     private lateinit var device: Device
+    private lateinit var event: EventReceiver
     private lateinit var timeout: Timeout
 
     // Path of last file imported
@@ -91,6 +92,8 @@ class MainActivity : NativeActivity(), JNILuaInterface,
         clipboard = Clipboard(this)
         device = Device(this)
         timeout = Timeout()
+        event = EventReceiver()
+
         super.onCreate(savedInstanceState)
         setTheme(R.style.Fullscreen)
 
@@ -109,6 +112,7 @@ class MainActivity : NativeActivity(), JNILuaInterface,
         }
         Logger.v(TAG_MAIN, "surface: $surfaceKind")
 
+        registerReceiver(event, event.filter())
         if (!Permissions.hasStoragePermission(this)) {
             Permissions.requestStoragePermission(this)
         }
@@ -207,6 +211,7 @@ class MainActivity : NativeActivity(), JNILuaInterface,
     /* Called when the activity is going to be destroyed */
     public override fun onDestroy() {
         Logger.v(TAG_MAIN, "onDestroy()")
+        unregisterReceiver(event)
         super.onDestroy()
     }
 

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -112,7 +112,7 @@ class MainActivity : NativeActivity(), JNILuaInterface,
         }
         Logger.v(TAG_MAIN, "surface: $surfaceKind")
 
-        registerReceiver(event, event.filter())
+        registerReceiver(event, event.filter)
         if (!Permissions.hasStoragePermission(this)) {
             Permissions.requestStoragePermission(this)
         }

--- a/app/src/main/java/org/koreader/launcher/MainApp.kt
+++ b/app/src/main/java/org/koreader/launcher/MainApp.kt
@@ -6,7 +6,6 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Environment
 import android.os.StrictMode
-import java.io.File
 
 class MainApp : android.app.Application() {
     companion object {
@@ -14,7 +13,7 @@ class MainApp : android.app.Application() {
 
         lateinit var info: String
             private set
-        lateinit var fifo_path: String
+        lateinit var assets_path: String
             private set
         lateinit var storage_path: String
             private set
@@ -27,7 +26,7 @@ class MainApp : android.app.Application() {
         super.onCreate()
         val pm = packageManager
         val am = this.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        val assetsDir = filesDir.absolutePath
+        assets_path = filesDir.absolutePath
         val isSystemApp = (pm.getPackageInfo(packageName, 0).applicationInfo.flags
             and ApplicationInfo.FLAG_SYSTEM == 1)
 
@@ -45,9 +44,6 @@ class MainApp : android.app.Application() {
         @Suppress("DEPRECATION")
         storage_path = Environment.getExternalStorageDirectory().absolutePath
 
-        // Path to the fifo for sending messages to ALooper (native glue and Lua)
-        fifo_path = File(filesDir, "alooper.fifo").path
-
         platform_type = if (pm.hasSystemFeature("org.chromium.arc.device_management")) {
             "chrome"
         } else if ((runtime >= 21) && pm.hasSystemFeature(PackageManager.FEATURE_LEANBACK)) {
@@ -58,7 +54,7 @@ class MainApp : android.app.Application() {
 
         info = StringBuilder(400)
             .append("{\n  VM heap: ${am.memoryClass}MB\n  Flags: $flags\n  ")
-            .append("Paths: {\n\tAssets: $assetsDir\n\tStorage: $storage_path\n  }\n}")
+            .append("Paths: {\n\tAssets: $assets_path\n\tStorage: $storage_path\n  }\n}")
             .toString()
     }
 }


### PR DESCRIPTION
Sorry @zwim, as most intents here were covered by your original PR (ie: separate file for the broadcast receiver class). I just found it confusing on previous iterations but now it makes all the sense in the world (to me :p).

A few changes:

- Be very verbose with the event filter and when a new event is registered/dispatched.

On app launch something like this will be logged:

```
V  [EventReceiver] Filtering 2 events:
V  android.intent.action.ACTION_POWER_CONNECTED
V  android.intent.action.ACTION_POWER_DISCONNECTED
```

- Use a hashmap between android broadcast events/intents and our event codes

That makes easier to watch new events, just asign the map between the intent and the event code in `init` and the new event will be automatically added to the filter and its asigned code pushed to the named pipe on event arrival.

~~- WIP: use the mechanism to manage APK downloads, so we can repurpose the ("app is ready to be updated, do you want to do it now?" used on other platforms).~~. Will be in a separate PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/298)
<!-- Reviewable:end -->
