### PR TITLE
decouple dictionary actions from generic shareText

### DIFF
--- a/app/src/main/java/org/koreader/launcher/ApkUpdater.kt
+++ b/app/src/main/java/org/koreader/launcher/ApkUpdater.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
-import android.os.Environment
 import android.util.Log
 import androidx.core.content.FileProvider
 import java.io.File

--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -69,7 +69,7 @@ interface LuaInterface {
     fun requestIgnoreBatteryOptimizations(rationale: String, okButton: String, cancelButton: String)
     fun requestWriteSystemSettings(rationale: String, okButton: String, cancelButton: String)
     fun safFilePicker(path: String?): Boolean
-    fun sendText(text: String?)
+    fun sendText(text: String, reason: String? = null, title: String? = null, mimetype: String? = null)
     fun setFullscreen(enabled: Boolean)
     fun setClipboardText(text: String)
     fun setIgnoreInput(enabled: Boolean)

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -275,12 +275,12 @@ class MainActivity : NativeActivity(), LuaInterface,
         text?.let { lookupText ->
             action?.let { lookupAction ->
                 when (lookupAction) {
-                    "aard2" -> aardLookup(lookupText)
-                    "colordict" -> colordictLookup(lookupText, nullablePackage)
-                    "quickdic" -> quickdicLookup(lookupText)
-                    "search" -> searchText(lookupText, nullablePackage)
-                    "send" -> sendText(lookupText, nullablePackage)
-                    "text" -> processText(lookupText, nullablePackage)
+                    "aard2" -> aardAction(lookupText)
+                    "colordict" -> colordictAction(lookupText, nullablePackage)
+                    "quickdic" -> quickdicAction(lookupText)
+                    "search" -> searchAction(lookupText, nullablePackage)
+                    "send" -> sendAction(lookupText, nullablePackage)
+                    "text" -> processTextAction(lookupText, nullablePackage)
                     else -> Log.w(tag, "Unsupported action $lookupAction")
                 }
             } ?: Log.e(tag, "invalid lookup: no action")
@@ -656,9 +656,21 @@ class MainActivity : NativeActivity(), LuaInterface,
         } ?: false
     }
 
