### PR TITLE
Fix native orientation for device rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,6 @@
             android:exported="true"
             android:theme="@style/SplashScreen"
             android:resizeableActivity="false"
-            android:screenOrientation="nosensor"
             android:launchMode="singleInstance"
             android:configChanges="colorMode|density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
             tools:ignore="NonResizeableActivity">


### PR DESCRIPTION
Following the doc:
android:screenOrientation="nosensor" explicitly disabled the automatic rotation of the screen android:screenOrientation="portrait" for portrait mode only 
android:screenOrientation="landscape" for landscape mode only

Removing these lines should allow the app to rotate based on the device's orientation.

I do tests with the native orientation of my device until I disabled app optimization to see the behavior like on a real android.  Then I see that Koreader even when my device is in landscape mode it's only starts in portrait mode.  Moving the device in circle does not cause Koreader to change its orientation. I can only change it manually by clicking the bottom menu buttons.

I believe Koreader should adjust the orientation when I physically move the hardware device. 

Btw, if the current behavior is intentional, it doesn't matter to me since I don't use the function and that's perfectly fine like is today. 
I just tested it on Android 11.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/438)
<!-- Reviewable:end -->
