### PR TITLE
Onyx boox note 4 support

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -66,6 +66,7 @@ object DeviceInfo {
         ONYX_MONTECRISTO3,
         ONYX_NOTE,
         ONYX_NOTE3,
+        ONYX_NOTE4,
         ONYX_NOTE5,
         ONYX_NOTE_AIR,
         ONYX_NOTE_AIR2,

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -112,6 +112,7 @@ object DeviceInfo {
         ONYX_MAGICBOOK,
         ONYX_MONTECRISTO3,
         ONYX_NOTE3,
+        ONYX_NOTE4,
         ONYX_NOTE_AIR,
         ONYX_NOTE_AIR2,
         ONYX_NOTE_PRO,
@@ -198,6 +199,7 @@ object DeviceInfo {
     private val ONYX_MAX: Boolean
     private val ONYX_NOTE: Boolean
     private val ONYX_NOTE3: Boolean
+    private val ONYX_NOTE4: Boolean
     private val ONYX_NOTE5: Boolean
     private val ONYX_NOTE_AIR: Boolean
     private val ONYX_NOTE_AIR2: Boolean
@@ -405,6 +407,10 @@ object DeviceInfo {
             && PRODUCT.contentEquals("note3")
             && DEVICE.contentEquals("note3")
 
+        // Onyx Note 4
+        ONYX_NOTE4 = MANUFACTURER.contentEquals("onyx")
+            && MODEL.contentEquals("mc_note4")
+
         // Onyx Note 5
         ONYX_NOTE5 = BRAND.contentEquals("onyx")
             && PRODUCT.contentEquals("note5")
@@ -610,6 +616,7 @@ object DeviceInfo {
         deviceMap[EinkDevice.ONYX_MONTECRISTO3] = ONYX_MONTECRISTO3
         deviceMap[EinkDevice.ONYX_NOTE] = ONYX_NOTE
         deviceMap[EinkDevice.ONYX_NOTE3] = ONYX_NOTE3
+        deviceMap[EinkDevice.ONYX_NOTE4] = ONYX_NOTE4
         deviceMap[EinkDevice.ONYX_NOTE5] = ONYX_NOTE5
         deviceMap[EinkDevice.ONYX_NOTE_AIR] = ONYX_NOTE_AIR
         deviceMap[EinkDevice.ONYX_NOTE_AIR2] = ONYX_NOTE_AIR2
@@ -665,6 +672,7 @@ object DeviceInfo {
         lightsMap[LightsDevice.ONYX_MAGICBOOK] = ONYX_MAGICBOOK
         lightsMap[LightsDevice.ONYX_MONTECRISTO3] = ONYX_MONTECRISTO3
         lightsMap[LightsDevice.ONYX_NOTE3] = ONYX_NOTE3
+        lightsMap[LightsDevice.ONYX_NOTE4] = ONYX_NOTE4
         lightsMap[LightsDevice.ONYX_NOTE_AIR] = ONYX_NOTE_AIR
         lightsMap[LightsDevice.ONYX_NOTE_AIR2] = ONYX_NOTE_AIR2
         lightsMap[LightsDevice.ONYX_NOTE_X2] = ONYX_NOTE_X2

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -72,6 +72,7 @@ object EPDFactory {
                 DeviceInfo.EinkDevice.ONYX_MAX,
                 DeviceInfo.EinkDevice.ONYX_NOTE,
                 DeviceInfo.EinkDevice.ONYX_NOTE3,
+                DeviceInfo.EinkDevice.ONYX_NOTE4,
                 DeviceInfo.EinkDevice.ONYX_NOTE5,
                 DeviceInfo.EinkDevice.ONYX_NOTE_AIR,
                 DeviceInfo.EinkDevice.ONYX_NOTE_AIR2,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -43,6 +43,7 @@ object LightsFactory {
                 DeviceInfo.LightsDevice.ONYX_DARWIN9,
                 DeviceInfo.LightsDevice.ONYX_NOTE_AIR2,
                 DeviceInfo.LightsDevice.ONYX_NOTE_X2,
+                DeviceInfo.LightsDevice.ONYX_NOTE4,
                 DeviceInfo.LightsDevice.ONYX_NOVA,
                 DeviceInfo.LightsDevice.ONYX_NOVA2,
                 DeviceInfo.LightsDevice.ONYX_NOVA_AIR_2,


### PR DESCRIPTION
Commercial name of product: Onyx Boox Note 4
Android Version: 11 (Firmware 3.3.2)
Test lights: Onyx SDK (lights) work
Test E-INK: Qualcomm/Onyx works

Device info:
Manufacturer: onyx
Brand: onyx
Model: mc_note4
Device: boox
Product: boox
Hardware: qcom
Platform: bengal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/454)
<!-- Reviewable:end -->