-    override fun sendText(text: String?) {
-        text?.let {
-            sendText(it, null, null)
+    override fun sendText(text: String, reason: String?, title: String?, mimetype: String?) {
+        val sendIntent: Intent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, text)
+            type = mimetype ?: "text/plain"
+        }
+        title?.let {
+            sendIntent.putExtra(Intent.EXTRA_TITLE, it)
+        }
+
+        val chooser = Intent.createChooser(sendIntent, reason)
+        try {
+            startActivity(chooser)
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
     }
 

--- a/app/src/main/java/org/koreader/launcher/device/epd/qualcomm/QualcommEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/qualcomm/QualcommEPDController.kt
@@ -19,7 +19,6 @@ abstract class QualcommEPDController {
         const val EINK_WAVEFORM_DELAY_UI = 100
         const val EINK_WAVEFORM_DELAY_FAST = 0
 
-
         private fun preventSystemRefresh() : Boolean{
             // Sets UpdateMode and UpdateScheme to None
             // this function is called EpdController.setSystemUpdateModeAndScheme in onyxsdk

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -42,21 +42,21 @@ fun Activity.hapticFeedback(constant: Int, force: Boolean, view: View) {
     }
 }
 
-fun Activity.aardLookup(text: String) {
+fun Activity.aardAction(text: String) {
     val aardIntent: Intent = Intent().apply {
         action = "aard2.lookup"
         putExtra(SearchManager.QUERY, text)
     }
-    startActivityCompat(this, aardIntent)
+    startDictionaryActivity(this, aardIntent)
 }
 
-fun Activity.colordictLookup(text: String, domain: String? = null) {
+fun Activity.colordictAction(text: String, domain: String? = null) {
     val colordictIntent: Intent = Intent().apply {
         action = "aard2.lookup"
         putExtra("EXTRA_QUERY", text)
         putExtra("EXTRA_FULLSCREEN", true)
     }
-    startActivityCompat(this, colordictIntent, domain)
+    startDictionaryActivity(this, colordictIntent, domain)
 }
 
 fun Activity.filePicker(id: Int): Boolean {
@@ -185,9 +185,9 @@ fun Activity.networkInfo(): String {
     return String.format(Locale.US, "%d;%d", if (connected) 1 else 0, connectionType)
 }
 
-fun Activity.processText(text: String, domain: String? = null, title: String? = null) {
+fun Activity.processTextAction(text: String, domain: String? = null) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-        sendText(text, domain, title)
+        sendAction(text, domain)
     } else {
         val processTextIntent: Intent = Intent().apply {
             action = Intent.ACTION_PROCESS_TEXT
@@ -196,16 +196,16 @@ fun Activity.processText(text: String, domain: String? = null, title: String? = 
             putExtra(Intent.EXTRA_PROCESS_TEXT_READONLY, text)
             type = "text/plain"
         }
-        startActivityCompat(this, processTextIntent, domain, title)
+        startDictionaryActivity(this, processTextIntent, domain)
     }
 }
 
-fun Activity.quickdicLookup(text: String) {
+fun Activity.quickdicAction(text: String) {
     val quickdicIntent: Intent = Intent().apply {
         action = "com.hughes.action.ACTION_SEARCH_DICT"
         putExtra(SearchManager.QUERY, text)
     }
-    startActivityCompat(this, quickdicIntent)
+    startDictionaryActivity(this, quickdicIntent)
 }
 
 fun Activity.openWifi() {
@@ -246,22 +246,22 @@ fun Activity.requestSpecialPermission(intent: Intent, rationale: String,
     }
 }
 
-fun Activity.searchText(text: String, domain: String? = null, title: String? = null) {
+fun Activity.searchAction(text: String, domain: String? = null) {
     val searchIntent: Intent = Intent().apply {
         action = Intent.ACTION_SEARCH
         putExtra(SearchManager.QUERY, text)
         putExtra(Intent.EXTRA_TEXT, text)
     }
-    startActivityCompat(this, searchIntent, domain, title)
+    startDictionaryActivity(this, searchIntent, domain)
 }
 
-fun Activity.sendText(text: String, domain: String? = null, title: String? = null) {
+fun Activity.sendAction(text: String, domain: String? = null) {
     val sendIntent: Intent = Intent().apply {
         action = Intent.ACTION_SEND
         putExtra(Intent.EXTRA_TEXT, text)
         type = "text/plain"
     }
-    startActivityCompat(this, sendIntent, domain, title)
+    startDictionaryActivity(this, sendIntent, domain)
 }
 
 @Suppress("DEPRECATION")
@@ -312,8 +312,7 @@ private fun getScreenSizeWithConstraints(activity: Activity): Point {
 }
 
 @SuppressLint("QueryPermissionsNeeded")
-private fun startActivityCompat(context: Context, intent: Intent,
-                                domain: String? = null, rationale: String? = null) {
+private fun startDictionaryActivity(context: Context, intent: Intent, domain: String? = null) {
     domain?.let {
         intent.setPackage(it)
         try {
@@ -325,7 +324,17 @@ private fun startActivityCompat(context: Context, intent: Intent,
         } catch (e: Exception) {
             e.printStackTrace()
         }
-    } ?: context.startActivity(Intent.createChooser(intent, rationale))
+    } ?: run {
+        startActivityCompat(context, intent)
+    }
+}
+
+private fun startActivityCompat(context: Context, intent: Intent) {
+    try {
+        context.startActivity(intent)
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
 }
 
 /* Orientation */

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2466,16 +2466,23 @@ local function run(android_app_state)
         end)
     end
 
-    android.sendText = function(text)
+    android.sendText = function(text, reason, title, mimetype)
+        if not text then return end
         JNI:context(android.app.activity.vm, function(jni)
             local _text = jni.env[0].NewStringUTF(jni.env, text)
+            local _reason = jni.env[0].NewStringUTF(jni.env, reason)
+            local _title = jni.env[0].NewStringUTF(jni.env, title)
+            local _mimetype = jni.env[0].NewStringUTF(jni.env, mimetype)
             jni:callVoidMethod(
                 android.app.activity.clazz,
                 "sendText",
-                "(Ljava/lang/String;)V",
-                _text
+                "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+                _text, _reason, _title, _mimetype
             )
             jni.env[0].DeleteLocalRef(jni.env, _text)
+            jni.env[0].DeleteLocalRef(jni.env, _reason)
+            jni.env[0].DeleteLocalRef(jni.env, _title)
+            jni.env[0].DeleteLocalRef(jni.env, _mimetype)
         end)
     end
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -64,7 +64,7 @@ complexity:
     ignoredLabels: ""
   LargeClass:
     active: true
-    threshold: 600
+    threshold: 800
   LongMethod:
     active: true
     threshold: 90


### PR DESCRIPTION
Intended to fix https://github.com/koreader/koreader/issues/9178

Since I needed to write a new function for generic sendText I implemented @uroybd request at
https://github.com/koreader/koreader/pull/9153#issuecomment-1143857139

Needs a minor change in the frontend:

```diff
diff --git a/frontend/apps/reader/modules/readerhighlight.lua b/frontend/apps/reader/modules/readerhighlight.lua
index 5f439ee6..344bdf12 100644
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -179,7 +179,7 @@ function ReaderHighlight:init()
                     local text = cleanupSelectedText(_self.selected_text.text)
                     -- call self:onClose() before calling the android framework
                     _self:onClose()
-                    Device.doShareText(text)
+                    Device:doShareText(text)
                 end,
             }
         end)
diff --git a/frontend/device/android/device.lua b/frontend/device/android/device.lua
index 3bd181b2..c7895279 100644
--- a/frontend/device/android/device.lua
+++ b/frontend/device/android/device.lua
@@ -97,7 +97,9 @@ local Device = Generic:new{
     hasExternalSD = function() return android.getExternalSdPath() end,
     importFile = function(path) android.importFile(path) end,
     canShareText = yes,
-    doShareText = function(text) android.sendText(text) end,
+    doShareText = function(self, text, reason, title, mimetype)
+        android.sendText(text, reason or _("Share text"), title, mimetype)
+    end,
 
     canExternalDictLookup = yes,
     getExternalDictLookupList = function() return external.dicts end,
```

After that the intended way of calling the function would be something like:

```lua
Device:doShareText(text, "_(Export JSON)", "Document Title", "text/json")
```

The "reason" is shown on older android versions (prior to the quick share sheet feature) and ignored on newer ones. See screenshots:
![Screenshot_20220608_142133](https://user-images.githubusercontent.com/975883/172614976-4d2c4335-47b8-4806-9928-23035e844539.png)

![Screenshot_20220608_142140](https://user-images.githubusercontent.com/975883/172615011-5d2ab618-a999-4b33-8ebe-1751c47a92b1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/371)
<!-- Reviewable:end -->
