### PR TITLE
Strict

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -129,6 +129,4 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_plugin_version"
     implementation "org.apache.commons:commons-compress:$commons_compress_version"
 
-    // add Leak Canary on debug variants.
-    debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakcanary_version"
 }

--- a/app/src/main/java/org/koreader/launcher/MainApp.kt
+++ b/app/src/main/java/org/koreader/launcher/MainApp.kt
@@ -107,9 +107,13 @@ class MainApp : MultiDexApplication() {
         }
 
         if (is_debug) {
-            // detect and log any potential issue within the vm.
-            val threadPolicy = StrictMode.ThreadPolicy.Builder().detectAll().penaltyLog().build()
-            val vmPolicy = StrictMode.VmPolicy.Builder().detectAll().penaltyLog().build()
+            val threadPolicy = StrictMode.ThreadPolicy.Builder().detectCustomSlowCalls()
+                .penaltyLog().build()
+
+            val vmPolicy = StrictMode.VmPolicy.Builder().detectActivityLeaks()
+                .detectLeakedClosableObjects()
+                .penaltyLog().build()
+
             StrictMode.setThreadPolicy(threadPolicy)
             StrictMode.setVmPolicy(vmPolicy)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
     ext.androidx_supportv4_version = '1.0.0'
     ext.android_desugar_jdk = '1.1.5'
     ext.commons_compress_version = '1.20'
-    ext.leakcanary_version = '2.7'
 
     repositories {
         google()


### PR DESCRIPTION
Changes in debug buildvariant

1. remove leakcanary:  only covers JVM code and didn't report a single memory leak in the last 2-3 years.
2. reduce strictmode penalty log categories to those that are actually useful:
2.1 slow calls: slow code paths on UiThread
2.2 potential leaks: closable objects and activity context

FWIW: I use this paired with the removal of https://github.com/koreader/koreader/blob/master/platform/android/llapp_main.lua#L24-L25 to test platform changes locally.

Also interesting when building for targetSdk > 28 is add nonsdk usage. We're clear ATM (targetSdk:30). Device drivers using reflection might trigger some logs but those need to be handled at the system/firmware level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/379)
<!-- Reviewable:end -->
