### PR TITLE
quick fix for Android11

### DIFF
--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -566,7 +566,7 @@ class MainActivity : NativeActivity(), LuaInterface,
     override fun requestIgnoreBatteryOptimizations(rationale: String, okButton: String, cancelButton: String) {
         if (MainApp.isAtLeastApi(Build.VERSION_CODES.M)) {
             val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
-            requestSpecialPermission(this, intent, rationale, okButton, cancelButton)
+            requestSpecialPermission(intent, rationale, okButton, cancelButton)
         }
     }
 
@@ -574,7 +574,7 @@ class MainActivity : NativeActivity(), LuaInterface,
     override fun requestWriteSystemSettings(rationale: String, okButton: String, cancelButton: String) {
         if (MainApp.isAtLeastApi(Build.VERSION_CODES.M)) {
             val intent = Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS)
-            requestSpecialPermission(this, intent, rationale, okButton, cancelButton)
+            requestSpecialPermission(intent, rationale, okButton, cancelButton)
         }
     }
 
@@ -708,7 +708,11 @@ class MainActivity : NativeActivity(), LuaInterface,
     @Suppress("NewApi")
     private fun requestMandatoryPermissions() {
         if (MainApp.isAtLeastApi(Build.VERSION_CODES.R)) {
-            requestSpecialPermission(this, intent,
+            val intent = Intent().apply {
+                action = Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION
+                data = Uri.fromParts("package", packageName, null)
+            }
+            requestSpecialPermission(intent,
                 resources.getString(R.string.permission_manage_storage),
                 null, null)
 

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -193,6 +193,25 @@ fun Activity.openWifi() {
     startActivityCompat(this, openWifiIntent)
 }
 
+fun Activity.requestSpecialPermission(intent: Intent, rationale: String,
+                             okButton: String?, cancelButton: String?) {
+    runOnUiThread {
+        val ok = okButton ?: "OK"
+        val builder = AlertDialog.Builder(this)
+            .setMessage(rationale)
+            .setCancelable(false)
+            .setPositiveButton(ok) { _, _ ->
+                startActivity(intent)
+                finish()
+            }
+
+        if (cancelButton != null) {
+            builder.setNegativeButton(cancelButton) { _, _ -> }
+        }
+        builder.create().show()
+    }
+}
+
 fun Activity.searchText(text: String, domain: String? = null, title: String? = null) {
     val searchIntent: Intent = Intent().apply {
         action = Intent.ACTION_SEARCH
@@ -258,25 +277,6 @@ private fun getScreenSizeWithConstraints(activity: Activity): Point {
     display.getMetrics(metrics)
     size.set(metrics.widthPixels, metrics.heightPixels)
     return size
-}
-
-fun requestSpecialPermission(activity: Activity, intent: Intent, rationale: String,
-                                     okButton: String?, cancelButton: String?) {
-    activity.runOnUiThread {
-        val ok = okButton ?: "OK"
-        val builder = AlertDialog.Builder(activity)
-            .setMessage(rationale)
-            .setCancelable(false)
-            .setPositiveButton(ok) { _, _ ->
-                activity.startActivity(intent)
-                activity.finish()
-            }
-
-        if (cancelButton != null) {
-            builder.setNegativeButton(cancelButton) { _, _ -> }
-        }
-        builder.create().show()
-    }
 }
 
 @SuppressLint("QueryPermissionsNeeded")


### PR DESCRIPTION
I found it while playing with https://github.com/koreader/koreader/issues/7837. intent was missing after some refactor and the app just borked in Android11+.

On the bright side now we redirect users to the specific settings for KOReader instead of the full list of app that declare `MANAGE_EXTERNAL_STORAGE` permission.

Merging soon, before the actual bug hits a nightly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/317)
<!-- Reviewable:end -->
