### PR TITLE
[wip]: refactor + proguard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,37 +3,21 @@ apply plugin: 'kotlin-android'
 
 android {
     ndkPath ndkCustomPath
-    compileSdkVersion 30
+    compileSdkVersion rootProject.ext.compileSdk
+
     defaultConfig {
         applicationId "org.koreader.launcher"
-
-        // Required when setting minSdkVersion to 20 or lower
-        multiDexEnabled true
-
-        minSdkVersion 14
-
-        //noinspection ExpiredTargetSdkVersion
-        targetSdkVersion 28
-
         versionCode versCode as Integer
         versionName versName
+        minSdkVersion rootProject.ext.minSdk
+        targetSdkVersion rootProject.ext.targetSdk
+
+        multiDexEnabled true
         manifestPlaceholders.APP_NAME = projectName
-        buildConfigField 'String', 'APP_NAME', '"' + projectName + '"'
+
+        buildConfigField "String", "APP_NAME", '"' + projectName + '"'
         buildConfigField "boolean", "IN_APP_UPDATES", "false"
         buildConfigField "boolean", "SUPPORTS_RUNTIME_CHANGES", "false"
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled true
-            shrinkResources true
-        }
-
-        debug {
-            applicationIdSuffix ".debug"
-            minifyEnabled false
-            debuggable true
-        }
     }
 
     sourceSets {
@@ -42,13 +26,24 @@ android {
         }
     }
 
