### PR TITLE
Build LuaJIT w/ table.pack support

### DIFF
--- a/jni/luajit/koreader-luajit-enable-table_pack.patch
+++ b/jni/luajit/koreader-luajit-enable-table_pack.patch
@@ -1,0 +1,31 @@
+diff --git a/src/lib_table.c b/src/lib_table.c
+index a723326a..28af227f 100644
+--- a/src/lib_table.c
++++ b/src/lib_table.c
+@@ -267,7 +267,6 @@ LJLIB_CF(table_sort)
+   return 0;
+ }
+ 
+-#if LJ_52
+ LJLIB_PUSH("n")
+ LJLIB_CF(table_pack)
+ {
+@@ -283,7 +282,6 @@ LJLIB_CF(table_pack)
+   lj_gc_check(L);
+   return 1;
+ }
+-#endif
+ 
+ LJLIB_NOREG LJLIB_CF(table_new)		LJLIB_REC(.)
+ {
+@@ -316,10 +314,8 @@ static int luaopen_table_clear(lua_State *L)
+ LUALIB_API int luaopen_table(lua_State *L)
+ {
+   LJ_LIB_REG(L, LUA_TABLIBNAME, table);
+-#if LJ_52
+   lua_getglobal(L, "unpack");
+   lua_setfield(L, -2, "unpack");
+-#endif
+   lj_lib_prereg(L, LUA_TABLIBNAME ".new", luaopen_table_new, tabV(L->top-1));
+   lj_lib_prereg(L, LUA_TABLIBNAME ".clear", luaopen_table_clear, tabV(L->top-1));
+   return 1;

--- a/jni/luajit/mk-luajit.sh
+++ b/jni/luajit/mk-luajit.sh
@@ -24,6 +24,7 @@ function do_patch() {
 }
 
 do_patch "koreader-luajit-makefile-tweaks.patch"
+do_patch "koreader-luajit-enable-table_pack.patch"
 do_patch "koreader-luajit-mcode-reserve-hack.patch"
 
 # In debug builds, we patch LuaJIT some more to grok what happens with mcode allocations


### PR DESCRIPTION
c.f., https://github.com/koreader/koreader-base/pull/1535

Note that I left a couple of `{...}` constructs alone in android.lua, because some were then passing the table to `table.concat`, which *will* choke on a nil (and it gets to iterate over it in a packed vararg table).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/388)
<!-- Reviewable:end -->
