### PR TITLE
export device properties

### DIFF
--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -18,6 +18,7 @@ interface LuaInterface {
     fun extractAssets(): Boolean
     fun getBatteryLevel(): Int
     fun getClipboardText(): String
+    fun getDeviceProperties(): String
     fun getEinkConstants(): String
     fun getEinkPlatform(): String
     fun getExternalPath(): String
@@ -29,7 +30,6 @@ interface LuaInterface {
     fun getName(): String
     fun getNetworkInfo(): String
     fun getPlatformName(): String
-    fun getProduct(): String
     fun getScreenAvailableHeight(): Int
     fun getScreenAvailableWidth(): Int
     fun getScreenBrightness(): Int

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -361,6 +361,10 @@ class MainActivity : NativeActivity(), LuaInterface,
         }
     }
 
+    override fun getDeviceProperties(): String {
+        return device.properties
+    }
+
     override fun getEinkConstants(): String {
         return String.format(Locale.US, "%d;%d;%d;%d;%d;%d;%d;%d",
             device.epd.getWaveformFull(),
@@ -417,10 +421,6 @@ class MainActivity : NativeActivity(), LuaInterface,
 
     override fun getPlatformName(): String {
         return platform
-    }
-
-    override fun getProduct(): String {
-        return device.product
     }
 
     override fun getScreenAvailableHeight(): Int {

--- a/app/src/main/java/org/koreader/launcher/device/Device.kt
+++ b/app/src/main/java/org/koreader/launcher/device/Device.kt
@@ -41,4 +41,15 @@ class Device(activity: Activity) {
             platform
         }
     }
+
+    val properties: String
+      get() = String.format("%s;%s;%s;%s;%s;%s;%b;%b",
+          DeviceInfo.MANUFACTURER,
+          DeviceInfo.BRAND,
+          DeviceInfo.MODEL,
+          DeviceInfo.DEVICE,
+          DeviceInfo.PRODUCT,
+          DeviceInfo.HARDWARE,
+          DeviceInfo.BOYUE,
+          DeviceInfo.TOLINO)
 }

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -113,8 +113,10 @@ object DeviceInfo {
     internal var LIGHTS = LightsDevice.NONE
     private var QUIRK = QuirkDevice.NONE
 
+    internal val BOYUE: Boolean
+    internal val TOLINO: Boolean
+
     // device probe
-    private val IS_BOYUE: Boolean
     private val BOYUE_K78W: Boolean
     private val BOYUE_K103: Boolean
     private val BOYUE_P6: Boolean
@@ -161,7 +163,6 @@ object DeviceInfo {
     private val ONYX_POKE_PRO: Boolean
     private val SONY_CP1: Boolean
     private val SONY_RP1: Boolean
-    private val TOLINO: Boolean
     private val TOLINO_EPOS: Boolean
 
     init {
@@ -171,57 +172,52 @@ object DeviceInfo {
         DEVICE = lowerCase(getBuildField("DEVICE"))
         PRODUCT = lowerCase(getBuildField("PRODUCT"))
         HARDWARE = lowerCase(getBuildField("HARDWARE"))
-        IS_BOYUE = MANUFACTURER.contentEquals("boeye")
+        BOYUE = MANUFACTURER.contentEquals("boeye")
             || MANUFACTURER.contentEquals("boyue")
 
         // Boyue Likebook Ares
-        BOYUE_K78W = IS_BOYUE
+        BOYUE_K78W = BOYUE
             && (PRODUCT.contentEquals("k78w") || PRODUCT.contentEquals("ares"))
 
         // Boyue Likebook Alita
-        BOYUE_K103 = IS_BOYUE
+        BOYUE_K103 = BOYUE
             && (PRODUCT.contentEquals("k103") || PRODUCT.contentEquals("alita"))
 
         // Boyue Likebook P6
-        BOYUE_P6 = IS_BOYUE
-            && PRODUCT.contentEquals("p6")
+        BOYUE_P6 = BOYUE && PRODUCT.contentEquals("p6")
 
         // Boyue Lemon
-        BOYUE_P61 = IS_BOYUE
-            && PRODUCT.contentEquals("p61-k12-l")
+        BOYUE_P61 = BOYUE && PRODUCT.contentEquals("p61-k12-l")
 
         // Boyue Likebook P78
-        BOYUE_P78 = IS_BOYUE
-            && PRODUCT.contentEquals("p78")
+        BOYUE_P78 = BOYUE && PRODUCT.contentEquals("p78")
 
         // Boyue T61
-        BOYUE_T61 = (IS_BOYUE
+        BOYUE_T61 = (BOYUE
             && (PRODUCT.startsWith("t61") || MODEL.contentEquals("rk30sdk"))
             && DEVICE.startsWith("t61"))
 
         // Boyue T62
-        BOYUE_T62 = (IS_BOYUE
+        BOYUE_T62 = (BOYUE
             && (PRODUCT.startsWith("t62") || MODEL.contentEquals("rk30sdk"))
             && DEVICE.startsWith("t62"))
 
         // Boyue/JDRead T65S
-        BOYUE_T65S = IS_BOYUE
-            && PRODUCT.contentEquals("t65s")
+        BOYUE_T65S = BOYUE && PRODUCT.contentEquals("t65s")
 
         // Boyue Likebook Muses
-        BOYUE_T78D = IS_BOYUE
+        BOYUE_T78D = BOYUE
             && (PRODUCT.contentEquals("t78d") || PRODUCT.contentEquals("muses"))
 
         // Boyue Likebook Mars
-        BOYUE_T80D = IS_BOYUE
+        BOYUE_T80D = BOYUE
             && (PRODUCT.contentEquals("t80d") || PRODUCT.contentEquals("mars"))
 
         // Boyue Likebook Plus
-        BOYUE_T80S = IS_BOYUE
-            && PRODUCT.contentEquals("t80s")
+        BOYUE_T80S = BOYUE && PRODUCT.contentEquals("t80s")
 
         // Boyue Likebook Mimas
-        BOYUE_T103D = IS_BOYUE
+        BOYUE_T103D = BOYUE
             && (PRODUCT.contentEquals("t103d") || PRODUCT.contentEquals("mimas"))
 
         // Crema Note (1010P)

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1635,19 +1635,6 @@ local function run(android_app_state)
         end)
     end
 
-    --- Device identification.
-    -- @treturn string product
-    android.getProduct = function()
-        return JNI:context(android.app.activity.vm, function(jni)
-            local product = jni:callObjectMethod(
-                android.app.activity.clazz,
-                "getProduct",
-                "()Ljava/lang/String;"
-            )
-            return jni:to_string(product) or "unknown"
-        end)
-    end
-
     android.getVersion =  function()
         return JNI:context(android.app.activity.vm, function(jni)
             local version = jni:callObjectMethod(
@@ -1873,8 +1860,29 @@ local function run(android_app_state)
         end)
     end
 
+    local manufacturer, brand, model, device, product, hardware, is_boyue, is_tolino =
+        JNI:context(android.app.activity.vm, function(jni)
+            local properties = jni:callObjectMethod(
+                android.app.activity.clazz,
+                "getDeviceProperties",
+                "()Ljava/lang/String;"
+            )
+
+            return string.match(jni:to_string(properties),
+                "(.*);(.*);(.*);(.*);(.*);(.*);(.*);(.*)")
+        end)
+
     -- properties that don't change during the execution of the program.
-    android.prop = {}
+    android.prop = {
+        manufacturer = manufacturer,
+        brand = brand,
+        model = model,
+        device = device,
+        product = product,
+        hardware = hardware,
+        is_boyue = is_boyue == "true",
+        is_tolino = is_tolino == "true",
+    }
 
     -- build properties
     android.prop.name = android.getName()
@@ -1883,7 +1891,6 @@ local function run(android_app_state)
     android.prop.runtimeChanges = android.supportsRuntimeChanges()
 
     -- device properties
-    android.prop.product = android.getProduct()
     android.prop.version = android.getVersion()
     android.prop.brokenLifecycle = android.hasBrokenLifecycle()
 


### PR DESCRIPTION
Same intent as #381 but exporting them all.

It makes possible to have very specific branches to workaround broken aosp devices, like

```lua
if android.prop.is_tolino then
    if android.prop.hardware ~= "whatever" or android.prop.model ~= "device" then
        -- stuff for all tolino devices except whatever/device
    end
end
```

exports manufacturer, brand, device, model, product and hardware as strings and boolean values for `is_tolino` and `is_boyue` as both brands use some non AOSP keycodes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/383)
<!-- Reviewable:end -->
