### PR TITLE
Add backlight support for Onyx C67

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -78,7 +78,8 @@ object DeviceInfo {
     enum class LightsDevice {
         NONE,
         TOLINO_EPOS,
-        ONYX_NOVA2
+        ONYX_NOVA2,
+        ONYX_C67
     }
 
     enum class BugDevice {
@@ -163,6 +164,7 @@ object DeviceInfo {
         ONYX_C67 = (MANUFACTURER.contentEquals("onyx")
                 && (PRODUCT.startsWith("c67") || MODEL.contentEquals("rk30sdk"))
                 && DEVICE.startsWith("c67"))
+        lightsMap[LightsDevice.ONYX_C67] = ONYX_C67
         deviceMap[EinkDevice.ONYX_C67] = ONYX_C67
 
         // Energy Sistem eReaders. Tested on Energy Ereader Pro 4

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -3,6 +3,7 @@ package org.koreader.launcher.device
 import org.koreader.launcher.Logger
 import org.koreader.launcher.device.lights.GenericController
 import org.koreader.launcher.device.lights.OnyxWarmthController
+import org.koreader.launcher.device.lights.OnyxC67Controller
 import org.koreader.launcher.device.lights.TolinoWarmthController
 import org.koreader.launcher.interfaces.LightInterface
 import java.util.*
@@ -18,6 +19,10 @@ object LightsFactory {
                 DeviceInfo.LightsDevice.ONYX_NOVA2 -> {
                     logController("ONYX_NOVA2")
                     OnyxWarmthController()
+                }
+                DeviceInfo.LightsDevice.ONYX_C67 -> {
+                    logController("ONYX_C67")
+                    OnyxC67Controller()
                 }
                 else -> {
                     logController("Generic")

--- a/app/src/main/java/org/koreader/launcher/device/lights/OnyxC67Controller.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/OnyxC67Controller.kt
@@ -1,0 +1,82 @@
+package org.koreader.launcher.device.lights
+
+import android.app.Activity
+import android.util.Log
+import org.koreader.launcher.Logger
+import org.koreader.launcher.interfaces.LightInterface
+import java.io.File
+
+class OnyxC67Controller : LightInterface {
+    companion object {
+        private const val TAG = "lights"
+        private const val BRIGHTNESS_MAX = 255
+        private const val BRIGHTNESS_MIN = 0
+        private const val BRIGHTNESS_FILE = "/sys/class/backlight/rk28_bl/brightness"
+    }
+
+    override fun hasFallback(): Boolean {
+        return true
+    }
+
+    override fun hasWarmth(): Boolean {
+        return false
+    }
+
+    override fun needsPermission(): Boolean {
+        return false
+    }
+
+    override fun enableFrontlightSwitch(activity: Activity): Int {
+        return 1
+    }
+
+    override fun getBrightness(activity: Activity): Int {
+        val brightnessFile = File(BRIGHTNESS_FILE)
+        return try {
+            // .replace("\n", "") is needed, since it's automatically appended
+            // without it exception is thrown
+            // java.lang.NumberFormatException: For input string: "125\n"
+            return brightnessFile.readText().replace("\n", "").toInt()
+        } catch (e: Exception) {
+            Logger.w(TAG, Log.getStackTraceString(e))
+            0
+        }
+    }
+
+    override fun getWarmth(activity: Activity): Int {
+        Logger.w(TAG, "getWarmth: not implemented")
+        return 0
+    }
+
+
+    override fun setBrightness(activity: Activity, brightness: Int) {
+        if (brightness < BRIGHTNESS_MIN || brightness > BRIGHTNESS_MAX) {
+            Logger.w(TAG, "brightness value of of range: $brightness")
+            return
+        }
+        Logger.v(TAG, "Setting brightness to $brightness")
+        val brightnessFile = File(BRIGHTNESS_FILE)
+        try {
+            brightnessFile.writeText(brightness.toString())
+        } catch (e: Exception) {
+            Logger.w(TAG, "$e")
+        }
+    }
+
+    override fun setWarmth(activity: Activity, warmth: Int) {
+        Logger.w(TAG, "ignoring setWarmth: not implemented")
+    }
+
+    override fun getMinWarmth(): Int {
+        return 0
+    }
+    override fun getMaxWarmth(): Int {
+        return 0
+    }
+    override fun getMinBrightness(): Int {
+        return BRIGHTNESS_MIN
+    }
+    override fun getMaxBrightness(): Int {
+        return BRIGHTNESS_MAX
+    }
+}


### PR DESCRIPTION
Onyx Boox C67ML doesn't use the Android API for brightness control.
I created a LightsController using sysfs, similar to the Onyx Nova 2's Controller.
Fixes: https://github.com/koreader/koreader/issues/5944, https://github.com/koreader/koreader/issues/2105, https://github.com/koreader/koreader/issues/1651

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/301)
<!-- Reviewable:end -->
