### PR TITLE
Fix running on android x86_64

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2656,7 +2656,7 @@ local function run(android_app_state)
     android.dl = require("dl")
     android.dl.library_path = android.nativeLibraryDir..":"..
         android.dir..":"..android.dir.."/libs:"..
-        "/lib:/system/lib:/lib/lib?.so:/system/lib/lib?.so"
+        "/lib:/system/lib:/system/lib64:/lib/lib?.so:/system/lib/lib?.so:/system/lib64/lib?.so"
 
     -- register the dependency lib loader
     table.insert(package.loaders, 3, android.deplib_loader)

--- a/assets/dl.lua
+++ b/assets/dl.lua
@@ -114,7 +114,7 @@ function dl.dlopen(library, load_func, depth)
             -- libvulkan, and libz
             -- c.f., https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#private-api-enforced-for-api-level-24
             -- Our current code should *never* hit any private system libs, so, this is basically overkill ;).
-            if depth > 0 and (pspec == "/system/lib" or library == "libdl.so") then
+            if depth > 0 and (pspec == "/system/lib" or pspec == "/system/lib64" or library == "libdl.so") then
                 -- depth > 0 to allow explicitly loading a system lib
                 -- (because this might have genuine use cases, as some early API levels do not put DT_NEEDED libraries into the global namespace)
                 -- pspec to reject system libs


### PR DESCRIPTION
It is necessary to load from the /system/lib64 directory, as this is where libraries like libm.so are located. Failure to do so will result in a crash of koreader.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/433)
<!-- Reviewable:end -->
