### PR TITLE
update Gradle to 7.3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ buildscript {
     ext.targetSdk = 30
     ext.minSdk = 18
 
-    ext.gradle_plugin_version = '4.2.1'
-    ext.kotlin_plugin_version = '1.5.20'
+    ext.gradle_plugin_version = '7.4.2'
+    ext.kotlin_plugin_version = '1.6.21'
     ext.androidx_core_version = '1.6.0'
     ext.androidx_appcompat_version = '1.3.1'
     ext.androidx_supportv4_version = '1.0.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
So Java 17 can be used, the minimum required version to use the most recent Android SDK tools like `sdkmanager`.

The `koandroid` docker image will have to be updated to Focal (20.04), which is good idea anyway as the currently used version reached EOL in May (Bionic: 18.04).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/445)
<!-- Reviewable:end -->
