### PR TITLE
restore global exclude paths

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -4,3 +4,6 @@ engines:
     exclude_paths:
       - "app/src/main/java/org/koreader/launcher/device/epd/**"
       - "app/src/main/java/org/koreader/launcher/device/lights/**"
+
+exclude_paths:
+  - "jni/**"


### PR DESCRIPTION
as they were with web config, missing since https://github.com/koreader/android-luajit-launcher/pull/384

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/385)
<!-- Reviewable:end -->