-    compileOptions {
-        // Flag to enable support for the new language APIs
-        coreLibraryDesugaringEnabled true
+    externalNativeBuild {
+        ndkBuild {
+            path file('../jni/Android.mk')
+        }
+    }
 
-        // Sets Java compatibility to Java 8
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+    buildTypes {
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+
+        debug {
+            applicationIdSuffix ".debug"
+            minifyEnabled false
+            debuggable true
+        }
     }
 
     flavorDimensions 'ABI', 'CHANNEL'
@@ -60,7 +55,7 @@ android {
         x86_64 {
             ndk { abiFilters "x86_64" }
             dimension = 'ABI'
-            minSdkVersion 21
+            minSdkVersion rootProject.ext.minSdk64
         }
         arm {
             ndk { abiFilters "armeabi-v7a" }
@@ -69,7 +64,7 @@ android {
         arm64 {
             ndk { abiFilters "arm64-v8a" }
             dimension = 'ABI'
-            minSdkVersion 21
+            minSdkVersion rootProject.ext.minSdk64
         }
 
         fdroid {
@@ -82,10 +77,13 @@ android {
         }
     }
 
-    externalNativeBuild {
-        ndkBuild {
-            path file('../jni/Android.mk')
-        }
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+        kotlinOptions.freeCompilerArgs += ['-module-name', projectName.toLowerCase()]
+    }
+
+    packagingOptions {
+        exclude 'META-INF/*.version'
     }
 
     applicationVariants.all { variant ->
@@ -106,8 +104,6 @@ dependencies {
     implementation "androidx.core:core-ktx:$androidx_core_version"
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
     implementation "androidx.legacy:legacy-support-v4:$androidx_supportv4_version"
-
-    //noinspection GradleDependency
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_plugin_version"
     implementation "org.apache.commons:commons-compress:$commons_compress_version"
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,9 @@
+# proguard is used to shrink and optimize dependencies.
+-keep class org.koreader.launcher.** { *; }
+
+# keep kotlin.Metadata annotations
+-keepattributes RuntimeVisibleAnnotations
+-keep class kotlin.Metadata { *; }
+
+# preserve the line number information for debugging stack traces.
+-keepattributes SourceFile,LineNumberTable

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,6 @@
         android:icon="@mipmap/icon"
         android:banner="@mipmap/banner"
         android:label="${APP_NAME}"
-        android:vmSafeMode="true"
         android:allowBackup="false"
         android:fullBackupContent="false"
         android:usesCleartextTraffic="true"
@@ -39,7 +38,8 @@
             android:resizeableActivity="false"
             android:screenOrientation="nosensor"
             android:launchMode="singleInstance"
-            android:configChanges="colorMode|density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode" >
+            android:configChanges="colorMode|density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
+            tools:ignore="NonResizeableActivity">
             <meta-data android:name="android.app.lib_name" android:value="luajit-launcher" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/org/koreader/launcher/Assets.kt
+++ b/app/src/main/java/org/koreader/launcher/Assets.kt
@@ -8,11 +8,9 @@ import android.util.Log
 import android.view.Gravity
 import android.view.ViewGroup
 import android.widget.ProgressBar
-import androidx.annotation.Keep
 import androidx.core.content.ContextCompat
 import java.io.*
 
-@Keep
 class Assets {
 
     private val tag = this::class.java.simpleName

--- a/app/src/main/java/org/koreader/launcher/EventReceiver.kt
+++ b/app/src/main/java/org/koreader/launcher/EventReceiver.kt
@@ -8,12 +8,10 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.util.Log
-import androidx.annotation.Keep
 import java.io.File
 import java.io.FileWriter
 import kotlin.collections.HashMap
 
-@Keep
 class EventReceiver : BroadcastReceiver() {
     private val tag = this::class.java.simpleName
     private val eventMap = HashMap<String, Int>()

--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -1,9 +1,9 @@
-package org.koreader.launcher.interfaces
+package org.koreader.launcher
 
 /* Declares methods that are exposed to lua via JNI
  * See https://github.com/koreader/android-luajit-launcher/blob/master/assets/android.lua */
 
-interface JNILuaInterface {
+interface LuaInterface {
     fun canIgnoreBatteryOptimizations(): Boolean
     fun canWriteSystemSettings(): Boolean
     fun dictLookup(text: String?, action: String?, nullablePackage: String?)

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -14,18 +14,16 @@ import android.provider.Settings
 import android.util.Log
 import android.view.*
 import android.widget.Toast
-import androidx.annotation.Keep
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import org.koreader.launcher.interfaces.JNILuaInterface
+import org.koreader.launcher.device.Device
 import org.koreader.launcher.utils.*
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
 import java.util.*
 
-@Keep
-class MainActivity : NativeActivity(), JNILuaInterface,
+class MainActivity : NativeActivity(), LuaInterface,
     ActivityCompat.OnRequestPermissionsResultCallback{
 
     private val tag = this::class.java.simpleName
@@ -88,9 +86,6 @@ class MainActivity : NativeActivity(), JNILuaInterface,
 
     /* Called when the activity is first created. */
     override fun onCreate(savedInstanceState: Bundle?) {
-        Log.v(tag, String.format(Locale.US,
-            "Launching %s %s", MainApp.name, MainApp.info))
-
         assets = Assets()
         device = Device(this)
         timeout = Timeout()

--- a/app/src/main/java/org/koreader/launcher/MainApp.kt
+++ b/app/src/main/java/org/koreader/launcher/MainApp.kt
@@ -1,72 +1,28 @@
 package org.koreader.launcher
 
-import android.app.ActivityManager
-import android.content.Context
-import android.content.pm.ApplicationInfo
-import android.content.pm.PackageManager
-import android.os.Environment
 import android.os.StrictMode
+import androidx.multidex.MultiDexApplication
 
-@Suppress("DEPRECATION")
-class MainApp : android.app.Application() {
+class MainApp : MultiDexApplication() {
     companion object {
-
-        // defined at build time
         const val name = BuildConfig.APP_NAME
         const val flavor = BuildConfig.FLAVOR_CHANNEL
         const val has_ota_updates = BuildConfig.IN_APP_UPDATES
         const val supports_runtime_changes = BuildConfig.SUPPORTS_RUNTIME_CHANGES
         const val provider = "${BuildConfig.APPLICATION_ID}.provider"
         val is_debug = BuildConfig.DEBUG
-
-        // runtime dependant
-        private val runtime = android.os.Build.VERSION.SDK_INT
-
-        lateinit var info: String
-            private set
         lateinit var assets_path: String
             private set
-        lateinit var storage_path: String
-            private set
-        lateinit var platform_type: String
-            private set
-
     }
 
     override fun onCreate() {
         super.onCreate()
-        val pm = packageManager
-        val am = this.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-
-        val isSystemApp = (pm.getPackageInfo(packageName, 0).applicationInfo.flags
-            and ApplicationInfo.FLAG_SYSTEM == 1)
-
-        val build = if(is_debug) "debug" else "release"
-        val install = if(isSystemApp) "system" else "user"
-
         if (is_debug) {
             val threadPolicy = StrictMode.ThreadPolicy.Builder().detectAll().penaltyLog().build()
             val vmPolicy = StrictMode.VmPolicy.Builder().detectAll().penaltyLog().build()
             StrictMode.setThreadPolicy(threadPolicy)
             StrictMode.setVmPolicy(vmPolicy)
         }
-
         assets_path = filesDir.absolutePath
-        storage_path = Environment.getExternalStorageDirectory().absolutePath
-        platform_type = if (pm.hasSystemFeature("org.chromium.arc.device_management")) {
-            "chrome"
-        } else if ((runtime >= 21) && pm.hasSystemFeature(PackageManager.FEATURE_LEANBACK)) {
-            "android_tv"
-        } else {
-            "android"
-        }
-
-        info = StringBuilder(400)
-            .append("{\n")
-            .append("  Platform: $platform_type\n  Installed by $install\n")
-            .append("  VM heap: ${am.memoryClass}MB\n  Build: $build\n  Flavor: $flavor\n")
-            .append("  Paths: {\n\tAssets: $assets_path\n\tStorage: $storage_path\n  }\n")
-            .append("}\n")
-            .toString()
     }
 }

--- a/app/src/main/java/org/koreader/launcher/device/Device.kt
+++ b/app/src/main/java/org/koreader/launcher/device/Device.kt
@@ -1,8 +1,10 @@
-package org.koreader.launcher
+package org.koreader.launcher.device
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Environment
 import android.util.Log
 import android.view.Gravity
 import android.view.Surface
@@ -10,13 +12,8 @@ import android.view.View
 import android.widget.LinearLayout
 import android.widget.SeekBar
 import android.widget.TextView
-import androidx.annotation.Keep
-import org.koreader.launcher.device.DeviceInfo
-import org.koreader.launcher.device.EPDFactory
-import org.koreader.launcher.device.LightsFactory
 import java.util.*
 
-@Keep
 class Device(activity: Activity) {
     private val tag = this::class.java.simpleName
 
@@ -25,8 +22,15 @@ class Device(activity: Activity) {
     val hasFullEinkSupport = DeviceInfo.EINK_FULL_SUPPORT
     val needsWakelocks = DeviceInfo.BUG_WAKELOCKS
     val bugRotation = DeviceInfo.BUG_SCREEN_ROTATION
-    val externalStorage = MainApp.storage_path
-    val platform = MainApp.platform_type
+
+    val platform: String = if (activity.packageManager.hasSystemFeature("org.chromium.arc.device_management")) {
+        "chrome"
+    } else if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+        && activity.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)) {
+        "android_tv"
+    } else {
+        "android"
+    }
 
     val einkPlatform: String = if (DeviceInfo.EINK_FREESCALE) {
         if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN)
@@ -42,15 +46,17 @@ class Device(activity: Activity) {
     } else {
         "none"
     }
-    val isTv = (platform == "android_tv")
-    val isChromeOS = (platform == "chrome")
 
+    val isTv: Boolean = (platform == "android_tv")
+    val isChromeOS: Boolean = (platform == "chrome")
     val needsView: Boolean = if (DeviceInfo.NEEDS_VIEW) {
         true
     } else {
         (isTv || isChromeOS)
     }
 
+    @Suppress("DEPRECATION")
+    val externalStorage: String = Environment.getExternalStorageDirectory().absolutePath
     var isResumed = false
 
     // EPD driver for this device

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -300,6 +300,6 @@ object DeviceInfo {
     }
 
     private fun lowerCase(text: String): String {
-        return text.toLowerCase(Locale.US)
+        return text.lowercase(Locale.US)
     }
 }

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -8,7 +8,6 @@ import org.koreader.launcher.device.epd.freescale.NTXNewEPDController
 import org.koreader.launcher.device.epd.rockchip.RK3026EPDController
 import org.koreader.launcher.device.epd.rockchip.RK3368EPDController
 import org.koreader.launcher.device.epd.qualcomm.QualcommOnyxEPDController
-import org.koreader.launcher.interfaces.EPDInterface
 import java.util.*
 
 object EPDFactory {

--- a/app/src/main/java/org/koreader/launcher/device/EPDInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDInterface.kt
@@ -1,7 +1,7 @@
 /* generic EPD Controller for Android devices,
  * based on https://github.com/unwmun/refreshU */
 
-package org.koreader.launcher.interfaces
+package org.koreader.launcher.device
 
 interface EPDInterface {
     fun resume()

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -5,12 +5,11 @@ import org.koreader.launcher.device.lights.GenericController
 import org.koreader.launcher.device.lights.OnyxWarmthController
 import org.koreader.launcher.device.lights.OnyxC67Controller
 import org.koreader.launcher.device.lights.TolinoWarmthController
-import org.koreader.launcher.interfaces.LightInterface
 import java.util.*
 
 object LightsFactory {
     private const val TAG = "Lights"
-    val lightsController: LightInterface
+    val lightsController: LightsInterface
         get() {
             return when (DeviceInfo.LIGHTS) {
                 DeviceInfo.LightsDevice.TOLINO_EPOS -> {

--- a/app/src/main/java/org/koreader/launcher/device/LightsInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsInterface.kt
@@ -1,8 +1,8 @@
-package org.koreader.launcher.interfaces
+package org.koreader.launcher.device
 
 import android.app.Activity
 
-interface LightInterface {
+interface LightsInterface {
     fun hasFallback(): Boolean
     fun hasWarmth(): Boolean
     fun needsPermission(): Boolean

--- a/app/src/main/java/org/koreader/launcher/device/epd/freescale/NTXEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/freescale/NTXEPDController.kt
@@ -33,7 +33,7 @@ import java.util.*
 
 abstract class NTXEPDController {
     companion object {
-        private const val TAG = "epd"
+        private const val TAG = "EPD"
 
         fun requestEpdMode(view: android.view.View,
                            mode: Int, delay: Long,

--- a/app/src/main/java/org/koreader/launcher/device/epd/freescale/NTXNewEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/freescale/NTXNewEPDController.kt
@@ -2,7 +2,7 @@
 
 package org.koreader.launcher.device.epd.freescale
 
-import org.koreader.launcher.interfaces.EPDInterface
+import org.koreader.launcher.device.EPDInterface
 
 class NTXNewEPDController : NTXEPDController(), EPDInterface {
     override fun resume() {}

--- a/app/src/main/java/org/koreader/launcher/device/epd/qualcomm/QualcommEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/qualcomm/QualcommEPDController.kt
@@ -2,14 +2,13 @@ package org.koreader.launcher.device.epd.qualcomm
 
 import android.util.Log
 import android.view.View
-import org.koreader.launcher.interfaces.EPDInterface
 import java.util.*
 
 // More information including epd mode values
 // https://github.com/koreader/android-luajit-launcher/pull/250#issuecomment-711443457
-abstract class QualcommEPDController : EPDInterface {
+abstract class QualcommEPDController {
     companion object  {
-        private const val TAG = "epd"
+        private const val TAG = "EPD"
 
         private fun preventSystemRefresh() : Boolean{
             // Sets UpdateMode and UpdateScheme to None

--- a/app/src/main/java/org/koreader/launcher/device/epd/qualcomm/QualcommOnyxEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/qualcomm/QualcommOnyxEPDController.kt
@@ -2,7 +2,7 @@
 
 package org.koreader.launcher.device.epd.qualcomm
 
-import org.koreader.launcher.interfaces.EPDInterface
+import org.koreader.launcher.device.EPDInterface
 
 class QualcommOnyxEPDController : QualcommEPDController(), EPDInterface {
     override fun resume() {}

--- a/app/src/main/java/org/koreader/launcher/device/epd/rockchip/RK3026EPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/rockchip/RK3026EPDController.kt
@@ -3,7 +3,7 @@
 
 package org.koreader.launcher.device.epd.rockchip
 
-import org.koreader.launcher.interfaces.EPDInterface
+import org.koreader.launcher.device.EPDInterface
 
 class RK3026EPDController : RK30xxEPDController(), EPDInterface {
     override fun resume() {}

--- a/app/src/main/java/org/koreader/launcher/device/epd/rockchip/RK30xxEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/rockchip/RK30xxEPDController.kt
@@ -32,7 +32,7 @@ import java.lang.reflect.Method
 
 abstract class RK30xxEPDController {
     companion object {
-        private const val TAG = "epd"
+        private const val TAG = "EPD"
         private var eInkEnum: Class<Enum<*>>? = null
         private var updateEpdMethod: Method? = null
 

--- a/app/src/main/java/org/koreader/launcher/device/epd/rockchip/RK3368EPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/rockchip/RK3368EPDController.kt
@@ -3,7 +3,7 @@
 
 package org.koreader.launcher.device.epd.rockchip
 
-import org.koreader.launcher.interfaces.EPDInterface
+import org.koreader.launcher.device.EPDInterface
 
 class RK3368EPDController : RK33xxEPDController(), EPDInterface {
     override fun resume() {}

--- a/app/src/main/java/org/koreader/launcher/device/epd/rockchip/RK33xxEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/rockchip/RK33xxEPDController.kt
@@ -25,7 +25,7 @@ import java.util.*
 
 abstract class RK33xxEPDController {
     companion object {
-        private const val TAG = "epd"
+        private const val TAG = "EPD"
         private const val EPD_FULL = 1
 
         fun requestEpdMode(epdMode: String): Boolean {

--- a/app/src/main/java/org/koreader/launcher/device/lights/GenericController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/GenericController.kt
@@ -3,11 +3,11 @@ package org.koreader.launcher.device.lights
 import android.app.Activity
 import android.provider.Settings
 import android.util.Log
-import org.koreader.launcher.interfaces.LightInterface
+import org.koreader.launcher.device.LightsInterface
 
 /* handle frontlight within the activity, without affecting other activities */
 
-class GenericController : LightInterface {
+class GenericController : LightsInterface {
     companion object {
         private const val TAG = "Lights"
         private const val BRIGHTNESS_MAX = 255

--- a/app/src/main/java/org/koreader/launcher/device/lights/OnyxC67Controller.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/OnyxC67Controller.kt
@@ -2,10 +2,10 @@ package org.koreader.launcher.device.lights
 
 import android.app.Activity
 import android.util.Log
-import org.koreader.launcher.interfaces.LightInterface
+import org.koreader.launcher.device.LightsInterface
 import java.io.File
 
-class OnyxC67Controller : LightInterface {
+class OnyxC67Controller : LightsInterface {
     companion object {
         private const val TAG = "Lights"
         private const val BRIGHTNESS_MAX = 255

--- a/app/src/main/java/org/koreader/launcher/device/lights/OnyxWarmthController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/OnyxWarmthController.kt
@@ -2,10 +2,10 @@ package org.koreader.launcher.device.lights
 
 import android.app.Activity
 import android.util.Log
-import org.koreader.launcher.interfaces.LightInterface
+import org.koreader.launcher.device.LightsInterface
 import java.io.File
 
-class OnyxWarmthController : LightInterface {
+class OnyxWarmthController : LightsInterface {
     companion object {
         private const val TAG = "Lights"
         private const val BRIGHTNESS_MAX = 255

--- a/app/src/main/java/org/koreader/launcher/device/lights/TolinoWarmthController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/TolinoWarmthController.kt
@@ -3,7 +3,7 @@ package org.koreader.launcher.device.lights
 import android.app.Activity
 import android.provider.Settings
 import android.util.Log
-import org.koreader.launcher.interfaces.LightInterface
+import org.koreader.launcher.device.LightsInterface
 import java.io.File
 
 /* Special controller for Tolino Epos/Epos2.
@@ -12,7 +12,7 @@ import java.io.File
  * Thanks to @zwim
  */
 
-class TolinoWarmthController : LightInterface {
+class TolinoWarmthController : LightsInterface {
     companion object {
         private const val TAG = "Lights"
         private const val BRIGHTNESS_MAX = 255

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1414,14 +1414,9 @@ local android = {
     glue = android_glue_ok and android_glue or C,
 }
 
-function android.LOG(level, message)
-    android.log.__android_log_print(level, android.log_name, "%s", message)
+function android.LOG(level, message, tag)
+    android.log.__android_log_print(level, tag and tag or android.log_name, "%s", message)
 end
-
-function android.LOGVV(tag, message)
-    android.log.__android_log_print(C.ANDROID_LOG_VERBOSE, tag, "%s", message)
-end
-
 function android.LOGV(message)
     android.LOG(C.ANDROID_LOG_VERBOSE, message)
 end

--- a/assets/launcher.lua
+++ b/assets/launcher.lua
@@ -5,39 +5,14 @@ local C = ffi.C
 
 ffi.cdef[[
 int chdir(const char *path);
-char *getcwd(char *buf, size_t size);
 ]]
-
-local function chdir(path)
-    if C.chdir(path) == 0 then
-        return true
-    else
-        return nil, "Unable to change working directory to '" ..path.."'"
-    end
-end
-
-local max_path = 4096
-local function currentdir()
-    return ffi.string(
-        C.getcwd(ffi.new('char[?]', max_path), max_path))
-end
-
---require("test")
 
 -- the default current directory is root so we should first of all
 -- change current directory to application's data directory
-if chdir(A.dir) then
-    local msg = "Change directory to assets dir"
-    local cwd = currentdir()
-    if A.dir ~= cwd then
-        -- multi user environment
-        A.LOGI(string.format("%s: %s -> %s", msg, A.dir, cwd))
-    else
-        -- single user environment
-        A.LOGI(string.format("%s: %s", msg, cwd))
-    end
-else
-    A.LOGE("Cannot change directory to "..A.dir)
+if C.chdir(A.dir) ~= 0 then
+    local err = "Unable to change working directory to '" .. A.dir .. "'"
+    A.LOGE(err)
+    error(err)
 end
 
 local function launch()

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,13 @@
 buildscript {
+    ext.compileSdk = 30
+    ext.targetSdk = 28
+    ext.minSdk64 = 21
+    ext.minSdk = 14
+
     ext.gradle_plugin_version = '4.2.0'
-    ext.kotlin_plugin_version = '1.4.32'
-    ext.androidx_core_version = '1.3.2'
-    ext.androidx_appcompat_version = '1.2.0'
+    ext.kotlin_plugin_version = '1.5.10'
+    ext.androidx_core_version = '1.5.0'
+    ext.androidx_appcompat_version = '1.3.0'
     ext.androidx_supportv4_version = '1.0.0'
     ext.android_desugar_jdk = '1.1.5'
     ext.commons_compress_version = '1.20'


### PR DESCRIPTION
Fairly minor changes in the grand scheme of things :)

Mainly to behave like a "normal" android app: with proguard/R8 rules and JIT/AOT compilation of kotlin classes.

I changed a few other things and removed some useless logs. 


* add proguard rules (don't obfuscate, keep line numbers for debugging stack traces, keep the entire `org.koreader.launcher` package)
* avoid packaging useless metadata into the APK
* refactor classes, finish migration to MultidexApp
* simplify `launcher.lua`
* use different log levels on `dlopen.lua`
* enable AOT compilation of JVM code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/313)
<!-- Reviewable:end -->
