### PR TITLE
Nook Glowlight 4/4e/4 plus EInk refresh support (full-only)

### DIFF
--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -117,8 +117,8 @@ class MainActivity : NativeActivity(), LuaInterface,
             view = NativeSurfaceView(this)
 
               // The following two lines brings SurfaceView to "top" in order for NGL4 refresh to work, should be compatible with other controllers
-            view?.setZOrderOnTop(true); 
-            view?.holder?.setFormat(PixelFormat.TRANSPARENT);
+            view?.setZOrderOnTop(true)
+            view?.holder?.setFormat(PixelFormat.TRANSPARENT)
 
             window.takeSurface(null)
             view?.holder?.addCallback(this)

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -115,6 +115,11 @@ class MainActivity : NativeActivity(), LuaInterface,
 
         val surfaceKind: String = if (device.needsView) {
             view = NativeSurfaceView(this)
+
+              // The following two lines brings SurfaceView to "top" in order for NGL4 refresh to work, should be compatible with other controllers
+            view?.setZOrderOnTop(true); 
+            view?.holder?.setFormat(PixelFormat.TRANSPARENT);
+
             window.takeSurface(null)
             view?.holder?.addCallback(this)
             setContentView(view)

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -52,6 +52,7 @@ object DeviceInfo {
         MEEBOOK_P6,
         NABUK,
         NOOK,
+        NOOK_GL4,
         ONYX_C67,
         ONYX_DARWIN7,
         ONYX_DARWIN9,
@@ -93,8 +94,7 @@ object DeviceInfo {
         SONY_CP1,
         SONY_RP1,
         TAGUS_GEA,
-        TOLINO,
-        NGL4
+        TOLINO
     }
 
     enum class LightsDevice {
@@ -187,7 +187,7 @@ object DeviceInfo {
     private val MEEBOOK_P6: Boolean
     private val NABUK_REGAL_HD: Boolean
     private val NOOK: Boolean
-    private val NGL4: Boolean
+    private val NOOK_GL4: Boolean
     private val ONYX_C67: Boolean
     private val ONYX_DARWIN7: Boolean
     private val ONYX_DARWIN9: Boolean
@@ -343,7 +343,7 @@ object DeviceInfo {
             || MODEL.contentEquals("evk_mx6sl") || MODEL.startsWith("ereader"))
 
         // Nook Glowlight 4  (4/4e/4plus)
-        NGL4 = (MANUFACTURER.contentEquals("barnesandnoble"))
+        NOOK_GL4 = (MANUFACTURER.contentEquals("barnesandnoble"))
             && (MODEL.contentEquals("bnrv1000") || MODEL.contentEquals("bnrv1100") || MODEL.contentEquals("bnrv1300"))
 
         // Onyx C67
@@ -609,7 +609,7 @@ object DeviceInfo {
         deviceMap[EinkDevice.MEEBOOK_P6] = MEEBOOK_P6
         deviceMap[EinkDevice.NABUK] = NABUK_REGAL_HD
         deviceMap[EinkDevice.NOOK] = NOOK
-        deviceMap[EinkDevice.NGL4] = NGL4
+        deviceMap[EinkDevice.NOOK_GL4] = NOOK_GL4
         deviceMap[EinkDevice.ONYX_C67] = ONYX_C67
         deviceMap[EinkDevice.ONYX_DARWIN7] = ONYX_DARWIN7
         deviceMap[EinkDevice.ONYX_DARWIN9] = ONYX_DARWIN9

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -93,7 +93,8 @@ object DeviceInfo {
         SONY_CP1,
         SONY_RP1,
         TAGUS_GEA,
-        TOLINO
+        TOLINO,
+        NGL4
     }
 
     enum class LightsDevice {
@@ -186,6 +187,7 @@ object DeviceInfo {
     private val MEEBOOK_P6: Boolean
     private val NABUK_REGAL_HD: Boolean
     private val NOOK: Boolean
+    private val NGL4: Boolean
     private val ONYX_C67: Boolean
     private val ONYX_DARWIN7: Boolean
     private val ONYX_DARWIN9: Boolean
@@ -339,6 +341,10 @@ object DeviceInfo {
         NOOK = (MANUFACTURER.contentEquals("barnesandnoble") || MANUFACTURER.contentEquals("freescale"))
             && (MODEL.contentEquals("bnrv510") || MODEL.contentEquals("bnrv520") || MODEL.contentEquals("bnrv700")
             || MODEL.contentEquals("evk_mx6sl") || MODEL.startsWith("ereader"))
+
+        // Nook Glowlight 4  (4/4e/4plus)
+        NGL4 = (MANUFACTURER.contentEquals("barnesandnoble"))
+            && (MODEL.contentEquals("bnrv1000") || MODEL.contentEquals("bnrv1100") || MODEL.contentEquals("bnrv1300"))
 
         // Onyx C67
         ONYX_C67 = MANUFACTURER.contentEquals("onyx")
@@ -603,6 +609,7 @@ object DeviceInfo {
         deviceMap[EinkDevice.MEEBOOK_P6] = MEEBOOK_P6
         deviceMap[EinkDevice.NABUK] = NABUK_REGAL_HD
         deviceMap[EinkDevice.NOOK] = NOOK
+        deviceMap[EinkDevice.NGL4] = NGL4
         deviceMap[EinkDevice.ONYX_C67] = ONYX_C67
         deviceMap[EinkDevice.ONYX_DARWIN7] = ONYX_DARWIN7
         deviceMap[EinkDevice.ONYX_DARWIN9] = ONYX_DARWIN9

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -54,8 +54,8 @@ object EPDFactory {
                     logController("Nook/NTX")
                     NookEPDController()
                 }
-               DeviceInfo.EinkDevice.NGL4 -> {
-                    logController("NGL4")
+               DeviceInfo.EinkDevice.NOOK_GL4 -> {
+                    logController("NOOK_GL4")
                     NGL4EPDController()
                 }
                 DeviceInfo.EinkDevice.CREMA,

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -10,6 +10,7 @@ import org.koreader.launcher.device.epd.RK3026EPDController
 import org.koreader.launcher.device.epd.RK3368EPDController
 import org.koreader.launcher.device.epd.OnyxEPDController
 import org.koreader.launcher.device.epd.OldTolinoEPDController
+import org.koreader.launcher.device.epd.NGL4EPDController
 
 import java.util.*
 
@@ -53,7 +54,10 @@ object EPDFactory {
                     logController("Nook/NTX")
                     NookEPDController()
                 }
-
+               DeviceInfo.EinkDevice.NGL4 -> {
+                    logController("NGL4")
+                    NGL4EPDController()
+                }
                 DeviceInfo.EinkDevice.CREMA,
                 DeviceInfo.EinkDevice.CREMA_CARTA_G,
                 DeviceInfo.EinkDevice.HANVON_960,

--- a/app/src/main/java/org/koreader/launcher/device/epd/NGL4EPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/NGL4EPDController.kt
@@ -12,7 +12,7 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
     companion object {
         private const val NGL4TAG = "NGL4"
 
-        // constants taken as is from sunxi-kobo.h (NGL4 prefix insered for names)
+        // constants taken as is from sunxi-kobo.h (NGL4 prefix inserted for names)
 
         const val NGL4_EINK_INIT_MODE = 0x01
         const val NGL4_EINK_DU_MODE = 0x02
@@ -40,13 +40,14 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
         const val NGL4_EINK_DITHERING_NTX_Y1 = 0x08800000
         const val NGL4_EINK_NO_MERGE = Integer.MIN_VALUE //0x80000000
 
-        const val NGL4_PAGE_DELAY = 0 //500
-        const val NGL4_UI_DELAY = 0   //500
-        const val NGL4_FAST_DELAY = 0 //500
+        const val NGL4_PAGE_DELAY = 0
+        const val NGL4_UI_DELAY = 0
+        const val NGL4_FAST_DELAY = 0
     }
 
     override fun getPlatform(): String {
-        return "ngl4"
+        // the platform reported is "freescale" in order to not introduce new unexplained names 
+        return "freescale"
     }
 
     override fun getMode(): String {
@@ -57,7 +58,7 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
         return NGL4_EINK_NO_MERGE + NGL4_EINK_GC16_MODE
     }
 
-    // the mode constants below are effectively not used because getMode returns anything other than "all"
+    // the mode constants below are effectively not used because getMode returns something other than "all"
 
     override fun getWaveformPartial(): Int {
         return NGL4_EINK_GU16_MODE
@@ -73,10 +74,9 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
 
     override fun getWaveformFast(): Int {
        return NGL4_EINK_GU16_MODE
-       // return NGL4_EINK_A2_MODE;
     }
 
-    // the delays below are effectively not used because of the method involved
+    // getWaveformDelay is the only effectively used delay because of getMode being not "all" 
 
     override fun getWaveformDelay(): Int {
         return NGL4_PAGE_DELAY
@@ -92,7 +92,6 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
 
     override fun needsView(): Boolean {
         return true
-        //return false
     }
 
     override fun setEpdMode(targetView: android.view.View,
@@ -100,7 +99,7 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
                             x: Int, y: Int, width: Int, height: Int, epdMode: String?)
     {
 
-       Log.i(NGL4TAG, String.format(Locale.US, "defaulting to requestEpdMode: type:%d delay: %d x:%d y:%d w:%d h:%d",
+       Log.i(NGL4TAG, String.format(Locale.US, "calling requestEpdMode: type:%d delay: %d x:%d y:%d w:%d h:%d",
           mode, delay, x, y, width, height))
        requestEpdMode(targetView, mode, delay, x, y, width, height)
 

--- a/app/src/main/java/org/koreader/launcher/device/epd/NGL4EPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/NGL4EPDController.kt
@@ -6,8 +6,6 @@ import org.koreader.launcher.device.EPDInterface
 import org.koreader.launcher.device.epd.freescale.NTXEPDController
 import android.util.Log
 import java.util.*
-import android.view.Surface;
-import android.view.SurfaceView;
 
 class NGL4EPDController : NTXEPDController(), EPDInterface {
 
@@ -15,7 +13,7 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
         private const val NGL4TAG = "NGL4"
 
         // constants taken as is from sunxi-kobo.h (NGL4 prefix insered for names)
-      
+
         const val NGL4_EINK_INIT_MODE = 0x01
         const val NGL4_EINK_DU_MODE = 0x02
         const val NGL4_EINK_GC16_MODE = 0x04
@@ -40,15 +38,15 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
         const val NGL4_EINK_DITHERING_Y4 = 0x02800000
         const val NGL4_EINK_DITHERING_SIMPLE = 0x04800000
         const val NGL4_EINK_DITHERING_NTX_Y1 = 0x08800000
-        const val NGL4_EINK_NO_MERGE = Integer.MIN_VALUE // 0x80000000
+        const val NGL4_EINK_NO_MERGE = Integer.MIN_VALUE //0x80000000
 
-        const val NGL4_PAGE_DELAY = 0
-        const val NGL4_UI_DELAY = 0
-        const val NGL4_FAST_DELAY = 0
+        const val NGL4_PAGE_DELAY = 0 //500
+        const val NGL4_UI_DELAY = 0   //500
+        const val NGL4_FAST_DELAY = 0 //500
     }
 
     override fun getPlatform(): String {
-        return "freescale"
+        return "ngl4"
     }
 
     override fun getMode(): String {
@@ -74,7 +72,8 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
     }
 
     override fun getWaveformFast(): Int {
-        return NGL4_EINK_A2_MODE;
+       return NGL4_EINK_GU16_MODE
+       // return NGL4_EINK_A2_MODE;
     }
 
     // the delays below are effectively not used because of the method involved
@@ -101,20 +100,15 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
                             x: Int, y: Int, width: Int, height: Int, epdMode: String?)
     {
 
-        try {
-          Log.i(NGL4TAG, String.format(Locale.US, "setEpdMode to addEpdc: type:%d x:%d y:%d w:%d h:%d",
-            mode, x, y, width, height))
+       Log.i(NGL4TAG, String.format(Locale.US, "defaulting to requestEpdMode: type:%d delay: %d x:%d y:%d w:%d h:%d",
+          mode, delay, x, y, width, height))
+       requestEpdMode(targetView, mode, delay, x, y, width, height)
 
-          val iArr = intArrayOf(x, y, width, height, mode)
-
-          Class.forName("android.view.Surface").getDeclaredMethod("addEpdc", IntArray::class.java).invoke(
-            (targetView as SurfaceView).holder.surface, iArr);
-        } catch (e: Exception) {
-            Log.e(NGL4TAG, e.toString())
-            false
-        }
     }
 
     override fun resume() {}
     override fun pause() {}
 }
+
+
+

--- a/app/src/main/java/org/koreader/launcher/device/epd/NGL4EPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/NGL4EPDController.kt
@@ -46,7 +46,7 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
     }
 
     override fun getPlatform(): String {
-        // the platform reported is "freescale" in order to not introduce new unexplained names 
+        // the platform reported is "freescale" in order to not introduce new unexplained names
         return "freescale"
     }
 
@@ -76,7 +76,7 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
        return NGL4_EINK_GU16_MODE
     }
 
-    // getWaveformDelay is the only effectively used delay because of getMode being not "all" 
+    // getWaveformDelay is the only effectively used delay because of getMode being not "all"
 
     override fun getWaveformDelay(): Int {
         return NGL4_PAGE_DELAY
@@ -102,12 +102,8 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
        Log.i(NGL4TAG, String.format(Locale.US, "calling requestEpdMode: type:%d delay: %d x:%d y:%d w:%d h:%d",
           mode, delay, x, y, width, height))
        requestEpdMode(targetView, mode, delay, x, y, width, height)
-
     }
 
     override fun resume() {}
     override fun pause() {}
 }
-
-
-

--- a/app/src/main/java/org/koreader/launcher/device/epd/NGL4EPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/NGL4EPDController.kt
@@ -14,11 +14,8 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
     companion object {
         private const val NGL4TAG = "NGL4"
 
-        //const val NGL4_UI_FULL_REFRESH = -2147483644
-
         // constants taken as is from sunxi-kobo.h (NGL4 prefix insered for names)
-        // Reverse-engineering and tests showed that the constants are identical 
-
+      
         const val NGL4_EINK_INIT_MODE = 0x01
         const val NGL4_EINK_DU_MODE = 0x02
         const val NGL4_EINK_GC16_MODE = 0x04
@@ -43,7 +40,7 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
         const val NGL4_EINK_DITHERING_Y4 = 0x02800000
         const val NGL4_EINK_DITHERING_SIMPLE = 0x04800000
         const val NGL4_EINK_DITHERING_NTX_Y1 = 0x08800000
-        const val NGL4_EINK_NO_MERGE = Integer.MIN_VALUE //0x80000000
+        const val NGL4_EINK_NO_MERGE = Integer.MIN_VALUE // 0x80000000
 
         const val NGL4_PAGE_DELAY = 0
         const val NGL4_UI_DELAY = 0
@@ -56,7 +53,6 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
 
     override fun getMode(): String {
        return "full-only"
-       // return "all"
     }
 
     override fun getWaveformFull(): Int {
@@ -67,7 +63,6 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
 
     override fun getWaveformPartial(): Int {
         return NGL4_EINK_GU16_MODE
-        //return NGL4_UPDATE_PARTIAL + NGL4_EINK_GC16_MODE
     }
 
     override fun getWaveformFullUi(): Int {
@@ -76,13 +71,10 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
 
     override fun getWaveformPartialUi(): Int {
        return NGL4_EINK_GLR16_MODE
-       // return NGL4_UPDATE_PARTIAL + NGL4_EINK_GLR16_MODE
     }
 
     override fun getWaveformFast(): Int {
         return NGL4_EINK_A2_MODE;
-        //return NGL4_UPDATE_PARTIAL + NGL4_EINK_DU_MODE
-        //return NGL4_UPDATE_PARTIAL + NGL4_EINK_A2_MODE + NGL4_EINK_DITHERING_Y4
     }
 
     // the delays below are effectively not used because of the method involved
@@ -112,7 +104,6 @@ class NGL4EPDController : NTXEPDController(), EPDInterface {
         try {
           Log.i(NGL4TAG, String.format(Locale.US, "setEpdMode to addEpdc: type:%d x:%d y:%d w:%d h:%d",
             mode, x, y, width, height))
-
 
           val iArr = intArrayOf(x, y, width, height, mode)
 

--- a/app/src/main/java/org/koreader/launcher/device/epd/NGL4EPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/NGL4EPDController.kt
@@ -1,0 +1,129 @@
+/* Tested on Nook Glowlight 4e */
+
+package org.koreader.launcher.device.epd
+
+import org.koreader.launcher.device.EPDInterface
+import org.koreader.launcher.device.epd.freescale.NTXEPDController
+import android.util.Log
+import java.util.*
+import android.view.Surface;
+import android.view.SurfaceView;
+
+class NGL4EPDController : NTXEPDController(), EPDInterface {
+
+    companion object {
+        private const val NGL4TAG = "NGL4"
+
+        //const val NGL4_UI_FULL_REFRESH = -2147483644
+
+        // constants taken as is from sunxi-kobo.h (NGL4 prefix insered for names)
+        // Reverse-engineering and tests showed that the constants are identical 
+
+        const val NGL4_EINK_INIT_MODE = 0x01
+        const val NGL4_EINK_DU_MODE = 0x02
+        const val NGL4_EINK_GC16_MODE = 0x04
+        const val NGL4_EINK_GC4_MODE = 0x08
+        const val NGL4_EINK_A2_MODE = 0x10
+        const val NGL4_EINK_GL16_MODE = 0x20
+        const val NGL4_EINK_GLR16_MODE = 0x40
+        const val NGL4_EINK_GLD16_MODE = 0x80
+        const val NGL4_EINK_GU16_MODE = 0x84
+        const val NGL4_EINK_GCK16_MODE = 0x90
+        const val NGL4_EINK_GLK16_MODE = 0x94
+        const val NGL4_EINK_CLEAR_MODE = 0x88
+        const val NGL4_EINK_GC4L_MODE = 0x8C
+        const val NGL4_EINK_GCC16_MODE = 0xA0
+        const val NGL4_EINK_PARTIAL_MODE = 0x400
+        const val NGL4_EINK_AUTO_MODE = 0x8000
+        const val NGL4_EINK_NEGATIVE_MODE = 0x10000
+        const val NGL4_EINK_REGAL_MODE = 0x80000
+        const val NGL4_EINK_GAMMA_CORRECT = 0x200000
+        const val NGL4_EINK_MONOCHROME = 0x400000
+        const val NGL4_EINK_DITHERING_Y1 = 0x01800000
+        const val NGL4_EINK_DITHERING_Y4 = 0x02800000
+        const val NGL4_EINK_DITHERING_SIMPLE = 0x04800000
+        const val NGL4_EINK_DITHERING_NTX_Y1 = 0x08800000
+        const val NGL4_EINK_NO_MERGE = Integer.MIN_VALUE //0x80000000
+
+        const val NGL4_PAGE_DELAY = 0
+        const val NGL4_UI_DELAY = 0
+        const val NGL4_FAST_DELAY = 0
+    }
+
+    override fun getPlatform(): String {
+        return "freescale"
+    }
+
+    override fun getMode(): String {
+       return "full-only"
+       // return "all"
+    }
+
+    override fun getWaveformFull(): Int {
+        return NGL4_EINK_NO_MERGE + NGL4_EINK_GC16_MODE
+    }
+
+    // the mode constants below are effectively not used because getMode returns anything other than "all"
+
+    override fun getWaveformPartial(): Int {
+        return NGL4_EINK_GU16_MODE
+        //return NGL4_UPDATE_PARTIAL + NGL4_EINK_GC16_MODE
+    }
+
+    override fun getWaveformFullUi(): Int {
+        return NGL4_EINK_NO_MERGE + EINK_WAVEFORM_MODE_GLR16
+    }
+
+    override fun getWaveformPartialUi(): Int {
+       return NGL4_EINK_GLR16_MODE
+       // return NGL4_UPDATE_PARTIAL + NGL4_EINK_GLR16_MODE
+    }
+
+    override fun getWaveformFast(): Int {
+        return NGL4_EINK_A2_MODE;
+        //return NGL4_UPDATE_PARTIAL + NGL4_EINK_DU_MODE
+        //return NGL4_UPDATE_PARTIAL + NGL4_EINK_A2_MODE + NGL4_EINK_DITHERING_Y4
+    }
+
+    // the delays below are effectively not used because of the method involved
+
+    override fun getWaveformDelay(): Int {
+        return NGL4_PAGE_DELAY
+    }
+
+    override fun getWaveformDelayUi(): Int {
+        return NGL4_UI_DELAY
+    }
+
+    override fun getWaveformDelayFast(): Int {
+        return NGL4_FAST_DELAY
+    }
+
+    override fun needsView(): Boolean {
+        return true
+        //return false
+    }
+
+    override fun setEpdMode(targetView: android.view.View,
+                            mode: Int, delay: Long,
+                            x: Int, y: Int, width: Int, height: Int, epdMode: String?)
+    {
+
+        try {
+          Log.i(NGL4TAG, String.format(Locale.US, "setEpdMode to addEpdc: type:%d x:%d y:%d w:%d h:%d",
+            mode, x, y, width, height))
+
+
+          val iArr = intArrayOf(x, y, width, height, mode)
+
+          Class.forName("android.view.Surface").getDeclaredMethod("addEpdc", IntArray::class.java).invoke(
+            (targetView as SurfaceView).holder.surface, iArr);
+        } catch (e: Exception) {
+            Log.e(NGL4TAG, e.toString())
+            false
+        }
+    }
+
+    override fun resume() {}
+    override fun pause() {}
+}


### PR DESCRIPTION
This commit overrides the [previously closed](https://github.com/koreader/android-luajit-launcher/pull/450) with the following changes

- `NativeSurfaceView` is brought to top in order for Nook Glowlight 4 refresh to work. This change logically affects other controllers that report `needsView`, but the change should be compatible 
- `NGL4EPDController.kt` module was introduced (mostly in the previous PR)  with all registering routines. In this PR made several changes based on the previous tests and discussions. 

The changes were tested on Nook Glowlight 4e (debug compilation to `koreader-android-arm-debug-v2023.10-82-g5d2a44106_2023-12-29.apk`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/460)
<!-- Reviewable:end -->
