### PR TITLE
Add Support for Onyx Boox Note X2

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -67,6 +67,7 @@ object DeviceInfo {
         ONYX_NOTE_AIR,
         ONYX_NOTE_AIR2,
         ONYX_NOTE_PRO,
+        ONYX_NOTE_X2,
         ONYX_NOVA2,
         ONYX_NOVA3,
         ONYX_NOVA3_COLOR,
@@ -101,6 +102,7 @@ object DeviceInfo {
         ONYX_NOTE_AIR,
         ONYX_NOTE_AIR2,
         ONYX_NOTE_PRO,
+        ONYX_NOTE_X2,
         ONYX_NOVA2,
         ONYX_NOVA3,
         ONYX_NOVA3_COLOR,
@@ -176,6 +178,7 @@ object DeviceInfo {
     private val ONYX_NOTE_AIR: Boolean
     private val ONYX_NOTE_AIR2: Boolean
     private val ONYX_NOTE_PRO: Boolean
+    private val ONYX_NOTE_X2: Boolean
     private val ONYX_NOVA2: Boolean
     private val ONYX_NOVA3: Boolean
     private val ONYX_NOVA3_COLOR: Boolean
@@ -375,6 +378,10 @@ object DeviceInfo {
             && PRODUCT.contentEquals("notepro")
             && DEVICE.contentEquals("notepro")
 
+        // Onyx Note X2
+        ONYX_NOTE_X2 = MANUFACTURER.contentEquals("onyx")
+            && MODEL.contentEquals("notex2")
+
         // Onyx Nova 2
         ONYX_NOVA2 = MANUFACTURER.contentEquals("onyx")
             && PRODUCT.contentEquals("nova2")
@@ -515,6 +522,7 @@ object DeviceInfo {
         deviceMap[EinkDevice.ONYX_NOTE_AIR] = ONYX_NOTE_AIR
         deviceMap[EinkDevice.ONYX_NOTE_AIR2] = ONYX_NOTE_AIR2
         deviceMap[EinkDevice.ONYX_NOTE_PRO] = ONYX_NOTE_PRO
+        deviceMap[EinkDevice.ONYX_NOTE_X2] = ONYX_NOTE_X2
         deviceMap[EinkDevice.ONYX_NOVA2] = ONYX_NOVA2
         deviceMap[EinkDevice.ONYX_NOVA3] = ONYX_NOVA3
         deviceMap[EinkDevice.ONYX_NOVA3_COLOR] = ONYX_NOVA3_COLOR
@@ -556,6 +564,7 @@ object DeviceInfo {
         lightsMap[LightsDevice.ONYX_NOTE3] = ONYX_NOTE3
         lightsMap[LightsDevice.ONYX_NOTE_AIR] = ONYX_NOTE_AIR
         lightsMap[LightsDevice.ONYX_NOTE_AIR2] = ONYX_NOTE_AIR2
+        lightsMap[LightsDevice.ONYX_NOTE_X2] = ONYX_NOTE_X2
         lightsMap[LightsDevice.ONYX_NOVA2] = ONYX_NOVA2
         lightsMap[LightsDevice.ONYX_NOVA3] = ONYX_NOVA3
         lightsMap[LightsDevice.ONYX_NOVA3_COLOR] = ONYX_NOVA3_COLOR

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -73,6 +73,7 @@ object EPDFactory {
                 DeviceInfo.EinkDevice.ONYX_NOTE_AIR,
                 DeviceInfo.EinkDevice.ONYX_NOTE_AIR2,
                 DeviceInfo.EinkDevice.ONYX_NOTE_PRO,
+                DeviceInfo.EinkDevice.ONYX_NOTE_X2,
                 DeviceInfo.EinkDevice.ONYX_NOVA2,
                 DeviceInfo.EinkDevice.ONYX_NOVA3,
                 DeviceInfo.EinkDevice.ONYX_NOVA3_COLOR,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -38,6 +38,7 @@ object LightsFactory {
                 }
                 DeviceInfo.LightsDevice.ONYX_LEAF2,
                 DeviceInfo.LightsDevice.ONYX_NOTE_AIR2,
+                DeviceInfo.LightsDevice.ONYX_NOTE_X2,
                 DeviceInfo.LightsDevice.ONYX_NOVA2,
                 DeviceInfo.LightsDevice.ONYX_NOVA_AIR_2,
                 DeviceInfo.LightsDevice.ONYX_NOVA_AIR_C,


### PR DESCRIPTION
I have tested KOReader compatibility on my Boox Note X2 and found that the "Onyx SDK (lights)" and "Onyx/Qualcomm" options worked for me. Since the device info section was printing "notex2" as the model, I edited the code to mimic issue #394. Please note that while I am experienced in systems programming, I am not familiar with Android development. Your help is much appreciated :-)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/402)
<!-- Reviewable:end -->
