### PR TITLE
Add driver support for onyx poke pro

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -59,6 +59,7 @@ object DeviceInfo {
         ONYX_NOVA3,
         ONYX_NOVA3_COLOR,
         ONYX_NOVA_AIR,
+        ONYX_POKE_PRO,
         TOLINO
     }
 
@@ -71,6 +72,7 @@ object DeviceInfo {
         ONYX_NOVA3,
         ONYX_NOVA_AIR,
         ONYX_KON_TIKI2,
+        ONYX_POKE_PRO,
         TOLINO_EPOS
     }
 
@@ -122,6 +124,7 @@ object DeviceInfo {
     private val ONYX_NOVA3_COLOR: Boolean
     private val ONYX_NOVA_AIR: Boolean
     private val ONYX_POKE2: Boolean
+    private val ONYX_POKE_PRO: Boolean
     private val SONY_RP1: Boolean
     private val TOLINO: Boolean
     private val TOLINO_EPOS: Boolean
@@ -279,6 +282,10 @@ object DeviceInfo {
         ONYX_POKE2 = MANUFACTURER.contentEquals("onyx")
             && PRODUCT.contentEquals("poke2")
 
+        // Onyx Poke Pro
+        ONYX_POKE_PRO = MANUFACTURER.contentEquals("onyx")
+            && PRODUCT.contentEquals("poke_pro")
+
         // Sony DPT-RP1
         SONY_RP1 = MANUFACTURER.contentEquals("sony")
             && MODEL.contentEquals("dpt-rp1")
@@ -341,6 +348,7 @@ object DeviceInfo {
         deviceMap[EinkDevice.ONYX_NOVA2] = ONYX_NOVA2
         deviceMap[EinkDevice.ONYX_NOVA3_COLOR] = ONYX_NOVA3_COLOR
         deviceMap[EinkDevice.ONYX_NOVA_AIR] = ONYX_NOVA_AIR
+        deviceMap[EinkDevice.ONYX_POKE_PRO] = ONYX_POKE_PRO
         deviceMap[EinkDevice.TOLINO] = TOLINO
 
         deviceMap.keys.iterator().run {
@@ -361,6 +369,7 @@ object DeviceInfo {
         lightsMap[LightsDevice.ONYX_NOTE3] = ONYX_NOTE3
         lightsMap[LightsDevice.ONYX_NOVA2] = ONYX_NOVA2
         lightsMap[LightsDevice.ONYX_NOVA_AIR] = ONYX_NOVA_AIR
+        lightsMap[LightsDevice.ONYX_POKE_PRO] = ONYX_POKE_PRO
         lightsMap[LightsDevice.TOLINO_EPOS] = TOLINO_EPOS
 
         lightsMap.keys.iterator().run {

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -63,7 +63,8 @@ object EPDFactory {
                 DeviceInfo.EinkDevice.ONYX_NOVA2,
                 DeviceInfo.EinkDevice.ONYX_NOVA3,
                 DeviceInfo.EinkDevice.ONYX_NOVA3_COLOR,
-                DeviceInfo.EinkDevice.ONYX_NOVA_AIR -> {
+                DeviceInfo.EinkDevice.ONYX_NOVA_AIR,
+                DeviceInfo.EinkDevice.ONYX_POKE_PRO -> {
                     logController("Onyx/Qualcomm")
                     OnyxEPDController()
                 }

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -18,7 +18,8 @@ object LightsFactory {
                 DeviceInfo.LightsDevice.ONYX_NOTE3,
                 DeviceInfo.LightsDevice.ONYX_NOVA2,
                 DeviceInfo.LightsDevice.ONYX_NOVA3,
-                DeviceInfo.LightsDevice.ONYX_NOVA_AIR -> {
+                DeviceInfo.LightsDevice.ONYX_NOVA_AIR,
+                DeviceInfo.LightsDevice.ONYX_POKE_PRO -> {
                     logController("Onyx/Qualcomm")
                     OnyxWarmthController()
                 }


### PR DESCRIPTION
Hi, I wanted koreader to run on my Poke Pro so I looked at a previous PR that added "more onyx" support and made the same changes for Poke Pro.
Hope it looks good and can be merged 😊

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/357)
<!-- Reviewable:end -->
