### PR TITLE
Tweak post_cmd_exec debug log messages

### DIFF
--- a/jni/android_native_app_glue/android_native_app_glue.c
+++ b/jni/android_native_app_glue/android_native_app_glue.c
@@ -154,7 +154,7 @@ void android_app_pre_exec_cmd(struct android_app* android_app, int8_t cmd) {
 void android_app_post_exec_cmd(struct android_app* android_app, int8_t cmd) {
     switch (cmd) {
         case APP_CMD_TERM_WINDOW:
-            LOGD("%s: APP_CMD_TERM_WINDOW", TAG);
+            LOGD("%s: Post APP_CMD_TERM_WINDOW", TAG);
             pthread_mutex_lock(&android_app->mutex);
             android_app->window = NULL;
             pthread_cond_broadcast(&android_app->cond);
@@ -162,7 +162,7 @@ void android_app_post_exec_cmd(struct android_app* android_app, int8_t cmd) {
             break;
 
         case APP_CMD_SAVE_STATE:
-            LOGD("%s: APP_CMD_SAVE_STATE", TAG);
+            LOGD("%s: Post APP_CMD_SAVE_STATE", TAG);
             pthread_mutex_lock(&android_app->mutex);
             android_app->stateSaved = 1;
             pthread_cond_broadcast(&android_app->cond);
@@ -170,6 +170,7 @@ void android_app_post_exec_cmd(struct android_app* android_app, int8_t cmd) {
             break;
 
         case APP_CMD_RESUME:
+            LOGD("%s: Post APP_CMD_RESUME", TAG);
             free_saved_state(android_app);
             break;
     }


### PR DESCRIPTION
To differentiate them from the pre_exec_cmd ones.
Otherwise, you can get two "APP_CMD_TERM_WINDOW" messages back to back,
which is mildly confusing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/300)
<!-- Reviewable:end -->
