### PR TITLE
Add Boyue S62

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -33,6 +33,7 @@ object DeviceInfo {
         BOYUE_P6,
         BOYUE_P61,
         BOYUE_P78,
+        BOYUE_S62,
         BOYUE_T61,
         BOYUE_T62,
         BOYUE_T65S,
@@ -144,6 +145,7 @@ object DeviceInfo {
     private val BOYUE_P6: Boolean
     private val BOYUE_P61: Boolean
     private val BOYUE_P78: Boolean
+    private val BOYUE_S62: Boolean
     private val BOYUE_T61: Boolean
     private val BOYUE_T62: Boolean
     private val BOYUE_T65S: Boolean
@@ -225,6 +227,9 @@ object DeviceInfo {
 
         // Boyue Likebook P78
         BOYUE_P78 = BOYUE && PRODUCT.contentEquals("p78")
+
+        // Boyue Likebook LemonRead S62A
+        BOYUE_S62 = BOYUE && PRODUCT.contentEquals("s62")
 
         // Boyue T61
         BOYUE_T61 = (BOYUE
@@ -498,6 +503,7 @@ object DeviceInfo {
         deviceMap[EinkDevice.BOYUE_P6] = BOYUE_P6
         deviceMap[EinkDevice.BOYUE_P61] = BOYUE_P61
         deviceMap[EinkDevice.BOYUE_P78] = BOYUE_P78
+        deviceMap[EinkDevice.BOYUE_S62] = BOYUE_S62
         deviceMap[EinkDevice.BOYUE_T61] = BOYUE_T61
         deviceMap[EinkDevice.BOYUE_T62] = BOYUE_T62
         deviceMap[EinkDevice.BOYUE_T65S] = BOYUE_T65S

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -37,6 +37,7 @@ object EPDFactory {
                 DeviceInfo.EinkDevice.BOYUE_P6,
                 DeviceInfo.EinkDevice.BOYUE_P61,
                 DeviceInfo.EinkDevice.BOYUE_P78,
+                DeviceInfo.EinkDevice.BOYUE_S62,
                 DeviceInfo.EinkDevice.BOYUE_T78D,
                 DeviceInfo.EinkDevice.BOYUE_T80D,
                 DeviceInfo.EinkDevice.BOYUE_T103D -> {


### PR DESCRIPTION
Boyue Likebook LemonRead S62A

Just the basic place holder.

I've written a wip frontlight controller too. But, although it reads fine, to write the brightness it needs system write so I haven't tested or added it to the pull. Attached here for reference: [BoyueS62Controller.zip](https://github.com/koreader/android-luajit-launcher/files/10683215/BoyueS62Controller.zip)

References: 
1. PhoneStatusBar.java from SystemUI.apk (deodox and decompile with jadx) showing the frontlight logic: [PhoneStatusBar.zip](https://github.com/koreader/android-luajit-launcher/files/10683289/PhoneStatusBar.zip)
   It also mentions _/sys/class/backlight/rk28_bl_warm/brightness_ but permissions are required there as well.
2. RK3368Impl.java from Boyue-Launcher.apk (deodox and decompile with jadx) showing mostly the EPD entries (EPD_FULL_DITHER isn't the same but we don't use it anyhow): [RK3368Impl.zip](https://github.com/koreader/android-luajit-launcher/files/10683244/RK3368Impl.zip)
3. FunctionUtil.java from Boyue-Launcher.apk (deodox and decompile with jadx) showing an alternative method to modify the brightness (that's also requires root): [FunctionUtil.zip](https://github.com/koreader/android-luajit-launcher/files/10683380/FunctionUtil.zip)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/404)
<!-- Reviewable:end -->
