### PR TITLE
Some early init changes

### DIFF
--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -1,8 +1,11 @@
 package org.koreader.launcher
 
+import androidx.annotation.WorkerThread
+
 /* Declares methods that are exposed to lua via JNI
  * See https://github.com/koreader/android-luajit-launcher/blob/master/assets/android.lua */
 
+@WorkerThread
 interface LuaInterface {
     fun canIgnoreBatteryOptimizations(): Boolean
     fun canWriteSystemSettings(): Boolean
@@ -40,7 +43,6 @@ interface LuaInterface {
     fun getStatusBarHeight(): Int
     fun getVersion(): String
     fun hasClipboardText(): Boolean
-    fun hasExternalStoragePermission(): Boolean
     fun hasNativeRotation(): Boolean
     fun hasOTAUpdates(): Boolean
     fun hasRuntimeChanges(): Boolean

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -189,7 +189,9 @@ class MainActivity : NativeActivity(), LuaInterface,
                     "Permission granted for request code: %d", requestCode))
         } else {
             Log.e(tag, "Permission rejected. Bye!")
-            showToastAndDie(resources.getString(R.string.error_no_permissions))
+            Toast.makeText(this, resources.getString(R.string.error_no_permissions),
+                Toast.LENGTH_SHORT).show()
+            finish()
         }
     }
 
@@ -696,10 +698,5 @@ class MainActivity : NativeActivity(), LuaInterface,
                     View.SYSTEM_UI_FLAG_LOW_PROFILE
             else -> decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LOW_PROFILE
         }
-    }
-
-    private fun showToastAndDie(msg: String) {
-        Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
-        finish()
     }
 }

--- a/app/src/main/java/org/koreader/launcher/MainApp.kt
+++ b/app/src/main/java/org/koreader/launcher/MainApp.kt
@@ -2,6 +2,7 @@ package org.koreader.launcher
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Environment
 import android.os.StrictMode
 import androidx.multidex.MultiDexApplication
@@ -15,8 +16,9 @@ class MainApp : MultiDexApplication() {
         const val flavor = BuildConfig.FLAVOR_CHANNEL
         const val has_ota_updates = BuildConfig.IN_APP_UPDATES
         const val supports_runtime_changes = BuildConfig.SUPPORTS_RUNTIME_CHANGES
-        const val provider = "${BuildConfig.APPLICATION_ID}.provider"
+
         val is_debug = BuildConfig.DEBUG
+        val provider = "${BuildConfig.APPLICATION_ID}.provider"
 
         // internal path for app files
         lateinit var assets_path: String
@@ -29,6 +31,8 @@ class MainApp : MultiDexApplication() {
         // app dir in external path
         lateinit var app_storage_path: String
             private set
+
+        private var targetSdk = 0
 
         // logcat to crash.log
         fun dumpLogcat() {
@@ -79,6 +83,14 @@ class MainApp : MultiDexApplication() {
                 }
             }
         }
+
+        fun isAtLeastApi(version: Int, runtimeOnly: Boolean = false): Boolean {
+            return if (runtimeOnly) {
+                (Build.VERSION.SDK_INT >= version)
+            } else {
+                ((Build.VERSION.SDK_INT >= version) and (targetSdk >= version))
+            }
+        }
     }
 
     @Suppress("DEPRECATION")
