### PR TITLE
Crash reporter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,10 +20,6 @@ android {
         buildConfigField "boolean", "SUPPORTS_RUNTIME_CHANGES", "false"
     }
 
-    viewBinding {
-        enabled = true
-    }
-
     sourceSets {
         main {
             assets.srcDirs = [ '../assets' ]
@@ -34,6 +30,10 @@ android {
         ndkBuild {
             path file('../jni/Android.mk')
         }
+    }
+
+    buildFeatures {
+        viewBinding = true
     }
 
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,10 @@ android {
         buildConfigField "boolean", "SUPPORTS_RUNTIME_CHANGES", "false"
     }
 
+    viewBinding {
+        enabled = true
+    }
+
     sourceSets {
         main {
             assets.srcDirs = [ '../assets' ]

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,4 +1,5 @@
 # proguard is used to shrink and optimize dependencies.
+-dontobfuscate
 -keep class org.koreader.launcher.** { *; }
 
 # keep kotlin.Metadata annotations

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,8 @@
         android:allowBackup="false"
         android:fullBackupContent="false"
         android:usesCleartextTraffic="true"
-        android:requestLegacyExternalStorage="true" >
+        android:requestLegacyExternalStorage="true"
+        android:supportsRtl="true">
         <meta-data android:name="android.max_aspect" android:value="3.1" />
         <activity
             android:name=".MainActivity"
@@ -87,6 +88,14 @@
                 <data android:mimeType="image/x-portable-bitmap" />
                 <data android:mimeType="text/html" />
                 <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:label="CrashReport"
+            android:theme="@style/NoTitle"
+            android:name=".CrashReportActivity" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/java/org/koreader/launcher/CrashReportActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/CrashReportActivity.kt
@@ -1,0 +1,37 @@
+package org.koreader.launcher
+
+import android.content.Intent
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import org.koreader.launcher.databinding.CrashReportBinding
+
+class CrashReportActivity : AppCompatActivity() {
+    private lateinit var binding: CrashReportBinding
+
+    public override fun onCreate(savedInstanceState: android.os.Bundle?) {
+        super.onCreate(savedInstanceState)
+        intent?.extras?.let { bundle ->
+            binding = CrashReportBinding.inflate(layoutInflater)
+            setContentView(binding.root)
+
+            binding.title.text = bundle.get("title").toString()
+            binding.reason.text = bundle.get("reason").toString()
+            binding.logs.text = bundle.get("logs").toString()
+
+            binding.shareReport.setOnClickListener {
+                val intent: Intent = Intent().apply {
+                    action = Intent.ACTION_SEND
+                    putExtra(Intent.EXTRA_TEXT, binding.logs.text.toString())
+                    type = "text/plain"
+                }
+                startActivity(Intent.createChooser(intent,
+                    resources.getString(R.string.crash_report_share_button)))
+            }
+        } ?: noCrashReportAttachedError()
+    }
+
+    private fun noCrashReportAttachedError() {
+        Toast.makeText(this, "No crash report", Toast.LENGTH_LONG).show()
+        finish()
+    }
+}

--- a/app/src/main/java/org/koreader/launcher/EPDTestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/EPDTestActivity.kt
@@ -1,134 +1,133 @@
 package org.koreader.launcher
 
-import android.app.Activity
 import android.content.Intent
 import android.graphics.Point
 import android.view.View
-import android.widget.Button
-import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import org.koreader.launcher.databinding.EpdTestBinding
+import org.koreader.launcher.device.DeviceInfo
 import org.koreader.launcher.device.epd.freescale.NTXEPDController
 import org.koreader.launcher.device.epd.qualcomm.QualcommEPDController
 import org.koreader.launcher.device.epd.rockchip.RK30xxEPDController
 import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController
-import java.util.*
+import java.util.Locale
 
 /* A test activity for EPD routines. It can be called from lua using the android.einkTest() function
    If the device in question doesn't play nice with the main NativeActivity it can be called from
    commandline using `adb shell am start -n org.koreader.launcher/.EPDTestActivity` */
 
-@Suppress("DEPRECATION")
-class EPDTestActivity : Activity() {
-    private lateinit var info: TextView
+class EPDTestActivity : AppCompatActivity() {
+    private lateinit var binding: EpdTestBinding
+
+    companion object {
+        private const val TEST_RK30XX = 1
+        private const val TEST_RK33XX = 2
+        private const val TEST_NTX = 3
+        private const val TEST_QUALCOMM = 4
+    }
 
     public override fun onCreate(savedInstanceState: android.os.Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.epdtest)
-        info = findViewById(R.id.info)
-        val readmeReport: TextView = findViewById(R.id.readmeReport)
-        val rk30xxDescription: TextView = findViewById(R.id.rk30xxText)
-        val rk33xxDescription: TextView = findViewById(R.id.rk33xxText)
-        val ntxNewDescription: TextView = findViewById(R.id.ntxNewText)
-        val qualcommDescription: TextView = findViewById(R.id.qualcommText)
-        val rk30xxButton: Button = findViewById(R.id.rk30xxButton)
-        val rk33xxButton: Button = findViewById(R.id.rk33xxButton)
-        val ntxNewButton: Button = findViewById(R.id.ntxNewButton)
-        val qualcommButton: Button = findViewById(R.id.qualcommButton)
-        val shareButton: Button = findViewById(R.id.shareButton)
 
-        /* current device info */
-        info.append("Manufacturer: $MANUFACTURER\n")
-        info.append("Brand: $BRAND\n")
-        info.append("Model: $MODEL\n")
-        info.append("Product: $PRODUCT\n")
-        info.append("Hardware: $HARDWARE\n")
+        binding = EpdTestBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        /* add platform if available */
-        var platform: String? = "unknown"
-        try {
-            platform = Class.forName("android.os.SystemProperties").getMethod(
-                    "get", String::class.java).invoke(null, "ro.board.platform")
-                as String?
-        } catch (e: Exception) {
-            e.printStackTrace()
-        } finally {
-            platform?.let { info.append("Platform: $it\n") }
+        binding.info.append("Manufacturer: ${DeviceInfo.MANUFACTURER}\n")
+        binding.info.append("Brand: ${DeviceInfo.BRAND}\n")
+        binding.info.append("Model: ${DeviceInfo.MODEL}\n")
+        binding.info.append("Device: ${DeviceInfo.DEVICE}\n")
+        binding.info.append("Product: ${DeviceInfo.PRODUCT}\n")
+        binding.info.append("Hardware: ${DeviceInfo.HARDWARE}\n")
+
+        getBuildProp("ro.board.platform")?.let {
+            binding.info.append("Platform: $it\n")
         }
 
-        readmeReport.text = resources.getString(R.string.epdtest_about)
+        binding.rk30xxButton.setOnClickListener {
+            runEinkTest(TEST_RK30XX)
+        }
 
-        /* rockchip rk30xx */
-        rk30xxDescription.text = resources.getString(R.string.epdtest_rk30xx)
-        rk30xxButton.setOnClickListener { runEinkTest(RK30xxTEST) }
+        binding.rk33xxButton.setOnClickListener {
+            runEinkTest(TEST_RK33XX)
+        }
 
-        /* rockchip rk33xx */
-        rk33xxDescription.text = resources.getString(R.string.epdtest_rk33xx)
-        rk33xxButton.setOnClickListener { runEinkTest(RK33xxTEST) }
+        binding.ntxNewButton.setOnClickListener {
+            runEinkTest(TEST_NTX)
+        }
 
-        /* freescale/ntx - Newer Tolino/Nook devices */
-        ntxNewDescription.text = resources.getString(R.string.epdtest_ntx)
-        ntxNewButton.setOnClickListener { runEinkTest(NTXTEST) }
+        binding.qualcommButton.setOnClickListener {
+            runEinkTest(TEST_QUALCOMM)
+        }
 
-        /* qualcomm - At least Onyx Boox Nova 2 */
-        qualcommDescription.text = resources.getString(R.string.epdtest_qualcomm)
-        qualcommButton.setOnClickListener { runEinkTest(QUALCOMMTEST) }
-
-        /* share button */
-        shareButton.setOnClickListener { shareText(info.text.toString()) }
+        binding.shareButton.setOnClickListener {
+            val intent: Intent = Intent().apply {
+                action = Intent.ACTION_SEND
+                putExtra(Intent.EXTRA_TEXT, binding.info.text.toString())
+                type = "text/plain"
+            }
+            startActivity(Intent.createChooser(intent,
+                resources.getString(R.string.epd_test_share_button)))
+        }
     }
 
+    @Suppress("DEPRECATION")
     private fun runEinkTest(test: Int) {
         var success = false
-        info.append(String.format(Locale.US, "run test #%d -> ", test))
+        binding.info.append(String.format(Locale.US, "run test #%d -> ", test))
         try {
             val v = window.decorView.findViewById<View>(android.R.id.content)
-            if (test == RK30xxTEST) {
-                info.append("rk30xx: ")
-                // force a flashing black->white update
-                if (RK30xxEPDController.requestEpdMode(v, "EPD_FULL", true)) success = true
-            } else if (test == RK33xxTEST) {
-                info.append("rk33xx: ")
-                if (RK33xxEPDController.requestEpdMode("EPD_FULL")) success = true
-            } else if (test == NTXTEST || test == QUALCOMMTEST) {
-                // get screen width and height
-                val display = windowManager.defaultDisplay
-                val size = Point()
-                display.getSize(size)
-                val width = size.x
-                val height = size.y
-                if (test == NTXTEST) {
-                    info.append("tolino: ")
-                    if (NTXEPDController.requestEpdMode(v, 34, 50, 0, 0, width, height)) success = true
-                } else if (test == QUALCOMMTEST) {
-                    info.append("qualcomm: ")
-                    if (QualcommEPDController.requestEpdMode(v, 98, 50, 0, 0, width, height)) success = true
+            when (test) {
+                TEST_RK30XX -> {
+                    binding.info.append("rk30xx: ")
+                    if (RK30xxEPDController.requestEpdMode(v, "EPD_FULL", true))
+                        success = true
+                }
+
+                TEST_RK33XX -> {
+                    binding.info.append("rk33xx: ")
+                    if (RK33xxEPDController.requestEpdMode("EPD_FULL"))
+                        success = true
+                }
+
+                TEST_NTX,
+                TEST_QUALCOMM -> {
+                    // get screen width and height
+                    val display = windowManager.defaultDisplay
+                    val size = Point()
+                    display.getSize(size)
+                    val width = size.x
+                    val height = size.y
+
+                    if (test == TEST_NTX) {
+                        binding.info.append("tolino: ")
+                        if (NTXEPDController.requestEpdMode(v, 34, 50, 0, 0, width, height))
+                            success = true
+                    } else if (test == TEST_QUALCOMM) {
+                        binding.info.append("qualcomm: ")
+                        if (QualcommEPDController.requestEpdMode(v, 98, 50, 0, 0, width, height))
+                            success = true
+                    }
                 }
             }
         } catch (e: Exception) {
             e.printStackTrace()
+        } finally {
+            if (success)
+                binding.info.append("pass\n")
+            else
+                binding.info.append("fail\n")
         }
-
-        if (success)
-            info.append("pass\n")
-        else
-            info.append("fail\n")
     }
 
-    private fun shareText(text: String) {
-        val i = Intent(Intent.ACTION_SEND)
-        i.putExtra(Intent.EXTRA_TEXT, text)
-        i.type = "text/plain"
-        startActivity(Intent.createChooser(i, "e-ink test results"))
-    }
-
-    companion object {
-        private const val RK30xxTEST = 1
-        private const val RK33xxTEST = 2
-        private const val NTXTEST = 3
-        private const val QUALCOMMTEST = 4
-        private val MANUFACTURER = android.os.Build.MANUFACTURER
-        private val BRAND = android.os.Build.BRAND
-        private val MODEL = android.os.Build.MODEL
-        private val PRODUCT = android.os.Build.PRODUCT
-        private val HARDWARE = android.os.Build.HARDWARE
+    @Suppress("SameParameterValue")
+    private fun getBuildProp(id: String): String? {
+        return try {
+            Class.forName("android.os.SystemProperties").getMethod(
+                "get", String::class.java).invoke(null, id)
+                as String?
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
     }
 }

--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -8,7 +8,7 @@ interface LuaInterface {
     fun canWriteSystemSettings(): Boolean
     fun dictLookup(text: String?, action: String?, nullablePackage: String?)
     fun download(url: String, name: String): Int
-    fun dumpLogs(path: String): Boolean
+    fun dumpLogs()
     fun einkUpdate(mode: Int)
     fun einkUpdate(mode: Int, delay: Long, x: Int, y: Int, width: Int, height: Int)
     fun enableFrontlightSwitch(): Boolean

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -7,11 +7,16 @@
 package org.koreader.launcher.device
 
 import android.os.Build
-import java.util.*
 import kotlin.collections.HashMap
+import java.util.Locale
 
 object DeviceInfo {
+    val MANUFACTURER: String
+    val BRAND: String
+    val MODEL: String
+    val DEVICE: String
     val PRODUCT: String
+    val HARDWARE: String
     val EINK_FREESCALE: Boolean
     val EINK_ROCKCHIP: Boolean
     val EINK_QCOM: Boolean
@@ -21,10 +26,6 @@ object DeviceInfo {
     val BUG_SCREEN_ROTATION: Boolean
     val NEEDS_VIEW: Boolean
 
-    private val MANUFACTURER: String
-    private val BRAND: String
-    private val MODEL: String
-    private val DEVICE: String
     private val BOYUE_T61: Boolean
     private val BOYUE_T62: Boolean
     private val BOYUE_T65S: Boolean
@@ -98,6 +99,7 @@ object DeviceInfo {
         MODEL = lowerCase(getBuildField("MODEL"))
         DEVICE = lowerCase(getBuildField("DEVICE"))
         PRODUCT = lowerCase(getBuildField("PRODUCT"))
+        HARDWARE = lowerCase(getBuildField("HARDWARE"))
         IS_BOYUE = MANUFACTURER.contentEquals("boeye") || MANUFACTURER.contentEquals("boyue")
 
         // --------------- device probe --------------- //

--- a/app/src/main/java/org/koreader/launcher/utils/Permissions.kt
+++ b/app/src/main/java/org/koreader/launcher/utils/Permissions.kt
@@ -43,7 +43,7 @@ object Permissions {
     fun requestStoragePermission(activity: Activity) {
         return if (newStoragePermissions(activity)) {
             val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
-            val rationale = activity.resources.getString(R.string.warning_manage_storage)
+            val rationale = activity.resources.getString(R.string.permission_manage_storage)
             requestSpecialPermission(activity, intent, rationale, null, null)
         } else {
             val perm = Manifest.permission.WRITE_EXTERNAL_STORAGE

--- a/app/src/main/res/layout/crash_report.xml
+++ b/app/src/main/res/layout/crash_report.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" >
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="12dp" />
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="24sp"
+        android:gravity="center_horizontal" />
+    <TextView
+        android:id="@+id/reason"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="16sp"
+        android:gravity="center_horizontal" />
+    <TextView
+        android:id="@+id/bomb"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/unicode_bomb"
+        android:textSize="60sp"
+        android:gravity="center_horizontal" />
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="12dp" />
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" >
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" >
+            <TextView
+                android:id="@+id/logs"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="12sp"
+                android:textAlignment="textStart"
+                android:gravity="start" />
+        </LinearLayout>
+    </ScrollView>
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0" >
+        <Button
+            android:id="@+id/shareReport"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/crash_report_share_button" />
+    </RelativeLayout>
+</LinearLayout>
+
+

--- a/app/src/main/res/layout/epd_test.xml
+++ b/app/src/main/res/layout/epd_test.xml
@@ -9,14 +9,16 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical" >
-
         <TextView
-            android:id="@+id/readmeFirst"
+            android:layout_width="fill_parent"
+            android:layout_height="12dp" />
+        <TextView
+            android:id="@+id/title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textSize="24sp"
             android:gravity="center_horizontal"
-            android:textSize="26sp"
-            android:text="@string/epdtest_title" />
+            android:text="@string/epd_test_title" />
 
         <TextView
             android:layout_width="fill_parent"
@@ -27,14 +29,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            android:textSize="18sp" />
+            android:textSize="14sp"
+            android:text="@string/epd_test_rk30xx_info" />
 
         <Button
             android:id="@+id/rk30xxButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/epdtest_rk30xx_button"
-            android:textSize="28sp" />
+            android:text="@string/epd_test_rk30xx_button" />
 
         <TextView
             android:layout_width="fill_parent"
@@ -45,14 +47,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            android:textSize="18sp" />
+            android:textSize="14sp"
+            android:text="@string/epd_test_rk33xx_info" />
 
         <Button
             android:id="@+id/rk33xxButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/epdtest_rk33xx_button"
-            android:textSize="28sp" />
+            android:text="@string/epd_test_rk33xx_button" />
 
         <TextView
             android:layout_width="fill_parent"
@@ -63,14 +65,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            android:textSize="18sp" />
+            android:textSize="14sp"
+            android:text="@string/epd_test_ntx_info" />
 
         <Button
             android:id="@+id/ntxNewButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/epdtest_ntx_button"
-            android:textSize="28sp" />
+            android:text="@string/epd_test_ntx_button" />
 
         <TextView
             android:layout_width="fill_parent"
@@ -81,14 +83,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            android:textSize="18sp" />
+            android:textSize="14sp"
+            android:text="@string/epd_test_qualcomm_info" />
 
         <Button
             android:id="@+id/qualcommButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/epdtest_qualcomm_button"
-            android:textSize="28sp" />
+            android:text="@string/epd_test_qualcomm_button" />
 
         <TextView
             android:layout_width="fill_parent"
@@ -99,7 +101,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            android:textSize="22sp" />
+            android:textSize="14sp"
+            android:text="@string/epd_test_about" />
 
         <TextView
             android:layout_width="fill_parent"
@@ -107,7 +110,7 @@
 
         <ImageView
             android:src="@android:drawable/divider_horizontal_dark"
-            android:contentDescription="@string/epdtest_divisor"
+            android:contentDescription="@string/divisor"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:scaleType="fitXY"
@@ -122,13 +125,12 @@
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
             android:text=""
-            android:textSize="20sp" />
+            android:textSize="16sp" />
 
         <Button
             android:id="@+id/shareButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/epdtest_share_results"
-            android:textSize="28sp" />
+            android:text="@string/epd_test_share_button" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- used on API30+ when targetSdk is 30+ -->
-    <string name="warning_manage_storage">Please allow the app to manage all files.</string>
-
-    <!-- strings used by EPDTestActivity -->
-    <string name="epdtest_title">is my device supported?</string>
-    <string name="epdtest_divisor" translatable="false"> </string>
-    <string name="epdtest_about">Did you see a flashing black to white eink update? Cool
+    <string name="crash_report_share_button">Share crash report</string>
+    <string name="divisor" translatable="false"> </string>
+    <string name="epd_test_about">Did you see a flashing black to white eink update? Cool
         Go to github.com/koreader/koreader/issues/4551 and share the following information with us </string>
-    <string name="epdtest_ntx">This button should work on modern Tolinos/Nooks and other ntx boards</string>
-    <string name="epdtest_ntx_button">freescale/ntx update</string>
-    <string name="epdtest_qualcomm">This button should work on some Onyx Boox devices. At least qualcomm ones</string>
-    <string name="epdtest_qualcomm_button">qualcomm/onyx update</string>
-    <string name="epdtest_rk30xx">This button should invoke a full refresh of Boyue T61/T62 clones.</string>
-    <string name="epdtest_rk30xx_button">rk30xx update</string>
-    <string name="epdtest_rk33xx">This button should work on boyue rk3368 clones.</string>
-    <string name="epdtest_rk33xx_button">rk33xx update</string>
-    <string name="epdtest_share_results">share results</string>
+    <string name="epd_test_ntx_info">This button should work on modern Tolinos/Nooks and other ntx boards</string>
+    <string name="epd_test_ntx_button">freescale/ntx update</string>
+    <string name="epd_test_qualcomm_info">This button should work on some Onyx Boox devices. At least qualcomm ones</string>
+    <string name="epd_test_qualcomm_button">qualcomm/onyx update</string>
+    <string name="epd_test_rk30xx_info">This button should invoke a full refresh of Boyue T61/T62 clones.</string>
+    <string name="epd_test_rk30xx_button">rk30xx update</string>
+    <string name="epd_test_rk33xx_info">This button should work on boyue rk3368 clones.</string>
+    <string name="epd_test_rk33xx_button">rk33xx update</string>
+    <string name="epd_test_share_button">Share EPD test results</string>
+    <string name="epd_test_title">EPD Test</string>
+    <string name="permission_manage_storage">Please allow the app to manage all files.</string>
+    <string name="unicode_bomb" translatable="false">💣</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -18,6 +18,10 @@
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowFullscreen">true</item>
     </style>
+    <style name="NoTitle" parent="@style/Theme.AppCompat.Light">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
     <style name="SplashScreen" parent="Fullscreen">
         <item name="android:windowBackground">@drawable/splash_icon</item>
     </style>

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2430,17 +2430,13 @@ local function run(android_app_state)
         end)
     end
 
-    android.dumpLogs = function(path)
+    android.dumpLogs = function()
         return JNI:context(android.app.activity.vm, function(jni)
-            local _path = jni.env[0].NewStringUTF(jni.env, path)
-            local ok = jni:callBooleanMethod(
+            jni:callVoidMethod(
                 android.app.activity.clazz,
                 "dumpLogs",
-                "(Ljava/lang/String;)Z",
-                _path
+                "()V"
             )
-            jni.env[0].DeleteLocalRef(jni.env, _path)
-            return ok
         end)
     end
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.minSdk64 = 21
     ext.minSdk = 14
 
-    ext.gradle_plugin_version = '4.2.0'
+    ext.gradle_plugin_version = '4.2.1'
     ext.kotlin_plugin_version = '1.5.10'
     ext.androidx_core_version = '1.5.0'
     ext.androidx_appcompat_version = '1.3.0'


### PR DESCRIPTION
Add a crash reporter that gets fired after an error in the frontend.
![test](https://user-images.githubusercontent.com/975883/120827668-f9e28580-c55b-11eb-83de-51ebc3d2b7f0.gif)

The same crash reporter is also fired in the case of an uncaught exception in the JVM.
The JNI interface is still unsafe. Exceptions raised there will absolutely crash the JVM without any bug report activity.

About signals:  SIGQUIT (used by ANR dialog) won't trigger the crash reporter. The rest of error signals (SIGSEV, SIGILL, SIGBUS...) should do, with the exception of SIGABRT. 

Also: migrate activities to AppCompatActivity and reduce boilerplate using view binding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/315)
<!-- Reviewable:end -->
