### PR TITLE
Modification to TestActivity.kt adding Nook GL4 support for testing

### DIFF
--- a/app/src/main/java/org/koreader/launcher/TestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/TestActivity.kt
@@ -16,6 +16,7 @@ import org.koreader.launcher.device.epd.OnyxEPDController
 import org.koreader.launcher.device.epd.RK3026EPDController
 import org.koreader.launcher.device.epd.RK3368EPDController
 import org.koreader.launcher.device.epd.TolinoEPDController
+import org.koreader.launcher.device.epd.NGL4EPDController
 import org.koreader.launcher.device.lights.OnyxC67Controller
 import org.koreader.launcher.device.lights.OnyxColorController
 import org.koreader.launcher.device.lights.OnyxSdkLightsController
@@ -63,6 +64,7 @@ class TestActivity: AppCompatActivity() {
         epdMap["Rockchip RK3026"] = RK3026EPDController()
         epdMap["Rockchip RK3368"] = RK3368EPDController()
         epdMap["Freescale/NTX"] = TolinoEPDController()
+        epdMap["Nook GL4"] = NGL4EPDController()
 
         // Lights drivers
         lightsMap["Boyue S62 Root"] = BoyueS62RootController()
@@ -158,14 +160,18 @@ class TestActivity: AppCompatActivity() {
             epdMap[id]?.let { driver ->
                 when (id) {
                     "Freescale/NTX",
-                    "Onyx/Qualcomm" -> {
+                    "Onyx/Qualcomm",
+                    "Nook GL4" -> {
                         val display = windowManager.defaultDisplay
                         val size = Point()
                         display.getSize(size)
-                        if (id == "Freescale/NTX") {
+                        when (id) {
+                          "Freescale/NTX" ->
                             driver.setEpdMode(v, 34, 50, 0, 0, size.x, size.y, null)
-                        } else {
+                          "Onyx/Qualcomm" ->
                             driver.setEpdMode(v, 98, 50, 0, 0, size.x, size.y, null)
+                          "Nook GL4" ->
+                            driver.setEpdMode(v, -2147483644, 50, 0, 0, size.x, size.y, null)
                         }
                     }
 


### PR DESCRIPTION
This modification will allow for any new device without eInk support to test it either with the refresh constant from the Nook Glowlight 4/4e/4 plus series.

The current drawback of the commit (if to say so) is that since the controllers are probably sorted by class names, the Nook GL4 becomes the first in the list and selected (the only direct competitor for sorting might be `Freescale..` but it has the class name `TolinoEPDController` so alphabetically it's after).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/465)
<!-- Reviewable:end -->