@@ -87,6 +99,7 @@ class MainApp : MultiDexApplication() {
         assets_path = filesDir.absolutePath
         storage_path = Environment.getExternalStorageDirectory().absolutePath
         app_storage_path = String.format("%s/%s", storage_path, name.lowercase())
+        targetSdk = applicationContext.applicationInfo.targetSdkVersion
 
         Thread.setDefaultUncaughtExceptionHandler { thread, _ ->
             val msg = "Uncaught exception in thread #${thread.id} (${thread.name})"

--- a/app/src/main/java/org/koreader/launcher/MainApp.kt
+++ b/app/src/main/java/org/koreader/launcher/MainApp.kt
@@ -8,7 +8,6 @@ import androidx.multidex.MultiDexApplication
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
-import java.lang.StringBuilder
 
 class MainApp : MultiDexApplication() {
     companion object {

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -1,6 +1,5 @@
 package org.koreader.launcher.extensions
 
-import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.SearchManager
@@ -13,12 +12,10 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.os.Environment
-import android.os.PowerManager
 import android.provider.Settings
 import android.util.DisplayMetrics
 import android.view.WindowManager
 import androidx.appcompat.app.AlertDialog
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import java.util.*
 import java.util.concurrent.CountDownLatch
@@ -93,35 +90,10 @@ fun Activity.getWidth(): Int {
     return getScreenSize(this).x
 }
 
-@SuppressLint("NewApi")
-fun Activity.hasStoragePermissionCompat(): Boolean {
-    return if (newStoragePermissions(this)) {
-        Environment.isExternalStorageManager()
-    } else {
-        return (ContextCompat.checkSelfPermission(this,
-            Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
-    }
-}
-
-@SuppressLint("NewApi")
-fun Activity.hasWriteSettingsPermissionCompat(): Boolean {
-    return if (newSettingsPermission())  {
-        Settings.System.canWrite(this)
-    } else true
-}
-
 @Suppress("DEPRECATION")
 fun Activity.isFullscreenDeprecated(): Boolean {
     return (window.attributes.flags and
         WindowManager.LayoutParams.FLAG_FULLSCREEN != 0)
-}
-
-@SuppressLint("NewApi")
-fun Activity.isIgnoringBatteryOptimizationCompat(): Boolean {
-    return if (newSettingsPermission()) {
-        val pm = this.applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
-        pm.isIgnoringBatteryOptimizations(this.packageName)
-    } else false
 }
 
 @Suppress("DEPRECATION")
@@ -221,37 +193,6 @@ fun Activity.openWifi() {
     startActivityCompat(this, openWifiIntent)
 }
 
-@SuppressLint("NewApi")
-fun Activity.requestIgnoreBatteryOptimizationCompat(rationale: String,
-                                                    okButton: String?, cancelButton: String?) {
-    if (newSettingsPermission()) {
-        val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
-        requestSpecialPermission(this, intent, rationale, okButton, cancelButton)
-    }
-}
-
-@SuppressLint("NewApi")
-fun Activity.requestStoragePermissionCompat(rationale: String) {
-    val code = 1
-    return if (newStoragePermissions(this)) {
-        val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
-        requestSpecialPermission(this, intent, rationale, null, null)
-    } else {
-        ActivityCompat.requestPermissions(this,
-            arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE), code)
-
-    }
-}
-
-@SuppressLint("NewApi")
-fun Activity.requestWriteSettingsPermissionCompat(rationale: String,
-                                                  okButton: String?, cancelButton: String?) {
-    if (newSettingsPermission()) {
-        val intent = Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS)
-        requestSpecialPermission(this, intent, rationale, okButton, cancelButton)
-    }
-}
-
 fun Activity.searchText(text: String, domain: String? = null, title: String? = null) {
     val searchIntent: Intent = Intent().apply {
         action = Intent.ACTION_SEARCH
@@ -319,20 +260,7 @@ private fun getScreenSizeWithConstraints(activity: Activity): Point {
     return size
 }
 
-private fun newStoragePermissions(activity: Activity): Boolean {
-    val targetSdk = activity.applicationContext.applicationInfo.targetSdkVersion
-    val runtimeSdk = Build.VERSION.SDK_INT
-    val minApi = Build.VERSION_CODES.R
-    return ((runtimeSdk >= minApi) and (targetSdk >= minApi))
-}
-
-private fun newSettingsPermission(): Boolean {
-    val runtimeSdk = Build.VERSION.SDK_INT
-    val minApi = Build.VERSION_CODES.M
-    return (runtimeSdk >= minApi)
-}
-
-private fun requestSpecialPermission(activity: Activity, intent: Intent, rationale: String,
+fun requestSpecialPermission(activity: Activity, intent: Intent, rationale: String,
                                      okButton: String?, cancelButton: String?) {
     activity.runOnUiThread {
         val ok = okButton ?: "OK"

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -214,6 +214,13 @@ fun Activity.quickdicLookup(text: String) {
     startActivityCompat(this, quickdicIntent)
 }
 
+fun Activity.openWifi() {
+    val openWifiIntent = Intent().apply {
+        action = Settings.ACTION_WIFI_SETTINGS
+    }
+    startActivityCompat(this, openWifiIntent)
+}
+
 @SuppressLint("NewApi")
 fun Activity.requestIgnoreBatteryOptimizationCompat(rationale: String,
                                                     okButton: String?, cancelButton: String?) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,6 @@
     <string name="epd_test_instructions">Go to github.com/koreader/koreader/issues/4551 and share the following information with us</string>
     <string name="epd_test_description">Supported platforms</string>
     <string name="error_no_permissions">Insufficient permissions</string>
-    <string name="error_extracting_assets">Error extracting assets</string>
     <string name="no_crash_attached">No crash report attached</string>
     <string name="permission_manage_storage">Please allow the app to manage all files.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="epd_test_question">Did you see a flashing black to white eink update?</string>
     <string name="epd_test_instructions">Go to github.com/koreader/koreader/issues/4551 and share the following information with us</string>
     <string name="epd_test_description">Supported platforms</string>
+    <string name="error_no_permissions">Insufficient permissions</string>
+    <string name="error_extracting_assets">Error extracting assets</string>
     <string name="no_crash_attached">No crash report attached</string>
     <string name="permission_manage_storage">Please allow the app to manage all files.</string>
 

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2307,17 +2307,6 @@ local function run(android_app_state)
         end)
     end
 
-    android.canWriteStorage = function()
-        android.DEBUG("checking write storage permission")
-        return JNI:context(android.app.activity.vm, function(jni)
-            return jni:callBooleanMethod(
-                android.app.activity.clazz,
-                "hasExternalStoragePermission",
-                "()Z"
-            )
-        end)
-    end
-
     android.getClipboardText = function()
         return JNI:context(android.app.activity.vm, function(jni)
             local text = jni:callObjectMethod(
@@ -2645,10 +2634,6 @@ local function run(android_app_state)
     ffi.load = function(library, ...) -- luacheck: ignore 212
         android.DEBUG("ffi.load "..library)
         return android.dl.dlopen(library, ffi_load)
-    end
-
-    if not android.canWriteStorage() then
-        error("insufficient permissions")
     end
 
     local installed = android.extractAssets()

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -42,7 +42,8 @@ include $(CLEAR_VARS)
 # final shared library to load via the NativeActivity framework.
 LOCAL_PATH := $(BASE_PATH)
 LOCAL_MODULE := luajit-launcher
-LOCAL_SRC_FILES := main.c
+LOCAL_C_INCLUDES := $(LOCAL_PATH)
+LOCAL_SRC_FILES := jni_helper.c main.c
 LOCAL_STATIC_LIBRARIES := android_native_app_glue
 # NOTE: By default, we link against the shared LuaJIT library directly.
 LOCAL_SHARED_LIBRARIES := luajit

--- a/jni/jni_helper.c
+++ b/jni/jni_helper.c
@@ -1,0 +1,33 @@
+#include <jni.h>
+#include "jni_helper.h"
+
+bool has_permission(struct android_app* app) {
+    JNIEnv* env;
+    JavaVM* vm = app->activity->vm;
+    int status = (*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_6);
+    if ((status == JNI_OK) || ((status == JNI_EDETACHED)
+        && ((*vm)->AttachCurrentThread(vm, &env, NULL) == 0)))
+    {
+        jclass clazz = (*env)->GetObjectClass(env, app->activity->clazz);
+        jmethodID method = (*env)->GetMethodID(env, clazz, "hasRequiredPermissions", "()Z");
+        bool ok = ((*env)->CallBooleanMethod(env, app->activity->clazz, method) == JNI_TRUE);
+        (*vm)->DetachCurrentThread(vm);
+        return ok;
+    } else {
+        return false;
+    }
+}
+
+void crash_report(struct android_app* app) {
+    JNIEnv* env;
+    JavaVM* vm = app->activity->vm;
+    int status = (*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_6);
+    if ((status == JNI_OK) || ((status == JNI_EDETACHED)
+        && ((*vm)->AttachCurrentThread(vm, &env, NULL) == 0)))
+    {
+        jclass clazz = (*env)->GetObjectClass(env, app->activity->clazz);
+        jmethodID method = (*env)->GetMethodID(env, clazz, "onNativeCrash", "()V");
+        (*env)->CallVoidMethod(env, app->activity->clazz, method);
+        (*vm)->DetachCurrentThread(vm);
+    }
+}

--- a/jni/jni_helper.h
+++ b/jni/jni_helper.h
@@ -1,0 +1,5 @@
+#include <stdbool.h>
+#include "android_native_app_glue.h"
+
+bool has_permission(struct android_app* app);
+void crash_report(struct android_app* app);


### PR DESCRIPTION
- Block until permissions are granted before launching the LuaJIT vm. 
- Don't raise errors if runtime permissions were rejected (can happen). Just show a toast and finish the activity.
- Annotate all methods called from lua as `@WorkerThread`
- Continue migration to kotlin extensions.
- Reworked mandatory permissions

I refactored a bit the C/JNI code. Probably some stuff in `jni_helper.c` can be abstracted away, but I'm fine as is and it seems to work fine :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/316)
<!-- Reviewable:end -->
