### PR TITLE
update to use NDK 23c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,26 +25,10 @@ BUILD_TASK?=assemble$(ARCH)$(FLAVOR)
 LINT_TASK?=lint$(ARCH)$(FLAVOR)
 
 # find the path where the SDK is installed
-ifdef SDK
-        ANDROID_SDK_FULLPATH?=$(SDK)
-else
-        ifdef ANDROID_HOME
-                ANDROID_SDK_FULLPATH?=$(ANDROID_HOME)
-        else
-                ANDROID_SDK_FULLPATH?=$(shell realpath ../../../base/toolchain/android-sdk-linux)
-        endif
-endif
+ANDROID_SDK_FULLPATH ?= $(or $(ANDROID_HOME),$(ANDROID_SDK_ROOT),$(shell realpath ../../../base/toolchain/android-sdk-linux))
 
 # find the path where the NDK is installed
-ifdef NDK
-	ANDROID_NDK_FULLPATH?=$(NDK)
-else
-	ifdef ANDROID_NDK_HOME
-		ANDROID_NDK_FULLPATH?=$(ANDROID_NDK_HOME)
-	else
-		ANDROID_NDK_FULLPATH?=$(shell realpath ../../../base/toolchain/android-ndk-r15c)
-	endif
-endif
+ANDROID_NDK_FULLPATH ?= $(or $(ANDROID_NDK_HOME),$(ANDROID_NDK_ROOT),$(shell realpath ../../../base/toolchain/android-ndk-r23c))
 
 # override android:versionName="string"
 ifdef ANDROID_NAME
@@ -126,7 +110,7 @@ clean:
 	@echo "Cleaning binaries, assets and LuaJIT build"
 	rm -rf assets/module/ bin/ jni/luajit/build
 	cd jni/luajit && \
-		./mk-luajit.sh clean
+		./mk-luajit.sh "$(ANDROID_FULL_ARCH)" clean
 
 mrproper: clean
 	-./gradlew clean --continue

--- a/app/src/main/java/org/koreader/launcher/Assets.kt
+++ b/app/src/main/java/org/koreader/launcher/Assets.kt
@@ -18,6 +18,7 @@ class Assets {
     private val tag = this::class.java.simpleName
 
     init {
+        Log.i(tag, "loading lib7z")
         System.loadLibrary("7z")
     }
 

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -91,6 +91,7 @@ class MainActivity : NativeActivity(), LuaInterface,
     }
 
     init {
+        Log.i(tag, "loading libluajit")
         System.loadLibrary("luajit")
     }
 

