### PR TITLE
A few platform fixes

### DIFF
--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -44,6 +44,7 @@ interface LuaInterface {
     fun getVersion(): String
     fun hasBrokenLifecycle(): Boolean
     fun hasClipboardText(): Boolean
+    fun hasLights(): Boolean
     fun hasNativeRotation(): Boolean
     fun hasOTAUpdates(): Boolean
     fun hasRuntimeChanges(): Boolean

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -463,6 +463,10 @@ class MainActivity : NativeActivity(), LuaInterface,
         }?: false
     }
 
+    override fun hasLights(): Boolean {
+        return device.hasLights
+    }
+
     override fun hasNativeRotation(): Boolean {
         return if (device.platform == "android") {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
@@ -472,7 +476,10 @@ class MainActivity : NativeActivity(), LuaInterface,
     }
 
     override fun hasOTAUpdates(): Boolean {
-        return MainApp.has_ota_updates
+        return when (device.platform) {
+            "chrome" -> false
+            else -> MainApp.has_ota_updates
+        }
     }
 
     override fun hasRuntimeChanges(): Boolean {

--- a/app/src/main/java/org/koreader/launcher/device/Device.kt
+++ b/app/src/main/java/org/koreader/launcher/device/Device.kt
@@ -29,10 +29,6 @@ class Device(activity: Activity) {
             return epd.getMode() == "all"
         }
 
-    val needsWakelocks = DeviceInfo.BUG_WAKELOCKS
-    val bugRotation = DeviceInfo.BUG_SCREEN_ROTATION
-    val bugLifecycle = DeviceInfo.BUG_BROKEN_LIFECYCLE
-
     val platform: String = if (activity.packageManager.hasSystemFeature("org.chromium.arc.device_management")) {
         "chrome"
     } else if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
@@ -40,6 +36,14 @@ class Device(activity: Activity) {
         "android_tv"
     } else {
         "android"
+    }
+
+    val needsWakelocks = DeviceInfo.QUIRK_NEEDS_WAKELOCKS
+    val bugRotation = DeviceInfo.QUIRK_NO_HW_ROTATION
+    val bugLifecycle = DeviceInfo.QUIRK_BROKEN_LIFECYCLE
+    val hasLights = when (platform) {
+        "android" -> !DeviceInfo.QUIRK_NO_LIGHTS
+        else -> false
     }
 
     val einkPlatform: String

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -18,10 +18,12 @@ object DeviceInfo {
     val PRODUCT: String
     val HARDWARE: String
 
-    // known bugs
-    val BUG_WAKELOCKS: Boolean
-    val BUG_SCREEN_ROTATION: Boolean
-    val BUG_BROKEN_LIFECYCLE: Boolean
+    // known quirks
+    val QUIRK_BROKEN_LIFECYCLE: Boolean
+    val QUIRK_NEEDS_WAKELOCKS: Boolean
+    val QUIRK_NO_HW_ROTATION: Boolean
+    val QUIRK_NO_LIGHTS: Boolean
+
 
     enum class EinkDevice {
         NONE,
@@ -57,7 +59,7 @@ object DeviceInfo {
         TOLINO_EPOS
     }
 
-    enum class BugDevice {
+    enum class QuirkDevice {
         NONE,
         EMULATOR,
         ONYX_POKE2,
@@ -67,7 +69,7 @@ object DeviceInfo {
     // default values for generic devices.
     internal var EINK = EinkDevice.NONE
     internal var LIGHTS = LightsDevice.NONE
-    private var BUG = BugDevice.NONE
+    private var QUIRK = QuirkDevice.NONE
 
     // device probe
     private val IS_BOYUE: Boolean
@@ -225,17 +227,17 @@ object DeviceInfo {
             && DEVICE.contentEquals("ntx_6sl")
 
         // devices with known bugs
-        val bugMap = HashMap<BugDevice, Boolean>()
-        bugMap[BugDevice.EMULATOR] = EMULATOR_X86
-        bugMap[BugDevice.ONYX_POKE2] = ONYX_POKE2
-        bugMap[BugDevice.SONY_RP1] = SONY_RP1
+        val bugMap = HashMap<QuirkDevice, Boolean>()
+        bugMap[QuirkDevice.EMULATOR] = EMULATOR_X86
+        bugMap[QuirkDevice.ONYX_POKE2] = ONYX_POKE2
+        bugMap[QuirkDevice.SONY_RP1] = SONY_RP1
 
         bugMap.keys.iterator().run {
             while (this.hasNext()) {
                 val bug = this.next()
                 val flag = bugMap[bug]
                 if (flag != null && flag) {
-                    BUG = bug
+                    QUIRK = bug
                 }
             }
         }
@@ -291,21 +293,27 @@ object DeviceInfo {
             }
         }
 
-        // need wakelocks
-        BUG_WAKELOCKS = when (BUG) {
-            BugDevice.SONY_RP1 -> true
+        // has broken lifecycle
+        QUIRK_BROKEN_LIFECYCLE = when (QUIRK) {
+            QuirkDevice.ONYX_POKE2 -> true
             else -> false
         }
 
-        // has broken lifecycle
-        BUG_BROKEN_LIFECYCLE = when (BUG) {
-            BugDevice.ONYX_POKE2 -> true
+        // need wakelocks
+        QUIRK_NEEDS_WAKELOCKS = when (QUIRK) {
+            QuirkDevice.SONY_RP1 -> true
             else -> false
         }
 
         // 4.4+ device without native surface rotation
-        BUG_SCREEN_ROTATION = when (BUG) {
-            BugDevice.EMULATOR -> true
+        QUIRK_NO_HW_ROTATION = when (QUIRK) {
+            QuirkDevice.EMULATOR -> true
+            else -> false
+        }
+
+        // Android devices without lights
+        QUIRK_NO_LIGHTS = when (QUIRK) {
+            QuirkDevice.SONY_RP1 -> true
             else -> false
         }
     }

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2141,6 +2141,16 @@ local function run(android_app_state)
         end)
     end
 
+    android.hasLights = function()
+        return JNI:context(android.app.activity.vm, function(jni)
+            return jni:callBooleanMethod(
+                android.app.activity.clazz,
+                "hasLights",
+                "()Z"
+            )
+        end)
+    end
+
     android.hasNativeRotation = function()
         return JNI:context(android.app.activity.vm, function(jni)
             return jni:callBooleanMethod(


### PR DESCRIPTION
Inner changes:

- Renames "bugs" as "quirks" to acommodate new fw/platform oddities.
- Adds a new device property: `hasLights` than can be disabled by device id (I disabled it for the Sony RP1 as it doesn't have frontlight)

Platform changes:

- Disables the light dialog handling for AndroidTV and ChromeOS. They have no effect.
- Disables OTA updates on ChromeOS. APK installation is forbidden unless the device is in Developer mode (aka: rooted) and even there the results aren't reliable. (I can get the apk to start downloading but it never finish it. If I replace the uncomplete download with an OK apk and restart the program it can install the updates fine)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/328)
<!-- Reviewable:end -->
