### PR TITLE
Don't get external files dir if media isn't mounted

### DIFF
--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -74,9 +74,9 @@ fun Activity.getHeight(): Int {
 fun Activity.getSdcardPath(): String? {
     val context = this.applicationContext
     val packageName = context.packageName
-    val volumes: Array<out java.io.File> = ContextCompat.getExternalFilesDirs(context, null)
     return if (Environment.getExternalStorageState() == Environment.MEDIA_MOUNTED) {
         try {
+            val volumes: Array<out java.io.File> = ContextCompat.getExternalFilesDirs(context, null)
             volumes[1].absolutePath.replace("/Android/data/$packageName/files", "")
         } catch (e: Exception) {
             null


### PR DESCRIPTION
It should work but it's broken on some Tolinos. With this PR we catch the `SecurityException` it throws.

Fix for https://github.com/koreader/koreader/issues/8355

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/337)
<!-- Reviewable:end -->
