### PR TITLE
Add Boyue S62 root light controller

### DIFF
--- a/app/src/main/java/org/koreader/launcher/TestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/TestActivity.kt
@@ -22,6 +22,7 @@ import org.koreader.launcher.device.lights.OnyxSdkLightsController
 import org.koreader.launcher.device.lights.OnyxWarmthController
 import org.koreader.launcher.device.lights.TolinoRootController
 import org.koreader.launcher.device.lights.TolinoNtxController
+import org.koreader.launcher.device.lights.BoyueS62RootController
 import org.koreader.launcher.dialog.LightDialog
 
 class TestActivity: AppCompatActivity() {
@@ -63,6 +64,7 @@ class TestActivity: AppCompatActivity() {
         epdMap["Freescale/NTX"] = TolinoEPDController()
 
         // Lights drivers
+        lightsMap["Boyue S62 Root"] = BoyueS62RootController()
         lightsMap["Onyx C67"] = OnyxC67Controller()
         lightsMap["Onyx Color"] = OnyxColorController()
         lightsMap["Onyx SDK (lights)"] = OnyxSdkLightsController()

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -89,6 +89,7 @@ object DeviceInfo {
 
     enum class LightsDevice {
         NONE,
+        BOYUE_S62,
         CREMA_CARTA_G,
         MEEBOOK_P6,
         ONYX_C67,
@@ -574,6 +575,7 @@ object DeviceInfo {
 
         // devices with custom lights
         val lightsMap = HashMap<LightsDevice, Boolean>()
+        lightsMap[LightsDevice.BOYUE_S62] = BOYUE_S62
         lightsMap[LightsDevice.CREMA_CARTA_G] = CREMA_CARTA_G
         lightsMap[LightsDevice.MEEBOOK_P6] = MEEBOOK_P6
         lightsMap[LightsDevice.ONYX_C67] = ONYX_C67

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -59,6 +59,10 @@ object LightsFactory {
                     logController("Onyx C67")
                     OnyxC67Controller()
                 }
+                DeviceInfo.LightsDevice.BOYUE_S62 -> {
+                    logController("Boyue S62")
+                    BoyueS62RootController()
+                }
                 else -> {
                     logController("Generic")
                     GenericController()

--- a/app/src/main/java/org/koreader/launcher/device/lights/BoyueS62RootController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/BoyueS62RootController.kt
@@ -1,0 +1,87 @@
+package org.koreader.launcher.device.lights
+
+import android.app.Activity
+import android.provider.Settings
+import android.util.Log
+import org.koreader.launcher.device.LightsInterface
+
+/* handle frontlight within the activity, without affecting other activities */
+
+class BoyueS62RootController : LightsInterface {
+    companion object {
+        private const val TAG = "Lights"
+        private const val BRIGHTNESS_MAX = 254
+        private const val BRIGHTNESS_MIN = 0
+    }
+
+    override fun getPlatform(): String {
+        return "boyue-s62-root"
+    }
+
+    override fun hasFallback(): Boolean {
+        return true
+    }
+
+    override fun hasWarmth(): Boolean {
+        return false
+    }
+
+    override fun needsPermission(): Boolean {
+        return false
+    }
+
+    override fun enableFrontlightSwitch(activity: Activity): Int {
+        return 1
+    }
+
+    override fun getBrightness(activity: Activity): Int {
+        var brightness = 0
+        activity.runOnUiThread {
+            try {
+                brightness = Settings.System.getInt(activity.applicationContext.contentResolver, "boyue_warm_light")
+            } catch (e: Exception) {
+                Log.w(TAG, "$e")
+            }
+        }
+        Log.v(TAG, "getBrightness: $brightness")
+        return brightness
+    }
+
+    override fun getWarmth(activity: Activity): Int {
+        Log.w(TAG, "getWarmth: not implemented")
+        return 0
+    }
+
+    override fun setBrightness(activity: Activity, brightness: Int) {
+        if (brightness < BRIGHTNESS_MIN || brightness > BRIGHTNESS_MAX) {
+            Log.w(TAG, "brightness value out of range: $brightness")
+            return
+        }
+        Log.v(TAG, "setBrightness: $brightness")
+        activity.runOnUiThread {
+            try {
+                //Runtime.getRuntime().exec("su -c settings put system boyue_warm_light " + brightness) // slow
+                Runtime.getRuntime().exec("su -c echo " + brightness + " > /sys/class/backlight/rk28_bl_warm/brightness")
+            } catch (e: Exception) {
+                Log.w(TAG, "$e")
+            }
+          }
+    }
+
+    override fun setWarmth(activity: Activity, warmth: Int) {
+        Log.w(TAG, "ignoring setWarmth: not implemented")
+    }
+
+    override fun getMinWarmth(): Int {
+        return 0
+    }
+    override fun getMaxWarmth(): Int {
+        return 0
+    }
+    override fun getMinBrightness(): Int {
+        return BRIGHTNESS_MIN
+    }
+    override fun getMaxBrightness(): Int {
+        return BRIGHTNESS_MAX
+    }
+}


### PR DESCRIPTION
requires root.

Notes:
1. This should also work on the [Boyue Likebook Mimas (T103D)](https://www.mobileread.com/forums/showpost.php?p=3890090&postcount=583) and possibly a few other models: https://www.mobileread.com/forums/showthread.php?t=311910&page=39

2. Technically, *boyue_warm_light* is accessible to the shell user (via adb) so it's possible to use shizuku for rootless frontlight. However, since this model is an Android 6 firmware, it will be highly inconvenient as the the user will have run "adb shell sh /sdcard/Android/data/moe.shizuku.privileged.api/start.sh" via the pc with every reboot.
Still, it's something to consider if later Haoqingtech (formerly boyue) models (Meebook P10 Pro, Meebook P78 pro and MeeBook M6 so far...) have similar issues as they're Android 11 based and can loopback adb via the wireless debugging and trust agent without rebooting as [covered in the user guide](https://shizuku.rikka.app/guide/setup/).

3. I commented out the use of settings and used wrote directly to the socket file instead since doing it "properly" introduced over ~500ms. Similar models will probably want to experiment and see if the issue was fixed in their firmwares.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/408)
<!-- Reviewable:end -->
