### PR TITLE
Add Onyx SDK lights controller, Onyx Note Air2, & Onyx Nova Air C

### DIFF
--- a/app/src/main/java/org/koreader/launcher/TestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/TestActivity.kt
@@ -17,6 +17,7 @@ import org.koreader.launcher.device.epd.RK3026EPDController
 import org.koreader.launcher.device.epd.RK3368EPDController
 import org.koreader.launcher.device.epd.TolinoEPDController
 import org.koreader.launcher.device.lights.OnyxC67Controller
+import org.koreader.launcher.device.lights.OnyxSdkLightsController
 import org.koreader.launcher.device.lights.OnyxWarmthController
 import org.koreader.launcher.device.lights.TolinoWarmthController
 import org.koreader.launcher.dialog.LightDialog
@@ -61,6 +62,7 @@ class TestActivity: AppCompatActivity() {
 
         // Lights drivers
         lightsMap["Onyx C67"] = OnyxC67Controller()
+        lightsMap["Onyx SDK (lights)"] = OnyxSdkLightsController()
         lightsMap["Onyx (warmth)"] = OnyxWarmthController()
         lightsMap["Tolino (warmth)"] = TolinoWarmthController()
 

--- a/app/src/main/java/org/koreader/launcher/TestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/TestActivity.kt
@@ -54,15 +54,15 @@ class TestActivity: AppCompatActivity() {
         }
 
         // EPD drivers
-        epdMap["Rockchip RK3368"] = RK3368EPDController()
-        epdMap["Rockchip RK3026"] = RK3026EPDController()
-        epdMap["Freescale/NTX"] = TolinoEPDController()
         epdMap["Onyx/Qualcomm"] = OnyxEPDController()
+        epdMap["Rockchip RK3026"] = RK3026EPDController()
+        epdMap["Rockchip RK3368"] = RK3368EPDController()
+        epdMap["Freescale/NTX"] = TolinoEPDController()
 
         // Lights drivers
-        lightsMap["Tolino (warmth)"] = TolinoWarmthController()
-        lightsMap["Onyx (warmth)"] = OnyxWarmthController()
         lightsMap["Onyx C67"] = OnyxC67Controller()
+        lightsMap["Onyx (warmth)"] = OnyxWarmthController()
+        lightsMap["Tolino (warmth)"] = TolinoWarmthController()
 
         // Device ID
         binding.info.append("Manufacturer: ${DeviceInfo.MANUFACTURER}\n")

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -59,11 +59,13 @@ object DeviceInfo {
         ONYX_NOTE3,
         ONYX_NOTE5,
         ONYX_NOTE_AIR,
+        ONYX_NOTE_AIR2,
         ONYX_NOTE_PRO,
         ONYX_NOVA2,
         ONYX_NOVA3,
         ONYX_NOVA3_COLOR,
         ONYX_NOVA_AIR,
+        ONYX_NOVA_AIR_C,
         ONYX_POKE3,
         ONYX_POKE_PRO,
         TOLINO
@@ -78,10 +80,12 @@ object DeviceInfo {
         ONYX_LEAF,
         ONYX_NOTE3,
         ONYX_NOTE_AIR,
+        ONYX_NOTE_AIR2,
         ONYX_NOTE_PRO,
         ONYX_NOVA2,
         ONYX_NOVA3,
         ONYX_NOVA_AIR,
+        ONYX_NOVA_AIR_C,
         ONYX_POKE3,
         ONYX_POKE_PRO,
         TOLINO_EPOS
@@ -135,11 +139,13 @@ object DeviceInfo {
     private val ONYX_NOTE3: Boolean
     private val ONYX_NOTE5: Boolean
     private val ONYX_NOTE_AIR: Boolean
+    private val ONYX_NOTE_AIR2: Boolean
     private val ONYX_NOTE_PRO: Boolean
     private val ONYX_NOVA2: Boolean
     private val ONYX_NOVA3: Boolean
     private val ONYX_NOVA3_COLOR: Boolean
     private val ONYX_NOVA_AIR: Boolean
+    private val ONYX_NOVA_AIR_C: Boolean
     private val ONYX_POKE2: Boolean
     private val ONYX_POKE3: Boolean
     private val ONYX_POKE_PRO: Boolean
@@ -298,6 +304,11 @@ object DeviceInfo {
             && PRODUCT.contentEquals("noteair")
             && DEVICE.contentEquals("noteair")
 
+        // Onyx Note Air 2
+        ONYX_NOTE_AIR2 = BRAND.contentEquals("onyx")
+            && PRODUCT.contentEquals("noteair2")
+            && MODEL.contentEquals("noteair2")
+
         // Onyx Note Pro
         ONYX_NOTE_PRO = MANUFACTURER.contentEquals("onyx")
             && PRODUCT.contentEquals("notepro")
@@ -320,6 +331,10 @@ object DeviceInfo {
         // Onyx Nova Air
         ONYX_NOVA_AIR = MANUFACTURER.contentEquals("onyx")
             && MODEL.contentEquals("novaair")
+
+        // Onyx Nova Air C
+        ONYX_NOVA_AIR_C = BRAND.contentEquals("onyx")
+            && MODEL.contentEquals("novaairc")
 
         // Onyx Poke 2
         ONYX_POKE2 = MANUFACTURER.contentEquals("onyx")
@@ -398,11 +413,13 @@ object DeviceInfo {
         deviceMap[EinkDevice.ONYX_NOTE3] = ONYX_NOTE3
         deviceMap[EinkDevice.ONYX_NOTE5] = ONYX_NOTE5
         deviceMap[EinkDevice.ONYX_NOTE_AIR] = ONYX_NOTE_AIR
+        deviceMap[EinkDevice.ONYX_NOTE_AIR2] = ONYX_NOTE_AIR2
         deviceMap[EinkDevice.ONYX_NOTE_PRO] = ONYX_NOTE_PRO
         deviceMap[EinkDevice.ONYX_NOVA2] = ONYX_NOVA2
         deviceMap[EinkDevice.ONYX_NOVA3] = ONYX_NOVA3
         deviceMap[EinkDevice.ONYX_NOVA3_COLOR] = ONYX_NOVA3_COLOR
         deviceMap[EinkDevice.ONYX_NOVA_AIR] = ONYX_NOVA_AIR
+        deviceMap[EinkDevice.ONYX_NOVA_AIR_C] = ONYX_NOVA_AIR_C
         deviceMap[EinkDevice.ONYX_POKE3] = ONYX_POKE3
         deviceMap[EinkDevice.ONYX_POKE_PRO] = ONYX_POKE_PRO
         deviceMap[EinkDevice.TOLINO] = TOLINO
@@ -425,9 +442,11 @@ object DeviceInfo {
         lightsMap[LightsDevice.ONYX_KON_TIKI2] = ONYX_KON_TIKI2
         lightsMap[LightsDevice.ONYX_NOTE3] = ONYX_NOTE3
         lightsMap[LightsDevice.ONYX_NOTE_AIR] = ONYX_NOTE_AIR
+        lightsMap[LightsDevice.ONYX_NOTE_AIR2] = ONYX_NOTE_AIR2
         lightsMap[LightsDevice.ONYX_NOVA2] = ONYX_NOVA2
         lightsMap[LightsDevice.ONYX_NOVA3] = ONYX_NOVA3
         lightsMap[LightsDevice.ONYX_NOVA_AIR] = ONYX_NOVA_AIR
+        lightsMap[LightsDevice.ONYX_NOVA_AIR_C] = ONYX_NOVA_AIR_C
         lightsMap[LightsDevice.ONYX_POKE_PRO] = ONYX_POKE_PRO
         lightsMap[LightsDevice.TOLINO_EPOS] = TOLINO_EPOS
 
@@ -469,7 +488,8 @@ object DeviceInfo {
 
         HAS_COLOR_SCREEN = when (EINK) {
             EinkDevice.NONE,
-            EinkDevice.ONYX_NOVA3_COLOR -> true
+            EinkDevice.ONYX_NOVA3_COLOR,
+            EinkDevice.ONYX_NOVA_AIR_C -> true
             else -> false
         }
     }

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -74,6 +74,7 @@ object DeviceInfo {
         ONYX_C67,
         ONYX_DARWIN7,
         ONYX_FAUST3,
+        ONYX_KON_TIKI2,
         ONYX_LEAF,
         ONYX_NOTE3,
         ONYX_NOTE_AIR,
@@ -81,7 +82,6 @@ object DeviceInfo {
         ONYX_NOVA2,
         ONYX_NOVA3,
         ONYX_NOVA_AIR,
-        ONYX_KON_TIKI2,
         ONYX_POKE3,
         ONYX_POKE_PRO,
         TOLINO_EPOS
@@ -248,55 +248,70 @@ object DeviceInfo {
             && (MODEL.contentEquals("bnrv510") || MODEL.contentEquals("bnrv520") || MODEL.contentEquals("bnrv700")
             || MODEL.contentEquals("evk_mx6sl") || MODEL.startsWith("ereader"))
 
-        // Onyx Leaf
-        ONYX_LEAF = (MANUFACTURER.contentEquals("onyx")
-            && PRODUCT.contentEquals("leaf")
-            && DEVICE.contentEquals("leaf"))
+        // Onyx C67
+        ONYX_C67 = MANUFACTURER.contentEquals("onyx")
+            && (PRODUCT.startsWith("c67") || MODEL.contentEquals("rk30sdk"))
+            && DEVICE.startsWith("c67")
 
-        // Onyx Max
-        ONYX_MAX = (MANUFACTURER.contentEquals("onyx")
-            && PRODUCT.contentEquals("max")
-            && DEVICE.contentEquals("max"))
-
-        // Onyx Note
-        ONYX_NOTE = (MANUFACTURER.contentEquals("onyx")
-            && PRODUCT.contentEquals("note")
-            && DEVICE.contentEquals("note"))
-
-        // Onyx Note 3
-        ONYX_NOTE3 = (MANUFACTURER.contentEquals("onyx")
-            && PRODUCT.contentEquals("note3")
-            && DEVICE.contentEquals("note3"))
-
-        // Onyx Note 5
-        ONYX_NOTE5 = (BRAND.contentEquals("onyx")
-            && PRODUCT.contentEquals("note5")
-            && DEVICE.contentEquals("note5"))
-
-        // Onyx Note Air
-        ONYX_NOTE_AIR = (MANUFACTURER.contentEquals("onyx")
-            && PRODUCT.contentEquals("noteair")
-            && DEVICE.contentEquals("noteair"))
-
-        // Onyx Note Pro
-        ONYX_NOTE_PRO = (MANUFACTURER.contentEquals("onyx")
-            && PRODUCT.contentEquals("notepro")
-            && DEVICE.contentEquals("notepro"))
+        // ONYX DARWIN 7
+        ONYX_DARWIN7 = MANUFACTURER.contentEquals("onyx")
+            && PRODUCT.contentEquals("mc_darwin7")
+            && DEVICE.contentEquals("mc_darwin7")
 
         // Onyx Faust 3
-        ONYX_FAUST3 = (MANUFACTURER.contentEquals("onyx")
+        ONYX_FAUST3 = MANUFACTURER.contentEquals("onyx")
             && PRODUCT.contentEquals("mc_faust3")
-            && DEVICE.contentEquals("mc_faust3"))
+            && DEVICE.contentEquals("mc_faust3")
+
+        // Onyx Kon-Tiki 2
+        ONYX_KON_TIKI2 = MANUFACTURER.contentEquals("onyx")
+            && PRODUCT.contentEquals("kon_tiki2")
+            && DEVICE.contentEquals("kon_tiki2")
+
+        // Onyx Leaf
+        ONYX_LEAF = MANUFACTURER.contentEquals("onyx")
+            && PRODUCT.contentEquals("leaf")
+            && DEVICE.contentEquals("leaf")
+
+        // Onyx Max
+        ONYX_MAX = MANUFACTURER.contentEquals("onyx")
+            && PRODUCT.contentEquals("max")
+            && DEVICE.contentEquals("max")
+
+        // Onyx Note
+        ONYX_NOTE = MANUFACTURER.contentEquals("onyx")
+            && PRODUCT.contentEquals("note")
+            && DEVICE.contentEquals("note")
+
+        // Onyx Note 3
+        ONYX_NOTE3 = MANUFACTURER.contentEquals("onyx")
+            && PRODUCT.contentEquals("note3")
+            && DEVICE.contentEquals("note3")
+
+        // Onyx Note 5
+        ONYX_NOTE5 = BRAND.contentEquals("onyx")
+            && PRODUCT.contentEquals("note5")
+            && DEVICE.contentEquals("note5")
+
+        // Onyx Note Air
+        ONYX_NOTE_AIR = MANUFACTURER.contentEquals("onyx")
+            && PRODUCT.contentEquals("noteair")
+            && DEVICE.contentEquals("noteair")
+
+        // Onyx Note Pro
+        ONYX_NOTE_PRO = MANUFACTURER.contentEquals("onyx")
+            && PRODUCT.contentEquals("notepro")
+            && DEVICE.contentEquals("notepro")
 
         // Onyx Nova 2
-        ONYX_NOVA2 = (MANUFACTURER.contentEquals("onyx")
+        ONYX_NOVA2 = MANUFACTURER.contentEquals("onyx")
             && PRODUCT.contentEquals("nova2")
-            && DEVICE.contentEquals("nova2"))
+            && DEVICE.contentEquals("nova2")
 
         // Onyx Nova 3
-        ONYX_NOVA3 = (MANUFACTURER.contentEquals("onyx")
+        ONYX_NOVA3 = MANUFACTURER.contentEquals("onyx")
             && PRODUCT.contentEquals("nova3")
-            && DEVICE.contentEquals("nova3"))
+            && DEVICE.contentEquals("nova3")
 
         // Onyx Nova 3 Color
         ONYX_NOVA3_COLOR = MANUFACTURER.contentEquals("onyx")
@@ -306,29 +321,14 @@ object DeviceInfo {
         ONYX_NOVA_AIR = MANUFACTURER.contentEquals("onyx")
             && MODEL.contentEquals("novaair")
 
-        // Onyx C67
-        ONYX_C67 = (MANUFACTURER.contentEquals("onyx")
-            && (PRODUCT.startsWith("c67") || MODEL.contentEquals("rk30sdk"))
-            && DEVICE.startsWith("c67"))
-
-        // ONYX DARWIN 7
-        ONYX_DARWIN7 = (MANUFACTURER.contentEquals("onyx")
-            && PRODUCT.contentEquals("mc_darwin7")
-            && DEVICE.contentEquals("mc_darwin7"))
-
-        // Onyx Kon-Tiki 2
-        ONYX_KON_TIKI2 = (MANUFACTURER.contentEquals("onyx")
-            && PRODUCT.contentEquals("kon_tiki2")
-            && DEVICE.contentEquals("kon_tiki2"))
-
         // Onyx Poke 2
         ONYX_POKE2 = MANUFACTURER.contentEquals("onyx")
             && PRODUCT.contentEquals("poke2")
 
         // Onyx Poke 3
-        ONYX_POKE3 = (MANUFACTURER.contentEquals("onyx")
+        ONYX_POKE3 = MANUFACTURER.contentEquals("onyx")
             && PRODUCT.contentEquals("poke3")
-            && DEVICE.contentEquals("poke3"))
+            && DEVICE.contentEquals("poke3")
 
         // Onyx Poke Pro
         ONYX_POKE_PRO = MANUFACTURER.contentEquals("onyx")
@@ -420,8 +420,8 @@ object DeviceInfo {
         // devices with custom lights
         val lightsMap = HashMap<LightsDevice, Boolean>()
         lightsMap[LightsDevice.ONYX_C67] = ONYX_C67
-        lightsMap[LightsDevice.ONYX_FAUST3] = ONYX_FAUST3
         lightsMap[LightsDevice.ONYX_DARWIN7] = ONYX_DARWIN7
+        lightsMap[LightsDevice.ONYX_FAUST3] = ONYX_FAUST3
         lightsMap[LightsDevice.ONYX_KON_TIKI2] = ONYX_KON_TIKI2
         lightsMap[LightsDevice.ONYX_NOTE3] = ONYX_NOTE3
         lightsMap[LightsDevice.ONYX_NOTE_AIR] = ONYX_NOTE_AIR

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -62,11 +62,13 @@ object EPDFactory {
                 DeviceInfo.EinkDevice.ONYX_NOTE3,
                 DeviceInfo.EinkDevice.ONYX_NOTE5,
                 DeviceInfo.EinkDevice.ONYX_NOTE_AIR,
+                DeviceInfo.EinkDevice.ONYX_NOTE_AIR2,
                 DeviceInfo.EinkDevice.ONYX_NOTE_PRO,
                 DeviceInfo.EinkDevice.ONYX_NOVA2,
                 DeviceInfo.EinkDevice.ONYX_NOVA3,
                 DeviceInfo.EinkDevice.ONYX_NOVA3_COLOR,
                 DeviceInfo.EinkDevice.ONYX_NOVA_AIR,
+                DeviceInfo.EinkDevice.ONYX_NOVA_AIR_C,
                 DeviceInfo.EinkDevice.ONYX_POKE3,
                 DeviceInfo.EinkDevice.ONYX_POKE_PRO -> {
                     logController("Onyx/Qualcomm")

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -17,15 +17,14 @@ object EPDFactory {
     val epdController: EPDInterface
         get() {
             return when (DeviceInfo.EINK) {
-
                 DeviceInfo.EinkDevice.BOYUE_T61,
                 DeviceInfo.EinkDevice.BOYUE_T62,
                 DeviceInfo.EinkDevice.BOYUE_T80S,
                 DeviceInfo.EinkDevice.CREMA_0650L,
-                DeviceInfo.EinkDevice.FIDIBOOK,
-                DeviceInfo.EinkDevice.ONYX_C67,
                 DeviceInfo.EinkDevice.ENERGY,
-                DeviceInfo.EinkDevice.INKBOOK -> {
+                DeviceInfo.EinkDevice.FIDIBOOK,
+                DeviceInfo.EinkDevice.INKBOOK,
+                DeviceInfo.EinkDevice.ONYX_C67 -> {
                     logController("Rockchip RK3026")
                     RK3026EPDController()
                 }
@@ -75,8 +74,8 @@ object EPDFactory {
                 }
 
                 DeviceInfo.EinkDevice.NABUK,
-                DeviceInfo.EinkDevice.ONYX_FAUST3,
-                DeviceInfo.EinkDevice.ONYX_DARWIN7 -> {
+                DeviceInfo.EinkDevice.ONYX_DARWIN7,
+                DeviceInfo.EinkDevice.ONYX_FAUST3 -> {
                     logController("Old Tolino/NTX")
                     OldTolinoEPDController()
                 }

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -20,13 +20,18 @@ object LightsFactory {
                 DeviceInfo.LightsDevice.ONYX_NOTE3,
                 DeviceInfo.LightsDevice.ONYX_NOTE_AIR,
                 DeviceInfo.LightsDevice.ONYX_NOTE_PRO,
-                DeviceInfo.LightsDevice.ONYX_NOVA2,
                 DeviceInfo.LightsDevice.ONYX_NOVA3,
                 DeviceInfo.LightsDevice.ONYX_NOVA_AIR,
                 DeviceInfo.LightsDevice.ONYX_POKE3,
                 DeviceInfo.LightsDevice.ONYX_POKE_PRO -> {
                     logController("Onyx/Qualcomm")
                     OnyxWarmthController()
+                }
+                DeviceInfo.LightsDevice.ONYX_NOTE_AIR2,
+                DeviceInfo.LightsDevice.ONYX_NOVA2,
+                DeviceInfo.LightsDevice.ONYX_NOVA_AIR_C -> {
+                    logController("Onyx/Sdk")
+                    OnyxSdkLightsController()
                 }
                 DeviceInfo.LightsDevice.ONYX_C67 -> {
                     logController("ONYX C67")

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -13,9 +13,9 @@ object LightsFactory {
                     logController("Tolino")
                     TolinoWarmthController()
                 }
-                DeviceInfo.LightsDevice.ONYX_KON_TIKI2,
                 DeviceInfo.LightsDevice.ONYX_DARWIN7,
                 DeviceInfo.LightsDevice.ONYX_FAUST3,
+                DeviceInfo.LightsDevice.ONYX_KON_TIKI2,
                 DeviceInfo.LightsDevice.ONYX_LEAF,
                 DeviceInfo.LightsDevice.ONYX_NOTE3,
                 DeviceInfo.LightsDevice.ONYX_NOTE_AIR,

--- a/app/src/main/java/org/koreader/launcher/device/lights/OnyxSdkLightsController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/OnyxSdkLightsController.kt
@@ -1,0 +1,146 @@
+package org.koreader.launcher.device.lights
+
+import android.app.Activity
+import android.util.Log
+import org.koreader.launcher.device.LightsInterface
+import android.content.Context
+import java.lang.Class.forName
+import java.lang.reflect.Method
+
+class OnyxSdkLightsController : LightsInterface {
+    companion object {
+        private const val TAG = "Lights"
+        private const val BRIGHTNESS_MAX = 255
+        private const val WARMTH_MAX = 255
+        private const val MIN = 0
+    }
+
+    override fun getPlatform(): String {
+        return "onyx-sdk-lights"
+    }
+
+    override fun hasFallback(): Boolean {
+        return false
+    }
+
+    override fun hasWarmth(): Boolean {
+        return true
+    }
+
+    override fun needsPermission(): Boolean {
+        return false
+    }
+
+    override fun getBrightness(activity: Activity): Int {
+        return FrontLight.getCold(activity)
+    }
+
+    override fun getWarmth(activity: Activity): Int {
+        return FrontLight.getWarm(activity)
+    }
+
+    override fun setBrightness(activity: Activity, brightness: Int) {
+        if (brightness < MIN || brightness > BRIGHTNESS_MAX) {
+            Log.w(TAG, "brightness value of of range: $brightness")
+            return
+        }
+        Log.v(TAG, "Setting brightness to $brightness")
+        FrontLight.setCold(brightness, activity)
+    }
+
+    override fun setWarmth(activity: Activity, warmth: Int) {
+        if (warmth < MIN || warmth > WARMTH_MAX) {
+            Log.w(TAG, "warmth value of of range: $warmth")
+            return
+        }
+        Log.v(TAG, "Setting warmth to $warmth")
+        FrontLight.setWarm(warmth, activity)
+    }
+
+    override fun getMinWarmth(): Int {
+        return MIN
+    }
+
+    override fun getMaxWarmth(): Int {
+        return WARMTH_MAX
+    }
+
+    override fun getMinBrightness(): Int {
+        return MIN
+    }
+
+    override fun getMaxBrightness(): Int {
+        return BRIGHTNESS_MAX
+    }
+
+    override fun enableFrontlightSwitch(activity: Activity): Int {
+        return 1
+    }
+}
+
+object FrontLight {
+    private const val TAG = "lights"
+
+    private val flController: Class<*>? = try {
+        forName("android.onyx.hardware.DeviceController")
+    } catch (e: Exception) {
+        Log.w(TAG, "$e")
+        null
+    }
+
+    private val setWarmBrightness: Method? = try {
+        flController!!.getMethod("setWarmLightDeviceValue", Context::class.java, Integer.TYPE)
+    } catch (e: Exception) {
+        Log.w(TAG, "$e")
+        null
+    }
+    private val setColdBrightness: Method? = try {
+        flController!!.getMethod("setColdLightDeviceValue", Context::class.java, Integer.TYPE)
+    } catch (e: Exception) {
+        Log.w(TAG, "$e")
+        null
+    }
+
+    private val getCoolWarmBrightness: Method? = try {
+        flController!!.getMethod("getBrightnessConfig", Context::class.java, Integer.TYPE)
+    } catch (e: Exception) {
+        Log.w(TAG, "$e")
+        null
+    }
+    private const val BRIGHTNESS_CONFIG_WARM_IDX: Int = 2
+    private const val BRIGHTNESS_CONFIG_COLD_IDX: Int = 3
+
+    fun getWarm(context: Context?): Int {
+        return try {
+            getCoolWarmBrightness!!.invoke(flController!!, context, BRIGHTNESS_CONFIG_WARM_IDX) as Int
+        } catch (e: Exception) {
+            e.printStackTrace()
+            0
+        }
+    }
+
+    fun getCold(context: Context?): Int {
+        return try {
+            getCoolWarmBrightness!!.invoke(flController!!, context, BRIGHTNESS_CONFIG_COLD_IDX) as Int
+        } catch (e: Exception) {
+            e.printStackTrace()
+            0
+        }
+    }
+
+    fun setWarm(value: Int, context: Context?) {
+        try {
+            setWarmBrightness!!.invoke(flController!!, context, value)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    fun setCold(value: Int, context: Context?) {
+        try {
+            setColdBrightness!!.invoke(flController!!, context, value)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #342. When classes or methods don't exist, KOReader doesn't crash, addressing koreader/koreader#8584.

Tested on an Onyx Nova Air C. cc/ @bezmi @Galunid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/372)
<!-- Reviewable:end -->