--- a/app/src/main/java/org/koreader/launcher/device/Ioctl.kt
+++ b/app/src/main/java/org/koreader/launcher/device/Ioctl.kt
@@ -5,12 +5,14 @@ import kotlin.math.abs
 
 open class Ioctl {
 
+    private val tag = this::class.java.simpleName
+
     init {
+        Log.i(tag, "loading libioctl")
         System.loadLibrary("ioctl")
     }
 
     private external fun ioctl(device: String, command: Int, args: Int): Int
-    private val tag = this::class.java.simpleName
 
     companion object {
         private const val ENOENT = 2

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.compileSdk = 30
     ext.targetSdk = 30
-    ext.minSdk = 14
+    ext.minSdk = 18
 
     ext.gradle_plugin_version = '4.2.1'
     ext.kotlin_plugin_version = '1.5.20'

--- a/jni/luajit/mk-luajit.sh
+++ b/jni/luajit/mk-luajit.sh
@@ -2,47 +2,34 @@
 # see http://luajit.org/install.html for details
 # there, a call like one of the following is recommended
 
+set -eo pipefail
+
 # We use NDK r15c for all architectures.
 
 # For 32 bits (armeabi-v7a and x86) we built against platform-14 (ICS)
 # For 64 bits (arm64-v8a and x86_64) we built against platform-21 (Lollipop)
 
-DEST=$(cd "$(dirname "$0")" && pwd)/build/$1
+DEST="$(cd "$(dirname "$0")" && pwd)/build/$1"
 # might be linux-x86_64 or darwin-x86-64
 HOST_ARCH="*"
 
-# Reverse patch will succeed if the patch is already applied.
-# In case of failure, it means we should try to apply the patch.
-function do_patch() {
-    local patch_file="${1}"
-    if ! patch -d luajit -R -p1 -N --dry-run <"${patch_file}" >/dev/null 2>&1; then
-        # Now patch for real.
-        if ! patch -d luajit -p1 -N <"${patch_file}"; then
-            exit $?
-        fi
-    fi
-}
-
-do_patch "koreader-luajit-makefile-tweaks.patch"
-do_patch "koreader-luajit-enable-table_pack.patch"
-do_patch "koreader-luajit-mcode-reserve-hack.patch"
-
-# In debug builds, we patch LuaJIT some more to grok what happens with mcode allocations
-if [[ "$2" == "debug" ]]; then
-    do_patch "koreader-luajit-mcode-debug.patch"
-    EXTRA_LIBS="-landroid -llog"
-fi
-
 function check_NDK() {
-    [[ -n $NDK ]] || export NDK=/opt/android-ndk
-    if [ ! -d "$NDK" ]; then
-        echo 'NDK not found. Please set NDK environment variable and have it point to the NDK dir.'
+    for v in ANDROID_NDK_HOME ANDROID_NDK_ROOT; do
+      ANDROID_NDK_HOME="${!v}"
+      if [[ -n "${!v}" ]]; then
+        break
+      fi
+    done
+    [[ -n "${ANDROID_NDK_HOME}" ]] || ANDROID_NDK_HOME=/opt/android-ndk
+    if [ ! -d "${ANDROID_NDK_HOME}" ]; then
+        echo 'NDK not found. Please set ANDROID_NDK_HOME environment variable and have it point to the NDK dir.'
         exit 1
     fi
+    export ANDROID_NDK_HOME
 
     echo "Using NDKABI ${NDKABI}."
 
-    NDKVER=$(grep -oP 'r\K([0-9]+)(?=[a-z])' ${NDK}/CHANGELOG.md | head -1)
+    NDKVER=$(grep -oP 'r\K([0-9]+)(?=[a-z])' ${ANDROID_NDK_ROOT}/CHANGELOG.md | head -1)
     echo "Detected NDK version ${NDKVER}..."
     if [ "$NDKVER" -lt 15 ]; then
         echo 'NDK not of the right version, please update to NDK version 15 or higher.'
@@ -50,51 +37,109 @@ function check_NDK() {
     fi
 }
 
+check_NDK
+export PATH="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin:${PATH}"
+
+makecmd=(
+  make -C "${DEST}"
+)
+declare -A makeenv
+patches=()
+
+if [[ -z "${USE_NO_CCACHE}" ]] && which ccache 2>/dev/null; then
+  ccache='ccache'
+else
+  ccache=''
+fi
+
+makeenv[HOST_CC]="${ccache}${ccache:+ } clang"
+makeenv[HOST_CFLAGS]='-O2 -pipe -mtune=generic'
+makeenv[HOST_LDFLAGS]=''
+
+makeenv[CROSS]="${ccache}"
+makeenv[CC]='clang'
+makeenv[CFLAGS]='-O2 -pipe'
+makeenv[LDFLAGS]=''
+
+makeenv[TARGET_AR]='llvm-ar rcus'
+makeenv[TARGET_RANLIB]='llvm-ranlib'
+makeenv[TARGET_STRIP]='llvm-strip'
+makeenv[TARGET_SYS]='Linux'
+
+makeenv[TARGET_FLAGS]=''
+makeenv[TARGET_CFLAGS]="${makeenv[CFLAGS]}"
+makeenv[TARGET_LDFLAGS]="${makeenv[LDFLAGS]}"
+makeenv[TARGET_LIBS]=''
+makeenv[TARGET_SONAME]='libluajit.so'
+
+makeenv[INSTALL_SONAME]='libluajit.so'
+
+makeenv[DESTDIR]="${DEST}"
+makeenv[PREFIX]=''
+
 ## NOTE: Since https://github.com/koreader/koreader-base/pull/1133, we append -DLUAJIT_SECURITY_STRHASH=0 -DLUAJIT_SECURITY_STRID=0 to TARGET_CFLAGS on !Android platforms.
 ##       Here, we leave it at the defaults, because we have much less control over the environment on Android, so, better be safe than sorry ;).
 case "$1" in
-    clean)
-        make -C luajit clean
-        ;;
     armeabi-v7a)
         # Android/ARM, armeabi-v7a (ARMv7 VFP)
-        NDKABI=${NDKABI:-14}
-        check_NDK
-        TCVER=("${NDK}"/toolchains/arm-linux-androideabi-4.*)
-        NDKP=${TCVER[0]}/prebuilt/${HOST_ARCH}/bin/arm-linux-androideabi-
-        NDKF="--sysroot ${NDK}/platforms/android-${NDKABI}/arch-arm"
-        NDKARCH="-march=armv7-a -mfloat-abi=softfp -Wl,--fix-cortex-a8"
-        make -C luajit amalg install HOST_CC="gcc -m32" CFLAGS="-O2 -pipe" HOST_CFLAGS="-O2 -pipe -mtune=generic" LDFLAGS="" HOST_LDFLAGS="" TARGET_CFLAGS="${CFLAGS}" TARGET_LDFLAGS="${LDFLAGS}" TARGET_LIBS="${EXTRA_LIBS}" TARGET_SONAME="libluajit.so" INSTALL_SONAME="libluajit.so" CROSS="$NDKP" TARGET_FLAGS="${NDKF} ${NDKARCH}" TARGET_SYS=Linux DESTDIR="${DEST}" PREFIX=
+        makeenv[CROSS]+=" armv7a-linux-androideabi${NDKABI:-18}-"
+        makeenv[TARGET_FLAGS]="-march=armv7-a -mfloat-abi=softfp"
+        makeenv[HOST_CC]+=' -m32'
         ;;
     arm64-v8a)
         # Android/ARM, arm64-v8a (ARM64 VFP4, NEON)
