### PR TITLE
Make the CMD & USER pipes NONBLOCK

### DIFF
--- a/jni/android_native_app_glue/android_native_app_glue.c
+++ b/jni/android_native_app_glue/android_native_app_glue.c
@@ -55,7 +55,12 @@ static void free_saved_state(struct android_app* android_app) {
 int8_t android_app_read_cmd(struct android_app* android_app) {
     int8_t cmd;
     if (read(android_app->msgread, &cmd, sizeof(cmd)) != sizeof(cmd)) {
-        LOGD("%s: No more data on command pipe!", TAG);
+        // NOTE: We drain the pipe in one batch in ffi/input_android.lua,
+        //       meaning we *expect* the -1 return to detect EAGAIN,
+        //       so this is just noise.
+        if (errno != EAGAIN) {
+            LOGE("%s: Failed to read command pipe: %s", TAG, strerror(errno));
+        }
         return -1;
     }
     if (cmd == APP_CMD_SAVE_STATE) {
@@ -246,17 +251,17 @@ static void* android_app_entry(void* param) {
 
     if (mkfifo(fifo_file, 0666) == -1) {
         if (errno == EEXIST) {
-            LOGV("%s: file %s already exists", TAG, fifo_file);
+            LOGV("%s: User FIFO already exists at `%s`", TAG, fifo_file);
         } else {
-            LOGE("%s: file %s cannot be created!", TAG, fifo_file);
+            LOGE("%s: Failed to create user FIFO at `%s`: %s", TAG, fifo_file, strerror(errno));
         }
     } else {
-        LOGV("%s: file %s created", TAG, fifo_file);
+        LOGV("%s: User FIFO created at `%s`", TAG, fifo_file);
     }
 
     int fifo_fd = open(fifo_file, O_RDWR | O_NONBLOCK | O_CLOEXEC);
     if (fifo_fd  == -1) {
-        LOGE("%s: file %s open error, errno=%d", TAG, fifo_file, errno);
+        LOGE("%s: Failed to open user FIFO at `%s`: %s", TAG, fifo_file, strerror(errno));
     } else {
         ALooper_addFd(looper, fifo_fd, LOOPER_ID_USER, ALOOPER_EVENT_INPUT, NULL, &android_app->cmdPollSource);
     }
@@ -293,7 +298,7 @@ static struct android_app* android_app_create(ANativeActivity* activity,
 
     int msgpipe[2];
     if (pipe(msgpipe)) {
-        LOGE("%s: could not create pipe: %s", TAG, strerror(errno));
+        LOGE("%s: Failed to create command pipe: %s", TAG, strerror(errno));
         return NULL;
     }
     // Because pipe2 has only been available as a bionic wrapper hilariously recently...
@@ -325,7 +330,7 @@ static struct android_app* android_app_create(ANativeActivity* activity,
 
 static void android_app_write_cmd(struct android_app* android_app, int8_t cmd) {
     if (write(android_app->msgwrite, &cmd, sizeof(cmd)) != sizeof(cmd)) {
-        LOGE("%s: Failure writing android_app cmd: %s", TAG, strerror(errno));
+        LOGE("%s: Failed to write to command pipe: %s", TAG, strerror(errno));
     }
 }
 

--- a/jni/android_native_app_glue/android_native_app_glue.c
+++ b/jni/android_native_app_glue/android_native_app_glue.c
@@ -55,7 +55,7 @@ static void free_saved_state(struct android_app* android_app) {
 int8_t android_app_read_cmd(struct android_app* android_app) {
     int8_t cmd;
     if (read(android_app->msgread, &cmd, sizeof(cmd)) != sizeof(cmd)) {
-        LOGE("%s: No data on command pipe!", TAG);
+        LOGD("%s: No data on command pipe!", TAG);
         return -1;
     }
     if (cmd == APP_CMD_SAVE_STATE) free_saved_state(android_app);


### PR DESCRIPTION
This will allow sanely draining them in a single waitForEvent iteration.

Testing the user pipe is a bit tricky, but after switching to wireless adb, I did manage to confirm that it behaved sensibly.
Same for the command pipe (a resume after a task switch was a great testcase for multiple commands in the queue).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/299)
<!-- Reviewable:end -->
