### PR TITLE
Fix Refresh Issue on Some Onyx Devices

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/epd/qualcomm/QualcommEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/qualcomm/QualcommEPDController.kt
@@ -18,22 +18,18 @@ abstract class QualcommEPDController {
         const val EINK_WAVEFORM_DELAY = 250
         const val EINK_WAVEFORM_DELAY_UI = 100
         const val EINK_WAVEFORM_DELAY_FAST = 0
+        const val UI_GC_MODE = 98 // This flag seems to be able to trigger a refresh for all modes when using the repaintEverything method.
 
-        private fun preventSystemRefresh() : Boolean{
-            // Sets UpdateMode and UpdateScheme to None
-            // this function is called EpdController.setSystemUpdateModeAndScheme in onyxsdk
-            return try {
-                Class.forName("android.view.View").getMethod("setWaveformAndScheme",
-                    Integer.TYPE,
-                    Integer.TYPE,
-                    Integer.TYPE).invoke(null, 5, 1, 0)
-                true
-            } catch (e: Exception) {
-                Log.e(TAG, e.toString())
-                false
-            }
-        }
-
+        // The refreshScreen method is causing a problem in ULTRAC, possibly others
+        // When we switch to one of the modes: Balanced Mode, Fast Mode, or Ultrafast Mode,
+        // we end up stuck in a fast mode that persists even if we return to Regal or HD Mode.
+        // This refresh mode is annoying when reading a cbz file,
+        // as it displays a white screen before each refresh, disrupting the reading experience.
+        // References:
+        // - https://github.com/onyx-intl/OnyxAndroidDemo/blob/master/doc/EPD-Screen-Update.md
+        // - https://help.boox.com/hc/en-us/articles/10701257029780-Refresh-Modes
+        // It seems that using the repaintEverything method solves the issue.
+        // The SDK also employs this method for full refresh.
         fun requestEpdMode(targetView: View,
                                 mode: Int, delay: Long,
                                 x: Int, y: Int, width: Int, height: Int) : Boolean
@@ -42,19 +38,24 @@ abstract class QualcommEPDController {
                 // We need to always call this, not sure why, if it's not called before
                 // system will refresh after us, it'll refresh anyway if user set
                 // Normal mode, or Regal mode works flawlessly otherwise
-                preventSystemRefresh()
-                // EpdController.refreshScreenRegion in onyxsdk
-                val refreshScreen = Class.forName("android.view.View").getMethod("refreshScreen",
-                                        Integer.TYPE,
-                                        Integer.TYPE,
-                                        Integer.TYPE,
-                                        Integer.TYPE,
+
+                // The setWaveformAndScheme on preventSystemRefresh() method does not exist for SDM devices (Bengal).
+                // We will no longer use preventSystemRefresh() here.
+                //preventSystemRefresh()
+
+                val repaintEverything = Class.forName("android.view.View").getMethod("repaintEverything",
                                         Integer.TYPE)
+
                 object: Thread(){
                     override fun run(){
-                        sleep(delay)
+                        Log.e(TAG, "Delay: " + delay)
                         try {
-                            refreshScreen.invoke(targetView, x, y, width, height, mode)
+                            // 500 ms hardcoded that comes from framebuffer_android.lua seems to be to much here IMHO
+                            // After some tests with a file the refresh fails to occur some value between 100-150 ms
+                            // We can use de EINK_WAVEFORM_DELAY 250 ms if using repaintEverything
+                            // Sad we need some delay anyway
+                            sleep(EINK_WAVEFORM_DELAY.toLong())
+                            repaintEverything.invoke(targetView, UI_GC_MODE)
                             Log.i(TAG, String.format(Locale.US,
                                 "requested eink refresh, type: %d x:%d y:%d w:%d h:%d",
                                 mode, x, y, width, height))


### PR DESCRIPTION
Fix Black/White refresh problem for Regal and HD Mode 
I'm considering using these changes for ULTRAC.
If it doesn't work for other devices, perhaps a condition could be used to distinguish. Added comments in the code explaining the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/435)
<!-- Reviewable:end -->