-        NDKABI=${NDKABI:-21}
-        check_NDK
-        TCVER=("${NDK}"/toolchains/aarch64-linux-android-4.*)
-        NDKP=${TCVER[0]}/prebuilt/${HOST_ARCH}/bin/aarch64-linux-android-
-        NDKF="--sysroot ${NDK}/platforms/android-${NDKABI}/arch-arm64"
-        make -C luajit amalg install HOST_CC="gcc" CFLAGS="-O2 -pipe" HOST_CFLAGS="-O2 -pipe -mtune=generic" LDFLAGS="" HOST_LDFLAGS="" TARGET_CFLAGS="${CFLAGS}" TARGET_LDFLAGS="${LDFLAGS}" TARGET_LIBS="${EXTRA_LIBS}" TARGET_SONAME="libluajit.so" INSTALL_SONAME="libluajit.so" CROSS="$NDKP" TARGET_FLAGS="${NDKF}" TARGET_SYS=Linux DESTDIR="${DEST}" PREFIX=
+        makeenv[CROSS]+=" aarch64-linux-android${NDKABI:-21}-"
         ;;
     x86)
         # Android/x86, x86 (i686 SSE3)
-        NDKABI=${NDKABI:-14}
-        check_NDK
-        TCVER=("${NDK}"/toolchains/x86-4.*)
-        NDKP=${TCVER[0]}/prebuilt/${HOST_ARCH}/bin/i686-linux-android-
-        NDKF="--sysroot ${NDK}/platforms/android-${NDKABI}/arch-x86"
-        make -C luajit amalg install HOST_CC="gcc -m32" CFLAGS="-O2 -pipe" HOST_CFLAGS="-O2 -pipe -mtune=generic" LDFLAGS="" HOST_LDFLAGS="" TARGET_CFLAGS="${CFLAGS}" TARGET_LDFLAGS="${LDFLAGS}" TARGET_LIBS="${EXTRA_LIBS}" TARGET_SONAME="libluajit.so" INSTALL_SONAME="libluajit.so" CROSS="$NDKP" TARGET_FLAGS="$NDKF" TARGET_SYS=Linux DESTDIR="${DEST}" PREFIX=
+        makeenv[CROSS]+=" i686-linux-android${NDKABI:-18}-"
+        makeenv[HOST_CC]+=' -m32'
         ;;
     x86_64)
         # Android/x86_64, x86_64
