### PR TITLE
Add support for setting Warmth for Tolino with `ntx_io`

### DIFF
--- a/app/src/main/java/org/koreader/launcher/TestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/TestActivity.kt
@@ -21,6 +21,7 @@ import org.koreader.launcher.device.lights.OnyxColorController
 import org.koreader.launcher.device.lights.OnyxSdkLightsController
 import org.koreader.launcher.device.lights.OnyxWarmthController
 import org.koreader.launcher.device.lights.TolinoWarmthController
+import org.koreader.launcher.device.lights.TolinoVision5WarmthController
 import org.koreader.launcher.dialog.LightDialog
 
 class TestActivity: AppCompatActivity() {
@@ -67,6 +68,7 @@ class TestActivity: AppCompatActivity() {
         lightsMap["Onyx SDK (lights)"] = OnyxSdkLightsController()
         lightsMap["Onyx (warmth)"] = OnyxWarmthController()
         lightsMap["Tolino (warmth)"] = TolinoWarmthController()
+        lightsMap["Tolino Vision5 (warmth)"] = TolinoVision5WarmthController()
 
         // Device ID
         binding.info.append("Manufacturer: ${DeviceInfo.MANUFACTURER}\n")

--- a/app/src/main/java/org/koreader/launcher/TestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/TestActivity.kt
@@ -20,8 +20,8 @@ import org.koreader.launcher.device.lights.OnyxC67Controller
 import org.koreader.launcher.device.lights.OnyxColorController
 import org.koreader.launcher.device.lights.OnyxSdkLightsController
 import org.koreader.launcher.device.lights.OnyxWarmthController
-import org.koreader.launcher.device.lights.TolinoWarmthController
-import org.koreader.launcher.device.lights.TolinoVision5WarmthController
+import org.koreader.launcher.device.lights.TolinoRootController
+import org.koreader.launcher.device.lights.TolinoNtxController
 import org.koreader.launcher.dialog.LightDialog
 
 class TestActivity: AppCompatActivity() {
@@ -67,8 +67,8 @@ class TestActivity: AppCompatActivity() {
         lightsMap["Onyx Color"] = OnyxColorController()
         lightsMap["Onyx SDK (lights)"] = OnyxSdkLightsController()
         lightsMap["Onyx (warmth)"] = OnyxWarmthController()
-        lightsMap["Tolino (warmth)"] = TolinoWarmthController()
-        lightsMap["Tolino Vision5 (warmth)"] = TolinoVision5WarmthController()
+        lightsMap["Tolino Root"] = TolinoRootController()
+        lightsMap["Tolino Ntx"] = TolinoNtxController()
 
         // Device ID
         binding.info.append("Manufacturer: ${DeviceInfo.MANUFACTURER}\n")

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -95,7 +95,8 @@ object DeviceInfo {
         ONYX_POKE3,
         ONYX_POKE4,
         ONYX_POKE_PRO,
-        TOLINO_EPOS
+        TOLINO_EPOS,
+        TOLINO_VISION5
     }
 
     enum class QuirkDevice {
@@ -163,6 +164,7 @@ object DeviceInfo {
     private val SONY_RP1: Boolean
     private val TOLINO: Boolean
     private val TOLINO_EPOS: Boolean
+    private val TOLINO_VISION5: Boolean
 
     init {
         MANUFACTURER = lowerCase(getBuildField("MANUFACTURER"))
@@ -385,6 +387,12 @@ object DeviceInfo {
             && MODEL.contentEquals("tolino")
             && DEVICE.contentEquals("ntx_6sl")
 
+        // Tolino Vision 5 also has warmth lights, but with ntx_io file
+        TOLINO_VISION5 = BRAND.contentEquals("rakutenkobo")
+            && MODEL.contentEquals("tolino")
+            && DEVICE.contentEquals("ntx_6sl")
+            && HARDWARE.contentEquals("e70k00")
+
         // devices with known bugs
         val bugMap = HashMap<QuirkDevice, Boolean>()
         bugMap[QuirkDevice.EMULATOR] = EMULATOR_X86
@@ -479,6 +487,7 @@ object DeviceInfo {
         lightsMap[LightsDevice.ONYX_POKE4] = ONYX_POKE4
         lightsMap[LightsDevice.ONYX_POKE_PRO] = ONYX_POKE_PRO
         lightsMap[LightsDevice.TOLINO_EPOS] = TOLINO_EPOS
+        lightsMap[LightsDevice.TOLINO_VISION5] = TOLINO_VISION5
 
         lightsMap.keys.iterator().run {
             while (this.hasNext()) {

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -386,6 +386,7 @@ object DeviceInfo {
         TOLINO_EPOS = BRAND.contentEquals("rakutenkobo")
             && MODEL.contentEquals("tolino")
             && DEVICE.contentEquals("ntx_6sl")
+            && !HARDWARE.contentEquals("e70k00")
 
         // Tolino Vision 5 also has warmth lights, but with ntx_io file
         TOLINO_VISION5 = BRAND.contentEquals("rakutenkobo")

--- a/app/src/main/java/org/koreader/launcher/device/Ioctl.kt
+++ b/app/src/main/java/org/koreader/launcher/device/Ioctl.kt
@@ -29,7 +29,7 @@ open class Ioctl {
             Log.v(tag, "$device: ioctl ok, code $status")
             true
         } else {
-            val err = when(abs(status)) {
+            val err = when (abs(status)) {
                 ENOENT -> "no such file or directory"
                 EBADF -> "bad file number"
                 EACCES -> "permission denied"

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -13,6 +13,10 @@ object LightsFactory {
                     logController("Tolino")
                     TolinoWarmthController()
                 }
+                DeviceInfo.LightsDevice.TOLINO_VISION5 -> {
+                    logController("Tolino")
+                    TolinoVision5WarmthController()
+                }
                 DeviceInfo.LightsDevice.ONYX_DARWIN7,
                 DeviceInfo.LightsDevice.ONYX_FAUST3,
                 DeviceInfo.LightsDevice.ONYX_KON_TIKI2,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -10,11 +10,11 @@ object LightsFactory {
         get() {
             return when (DeviceInfo.LIGHTS) {
                 DeviceInfo.LightsDevice.TOLINO_EPOS -> {
-                    logController("Tolino")
+                    logController("TolinoRoot")
                     TolinoRootController()
                 }
                 DeviceInfo.LightsDevice.TOLINO_VISION5 -> {
-                    logController("Tolino")
+                    logController("TolinoNTX")
                     TolinoNtxController()
                 }
                 DeviceInfo.LightsDevice.ONYX_DARWIN7,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -11,11 +11,11 @@ object LightsFactory {
             return when (DeviceInfo.LIGHTS) {
                 DeviceInfo.LightsDevice.TOLINO_EPOS -> {
                     logController("Tolino")
-                    TolinoWarmthController()
+                    TolinoRootController()
                 }
                 DeviceInfo.LightsDevice.TOLINO_VISION5 -> {
                     logController("Tolino")
-                    TolinoVision5WarmthController()
+                    TolinoNtxController()
                 }
                 DeviceInfo.LightsDevice.ONYX_DARWIN7,
                 DeviceInfo.LightsDevice.ONYX_FAUST3,

--- a/app/src/main/java/org/koreader/launcher/device/lights/TolinoNtxController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/TolinoNtxController.kt
@@ -11,10 +11,10 @@ import java.io.File
 /* Special controller for Tolino Vision5
  * see https://github.com/koreader/android-luajit-launcher/pull/382
  *
- * Original Controller by @zwim, see "./TolinoWarmthController.kt"
+ * Original Controller by @zwim, see "./TolinoRootController.kt"
  */
 
-class TolinoVision5WarmthController : Ioctl(), LightsInterface {
+class TolinoNtxController : Ioctl(), LightsInterface {
 
     companion object {
         private const val TAG = "Lights"

--- a/app/src/main/java/org/koreader/launcher/device/lights/TolinoRootController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/TolinoRootController.kt
@@ -14,7 +14,7 @@ import java.io.File
  * Thanks to @zwim
  */
 
-class TolinoWarmthController : LightsInterface {
+class TolinoRootController : LightsInterface {
     companion object {
         private const val TAG = "Lights"
         private const val BRIGHTNESS_MAX = 255

--- a/app/src/main/java/org/koreader/launcher/device/lights/TolinoVision5WarmthController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/TolinoVision5WarmthController.kt
@@ -19,7 +19,7 @@ class TolinoVision5WarmthController : Ioctl(), LightsInterface {
     companion object {
         private const val TAG = "Lights"
         private const val BRIGHTNESS_MAX = 255
-        private const val WARMTH_MAX = 10
+        private const val WARMTH_MAX = 10 // can also be read by ""/sys/class/backlight/lm3630a_led/max_color" on Vision5
         private const val MIN = 0
         private const val NTX_IO_FILE = "/dev/ntx_io"
         private const val NTX_WARMTH_ID = 248

--- a/app/src/main/java/org/koreader/launcher/device/lights/TolinoVision5WarmthController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/TolinoVision5WarmthController.kt
@@ -19,7 +19,7 @@ class TolinoVision5WarmthController : Ioctl(), LightsInterface {
     companion object {
         private const val TAG = "Lights"
         private const val BRIGHTNESS_MAX = 255
-        private const val WARMTH_MAX = 10 // can also be read by ""/sys/class/backlight/lm3630a_led/max_color" on Vision5
+        private const val WARMTH_MAX = 10 // can also be read by "/sys/class/backlight/lm3630a_led/max_color" on Vision5
         private const val MIN = 0
         private const val NTX_IO_FILE = "/dev/ntx_io"
         private const val NTX_WARMTH_ID = 248

--- a/app/src/main/java/org/koreader/launcher/device/lights/TolinoVision5WarmthController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/TolinoVision5WarmthController.kt
@@ -8,10 +8,10 @@ import org.koreader.launcher.device.LightsInterface
 import org.koreader.launcher.extensions.read
 import java.io.File
 
-/* Special controller for Tolino Epos/Epos2.
- * see https://github.com/koreader/koreader/pull/6332
+/* Special controller for Tolino Vision5
+ * see https://github.com/koreader/android-luajit-launcher/pull/382
  *
- * Thanks to @zwim
+ * Original Controller by @zwim, see "./TolinoWarmthController.kt"
  */
 
 class TolinoVision5WarmthController : Ioctl(), LightsInterface {

--- a/app/src/main/java/org/koreader/launcher/device/lights/TolinoVision5WarmthController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/TolinoVision5WarmthController.kt
@@ -26,6 +26,7 @@ class TolinoVision5WarmthController : Ioctl(), LightsInterface {
         private const val COLOR_FILE = "/sys/class/backlight/lm3630a_led/color" // only readable by "system" in Vision5
     }
 
+    // store the current warmth value, because in some models (Vision5) it cannot be fetched
     private var currentWarmth: Int? = null
 
     override fun getPlatform(): String {


### PR DESCRIPTION
This PR adds support in `TolinoWarmthController.kt` to use `/dev/ntx_io` to set the Warmth

fixes #351
~~requires https://github.com/koreader/koreader/pull/9511~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/382)
<!-- Reviewable:end -->
