### PR TITLE
Added onyx note air3c

### DIFF
--- a/app/src/main/java/org/koreader/launcher/TestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/TestActivity.kt
@@ -17,6 +17,7 @@ import org.koreader.launcher.device.epd.RK3026EPDController
 import org.koreader.launcher.device.epd.RK3368EPDController
 import org.koreader.launcher.device.epd.TolinoEPDController
 import org.koreader.launcher.device.epd.NGL4EPDController
+import org.koreader.launcher.device.lights.OnyxBlController
 import org.koreader.launcher.device.lights.OnyxC67Controller
 import org.koreader.launcher.device.lights.OnyxColorController
 import org.koreader.launcher.device.lights.OnyxSdkLightsController
@@ -72,6 +73,7 @@ class TestActivity: AppCompatActivity() {
         lightsMap["Onyx Color"] = OnyxColorController()
         lightsMap["Onyx SDK (lights)"] = OnyxSdkLightsController()
         lightsMap["Onyx (warmth)"] = OnyxWarmthController()
+        lightsMap["Onyx (bl)"] = OnyxBlController()
         lightsMap["Tolino Root"] = TolinoRootController()
         lightsMap["Tolino Ntx"] = TolinoNtxController()
         lightsMap["Tolino Ntx (no warmth)"] = TolinoNtxNoWarmthController()

--- a/app/src/main/java/org/koreader/launcher/TestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/TestActivity.kt
@@ -17,10 +17,10 @@ import org.koreader.launcher.device.epd.RK3026EPDController
 import org.koreader.launcher.device.epd.RK3368EPDController
 import org.koreader.launcher.device.epd.TolinoEPDController
 import org.koreader.launcher.device.epd.NGL4EPDController
-import org.koreader.launcher.device.lights.OnyxBlController
 import org.koreader.launcher.device.lights.OnyxC67Controller
 import org.koreader.launcher.device.lights.OnyxColorController
 import org.koreader.launcher.device.lights.OnyxSdkLightsController
+import org.koreader.launcher.device.lights.OnyxSdk2LightsController
 import org.koreader.launcher.device.lights.OnyxWarmthController
 import org.koreader.launcher.device.lights.TolinoRootController
 import org.koreader.launcher.device.lights.TolinoNtxController
@@ -72,8 +72,8 @@ class TestActivity: AppCompatActivity() {
         lightsMap["Onyx C67"] = OnyxC67Controller()
         lightsMap["Onyx Color"] = OnyxColorController()
         lightsMap["Onyx SDK (lights)"] = OnyxSdkLightsController()
+        lightsMap["Onyx SDK2 (lights)"] = OnyxSdk2LightsController()
         lightsMap["Onyx (warmth)"] = OnyxWarmthController()
-        lightsMap["Onyx (bl)"] = OnyxBlController()
         lightsMap["Tolino Root"] = TolinoRootController()
         lightsMap["Tolino Ntx"] = TolinoNtxController()
         lightsMap["Tolino Ntx (no warmth)"] = TolinoNtxNoWarmthController()

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -71,6 +71,7 @@ object DeviceInfo {
         ONYX_NOTE5,
         ONYX_NOTE_AIR,
         ONYX_NOTE_AIR2,
+        ONYX_NOTE_AIR3C,
         ONYX_NOTE_PRO,
         ONYX_NOTE_X2,
         ONYX_NOVA,
@@ -117,6 +118,7 @@ object DeviceInfo {
         ONYX_NOTE4,
         ONYX_NOTE_AIR,
         ONYX_NOTE_AIR2,
+        ONYX_NOTE_AIR3C,
         ONYX_NOTE_PRO,
         ONYX_NOTE_X2,
         ONYX_NOVA,
@@ -208,6 +210,7 @@ object DeviceInfo {
     private val ONYX_NOTE5: Boolean
     private val ONYX_NOTE_AIR: Boolean
     private val ONYX_NOTE_AIR2: Boolean
+    private val ONYX_NOTE_AIR3C: Boolean
     private val ONYX_NOTE_PRO: Boolean
     private val ONYX_NOTE_X2: Boolean
     private val ONYX_NOVA: Boolean
@@ -435,6 +438,11 @@ object DeviceInfo {
         ONYX_NOTE_AIR2 = BRAND.contentEquals("onyx")
             && (MODEL.contentEquals("noteair2") || MODEL.contentEquals("noteair2p"))
 
+        // Onyx Note Air 3C
+        ONYX_NOTE_AIR3C = BRAND.contentEquals("onyx")
+            && PRODUCT.contentEquals("noteair3c")
+            && DEVICE.contentEquals("noteair3c")
+
         // Onyx Note Pro
         ONYX_NOTE_PRO = MANUFACTURER.contentEquals("onyx")
             && PRODUCT.contentEquals("notepro")
@@ -638,6 +646,7 @@ object DeviceInfo {
         deviceMap[EinkDevice.ONYX_NOTE5] = ONYX_NOTE5
         deviceMap[EinkDevice.ONYX_NOTE_AIR] = ONYX_NOTE_AIR
         deviceMap[EinkDevice.ONYX_NOTE_AIR2] = ONYX_NOTE_AIR2
+        deviceMap[EinkDevice.ONYX_NOTE_AIR3C] = ONYX_NOTE_AIR3C
         deviceMap[EinkDevice.ONYX_NOTE_PRO] = ONYX_NOTE_PRO
         deviceMap[EinkDevice.ONYX_NOTE_X2] = ONYX_NOTE_X2
         deviceMap[EinkDevice.ONYX_NOVA] = ONYX_NOVA
@@ -693,6 +702,7 @@ object DeviceInfo {
         lightsMap[LightsDevice.ONYX_NOTE4] = ONYX_NOTE4
         lightsMap[LightsDevice.ONYX_NOTE_AIR] = ONYX_NOTE_AIR
         lightsMap[LightsDevice.ONYX_NOTE_AIR2] = ONYX_NOTE_AIR2
+        lightsMap[LightsDevice.ONYX_NOTE_AIR3C] = ONYX_NOTE_AIR3C
         lightsMap[LightsDevice.ONYX_NOTE_X2] = ONYX_NOTE_X2
         lightsMap[LightsDevice.ONYX_NOVA] = ONYX_NOVA
         lightsMap[LightsDevice.ONYX_NOVA2] = ONYX_NOVA2

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -768,6 +768,7 @@ object DeviceInfo {
 
         HAS_COLOR_SCREEN = when (EINK) {
             EinkDevice.NONE,
+            EinkDevice.ONYX_NOTE_AIR3C,
             EinkDevice.ONYX_NOVA3_COLOR,
             EinkDevice.ONYX_TAB_ULTRA_C,
             EinkDevice.ONYX_NOVA_AIR_C -> true

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -80,6 +80,7 @@ object EPDFactory {
                 DeviceInfo.EinkDevice.ONYX_NOTE5,
                 DeviceInfo.EinkDevice.ONYX_NOTE_AIR,
                 DeviceInfo.EinkDevice.ONYX_NOTE_AIR2,
+                DeviceInfo.EinkDevice.ONYX_NOTE_AIR3C,
                 DeviceInfo.EinkDevice.ONYX_NOTE_PRO,
                 DeviceInfo.EinkDevice.ONYX_NOTE_X2,
                 DeviceInfo.EinkDevice.ONYX_NOVA,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -61,8 +61,8 @@ object LightsFactory {
                     OnyxSdkLightsController()
                 }
                 DeviceInfo.LightsDevice.ONYX_NOTE_AIR3C -> {
-                    logController("Onyx/Bl")
-                    OnyxBlController()
+                    logController("Onyx/Sdk2")
+                    OnyxSdk2LightsController()
                 }
                 DeviceInfo.LightsDevice.ONYX_NOVA3_COLOR,
                 DeviceInfo.LightsDevice.TAGUS_GEA -> {

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -60,6 +60,10 @@ object LightsFactory {
                     logController("Onyx/Sdk")
                     OnyxSdkLightsController()
                 }
+                DeviceInfo.LightsDevice.ONYX_NOTE_AIR3C -> {
+                    logController("Onyx/Bl")
+                    OnyxBlController()
+                }
                 DeviceInfo.LightsDevice.ONYX_NOVA3_COLOR,
                 DeviceInfo.LightsDevice.TAGUS_GEA -> {
                     logController("Onyx color")

--- a/app/src/main/java/org/koreader/launcher/device/lights/OnyxBlController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/OnyxBlController.kt
@@ -1,0 +1,86 @@
+package org.koreader.launcher.device.lights
+
+import android.app.Activity
+import android.util.Log
+import org.koreader.launcher.device.LightsInterface
+import org.koreader.launcher.extensions.read
+import org.koreader.launcher.extensions.write
+import java.io.File
+
+class OnyxBlController : LightsInterface {
+    companion object {
+        private const val TAG = "Lights"
+        private const val MIN = 0
+        private const val WHITE_FILE = "/sys/class/backlight/onyx_bl_br/brightness"
+        private const val WARMTH_FILE = "/sys/class/backlight/onyx_bl_ct/brightness"
+        private const val MAX_WHITE_FILE = "/sys/class/backlight/onyx_bl_br/max_brightness"
+        private const val MAX_WARMTH_FILE = "/sys/class/backlight/onyx_bl_ct/max_brightness"
+    }
+
+    override fun getPlatform(): String {
+        return "onyx-bl"
+    }
+
+    override fun hasFallback(): Boolean {
+        return false
+    }
+
+    override fun hasWarmth(): Boolean {
+        return true
+    }
+
+    override fun needsPermission(): Boolean {
+        return false
+    }
+
+    override fun getBrightness(activity: Activity): Int {
+        return File(WHITE_FILE).read()
+    }
+
+    override fun getWarmth(activity: Activity): Int {
+        return File(WARMTH_FILE).read()
+    }
+
+    override fun setBrightness(activity: Activity, brightness: Int) {
+        if (brightness < MIN || brightness > getMaxBrightness()) {
+            Log.w(TAG, "brightness value of of range: $brightness")
+            return
+        }
+        Log.v(TAG, "Setting brightness to $brightness")
+        File(WHITE_FILE).write(brightness)
+    }
+
+    override fun setWarmth(activity: Activity, warmth: Int) {
+        if (warmth < MIN || warmth > getMaxWarmth()) {
+            Log.w(TAG, "warmth value of of range: $warmth")
+            return
+        }
+
+        Log.v(TAG, "Setting warmth to $warmth")
+        File(WARMTH_FILE).write(warmth)
+    }
+
+    override fun getMinWarmth(): Int {
+        return MIN
+    }
+
+    override fun getMaxWarmth(): Int {
+        return File(MAX_WARMTH_FILE).read()
+    }
+
+    override fun getMinBrightness(): Int {
+        return MIN
+    }
+
+    override fun getMaxBrightness(): Int {
+        return File(MAX_WHITE_FILE).read()
+    }
+
+    override fun enableFrontlightSwitch(activity: Activity): Int {
+        return 1
+    }
+
+    override fun hasStandaloneWarmth(): Boolean {
+        return true
+    }
+}

--- a/app/src/main/java/org/koreader/launcher/device/lights/OnyxSdk2LightsController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/OnyxSdk2LightsController.kt
@@ -3,22 +3,15 @@ package org.koreader.launcher.device.lights
 import android.app.Activity
 import android.util.Log
 import org.koreader.launcher.device.LightsInterface
-import org.koreader.launcher.extensions.read
-import org.koreader.launcher.extensions.write
-import java.io.File
 
-class OnyxBlController : LightsInterface {
+class OnyxSdk2LightsController : LightsInterface {
     companion object {
         private const val TAG = "Lights"
-        private const val MIN = 0
-        private const val WHITE_FILE = "/sys/class/backlight/onyx_bl_br/brightness"
-        private const val WARMTH_FILE = "/sys/class/backlight/onyx_bl_ct/brightness"
-        private const val MAX_WHITE_FILE = "/sys/class/backlight/onyx_bl_br/max_brightness"
-        private const val MAX_WARMTH_FILE = "/sys/class/backlight/onyx_bl_ct/max_brightness"
+        private const val MIN_LIGHT_VALUE = 0
     }
 
     override fun getPlatform(): String {
-        return "onyx-bl"
+        return "onyx-sdk-2-lights"
     }
 
     override fun hasFallback(): Boolean {
@@ -34,46 +27,45 @@ class OnyxBlController : LightsInterface {
     }
 
     override fun getBrightness(activity: Activity): Int {
-        return File(WHITE_FILE).read()
+        return OnyxSdkDeviceController.getLightValue(OnyxSdkDeviceController.Light.COLD)
     }
 
     override fun getWarmth(activity: Activity): Int {
-        return File(WARMTH_FILE).read()
+        return OnyxSdkDeviceController.getLightValue(OnyxSdkDeviceController.Light.WARM)
     }
 
     override fun setBrightness(activity: Activity, brightness: Int) {
-        if (brightness < MIN || brightness > getMaxBrightness()) {
+        if (brightness < getMinBrightness() || brightness > getMaxBrightness()) {
             Log.w(TAG, "brightness value of of range: $brightness")
             return
         }
         Log.v(TAG, "Setting brightness to $brightness")
-        File(WHITE_FILE).write(brightness)
+        OnyxSdkDeviceController.setLightValue(OnyxSdkDeviceController.Light.COLD, brightness)
     }
 
     override fun setWarmth(activity: Activity, warmth: Int) {
-        if (warmth < MIN || warmth > getMaxWarmth()) {
+        if (warmth < getMinWarmth() || warmth > getMaxWarmth()) {
             Log.w(TAG, "warmth value of of range: $warmth")
             return
         }
-
         Log.v(TAG, "Setting warmth to $warmth")
-        File(WARMTH_FILE).write(warmth)
+        OnyxSdkDeviceController.setLightValue(OnyxSdkDeviceController.Light.WARM, warmth)
     }
 
     override fun getMinWarmth(): Int {
-        return MIN
+        return MIN_LIGHT_VALUE
     }
 
     override fun getMaxWarmth(): Int {
-        return File(MAX_WARMTH_FILE).read()
+        return OnyxSdkDeviceController.getMaxLightValue(OnyxSdkDeviceController.Light.WARM)
     }
 
     override fun getMinBrightness(): Int {
-        return MIN
+        return MIN_LIGHT_VALUE
     }
 
     override fun getMaxBrightness(): Int {
-        return File(MAX_WHITE_FILE).read()
+        return OnyxSdkDeviceController.getMaxLightValue(OnyxSdkDeviceController.Light.COLD)
     }
 
     override fun enableFrontlightSwitch(activity: Activity): Int {
@@ -81,6 +73,6 @@ class OnyxBlController : LightsInterface {
     }
 
     override fun hasStandaloneWarmth(): Boolean {
-        return true
+        return false
     }
 }

--- a/app/src/main/java/org/koreader/launcher/device/lights/OnyxSdkDeviceController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/OnyxSdkDeviceController.kt
@@ -1,0 +1,68 @@
+package org.koreader.launcher.device.lights
+
+import android.util.Log
+import java.lang.Class.forName
+import java.lang.reflect.Method
+
+object OnyxSdkDeviceController {
+    enum class Light(val code: Int) {
+        COLD(7),
+        WARM(6)
+    }
+
+    private const val TAG = "lights"
+
+    private val flController: Class<*>? = try {
+        forName("android.onyx.hardware.DeviceController")
+    } catch (e: Exception) {
+        Log.w(TAG, "$e")
+        null
+    }
+
+    private val getMaxLightValueMethod: Method? = try {
+        flController!!.getMethod("getMaxLightValue", Integer.TYPE)
+    } catch (e: Exception) {
+        Log.w(TAG, "$e")
+        null
+    }
+
+    private val getLightValueMethod: Method? = try {
+        flController!!.getMethod("getLightValue", Integer.TYPE)
+    } catch (e: Exception) {
+        Log.w(TAG, "$e")
+        null
+    }
+
+    private val setLightValueMethod: Method? = try {
+        flController!!.getMethod("setLightValue", Integer.TYPE, Integer.TYPE)
+    } catch (e: Exception) {
+        Log.w(TAG, "$e")
+        null
+    }
+
+    fun getMaxLightValue(light: Light): Int {
+        return try {
+            getMaxLightValueMethod!!.invoke(flController!!, light.code) as Int
+        } catch (e: Exception) {
+            Log.e(TAG, "error getting the max light $light", e)
+            0
+        }
+    }
+
+    fun getLightValue(light: Light): Int {
+        return try {
+            getLightValueMethod!!.invoke(flController!!, light.code) as Int
+        } catch (e: Exception) {
+            Log.e(TAG, "error getting the light $light", e)
+            0
+        }
+    }
+
+    fun setLightValue(light: Light, value: Int) {
+        try {
+            setLightValueMethod!!.invoke(flController!!, light.code, value)
+        } catch (e: Exception) {
+            Log.e(TAG, "error setting the light $light to $value", e)
+        }
+    }
+}


### PR DESCRIPTION
Changes to support the onyx air book3c device. I have not been able to check that the code works after compiling it since I don't have the android development kit installed although I have checked that the paths to get/modify the white/warm light work correctly with the adb shell.

The android version is `12`, the device version is `2023-12-29_16-55_3.5_f54c71ad2` and the device info is

```
Manufacturer: qualcomm
Brand: onyx
Model: noteair3c
Device: noteair3c
Product: noteair3c
Hardware: qcom
Platform: bengal
```

The log obtained after the execution of the compability test could be found in [test.log.zip](https://github.com/koreader/android-luajit-launcher/files/14412731/test.log.zip)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/471)
<!-- Reviewable:end -->