-        NDKABI=${NDKABI:-21}
-        check_NDK
-        TCVER=("${NDK}"/toolchains/x86_64-4.*)
-        NDKP=${TCVER[0]}/prebuilt/${HOST_ARCH}/bin/x86_64-linux-android-
-        NDKF="--sysroot ${NDK}/platforms/android-${NDKABI}/arch-x86_64"
-        make -C luajit amalg install HOST_CC="gcc" CFLAGS="-O2 -pipe" HOST_CFLAGS="-O2 -pipe -mtune=generic" LDFLAGS="" HOST_LDFLAGS="" TARGET_CFLAGS="${CFLAGS}" TARGET_LDFLAGS="${LDFLAGS}" TARGET_LIBS="${EXTRA_LIBS}" TARGET_SONAME="libluajit.so" INSTALL_SONAME="libluajit.so" CROSS="$NDKP" TARGET_FLAGS="${NDKF}" TARGET_SYS=Linux DESTDIR="${DEST}" PREFIX=
+        makeenv[CROSS]="x86_64-linux-android${NDKABI:-21}-"
         ;;
     *)
         echo 'specify one of "armeabi-v7a", "arm64-v8a", "x86", "x86_64" or "clean" as first argument'
         exit 1
         ;;
 esac
+
+case "$2" in
+  clean)
+    rm -rf "${DEST}"
+    exit
+    ;;
+  debug)
+    makeenv[TARGET_LIBS]="-landroid -llog"
+    ;&
+  '')
+    patches+=(
+      koreader-luajit-makefile-tweaks.patch
+      koreader-luajit-enable-table_pack.patch
+      koreader-luajit-mcode-reserve-hack.patch
+    )
+    makecmd+=(amalg install)
+    ;;
+esac
+
+for k in "${!makeenv[@]}"; do
+  makecmd+=("${k}=${makeenv[${k}]}")
+done
+
+if ! [[ -d "${DEST}" ]]; then
+  # Poor man's lndir…
+  find "$PWD/luajit" \
+    -name .git -prune \
+    -o -type d -printf "mkdir -p '${DEST}/%P'; " \
+    -o -type f -printf "ln -s %p '${DEST}/%P'; " \
+    | sh -e
+  for p in "${patches[@]}"; do
+    patch --follow-symlinks --directory="${DEST}" --strip=1 --forward <"${p}"
+  done
+fi
+
+printf '%q ' "${makecmd[@]}"
+printf '\n'
+
+exec "${makecmd[@]}"


### PR DESCRIPTION
The API level is now encoded in the toolchain executable names, and can be used in place.

Additionally, rework `jni/luajit/mk-luajit.sh` so each architecture has its own build directory (no need to clean when switching architecture). Note: the patches are applied to each build directory, not the original source checkout.

Bump minimum SDK version to 18 in `build.gradle`: the NDK version 23c minimal supported version is 16, but our builds only really work on 18 and above.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/419)
<!-- Reviewable:end -->
