### PR TITLE
Add support for C64P

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -101,7 +101,6 @@ object DeviceInfo {
 
     enum class LightsDevice {
         NONE,
-        BOYUE_C64P,
         BOYUE_S62,
         CREMA_CARTA_G,
         MEEBOOK_P6,

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -41,6 +41,7 @@ object DeviceInfo {
         BOYUE_T80D,
         BOYUE_T80S,
         BOYUE_T103D,
+        C64P,
         CREMA,
         CREMA_0650L,
         CREMA_CARTA_G,
@@ -101,6 +102,7 @@ object DeviceInfo {
     enum class LightsDevice {
         NONE,
         BOYUE_S62,
+        C64P,
         CREMA_CARTA_G,
         MEEBOOK_P6,
         ONYX_C67,
@@ -179,6 +181,7 @@ object DeviceInfo {
     private val BOYUE_T80D: Boolean
     private val BOYUE_T80S: Boolean
     private val BOYUE_T103D: Boolean
+    private val C64P: Boolean
     private val CREMA: Boolean
     private val CREMA_0650L: Boolean
     private val CREMA_CARTA_G: Boolean
@@ -298,6 +301,10 @@ object DeviceInfo {
         // Boyue Likebook Mimas
         BOYUE_T103D = BOYUE
             && (PRODUCT.contentEquals("t103d") || PRODUCT.contentEquals("mimas"))
+
+        // C64P (Boyue P6 Clone)
+        C64P = BRAND.contentEquals("c64p")
+            && PRODUCT.contentEquals("c64p")
 
         // Crema Note (1010P)
         CREMA = BRAND.contentEquals("crema")
@@ -617,6 +624,7 @@ object DeviceInfo {
         deviceMap[EinkDevice.BOYUE_T80D] = BOYUE_T80D
         deviceMap[EinkDevice.BOYUE_T80S] = BOYUE_T80S
         deviceMap[EinkDevice.BOYUE_T103D] = BOYUE_T103D
+        deviceMap[EinkDevice.C64P] = C64P
         deviceMap[EinkDevice.CREMA] = CREMA
         deviceMap[EinkDevice.CREMA_0650L] = CREMA_0650L
         deviceMap[EinkDevice.CREMA_CARTA_G] = CREMA_CARTA_G
@@ -685,6 +693,7 @@ object DeviceInfo {
         // devices with custom lights
         val lightsMap = HashMap<LightsDevice, Boolean>()
         lightsMap[LightsDevice.BOYUE_S62] = BOYUE_S62
+        lightsMap[LightsDevice.C64P] = C64P
         lightsMap[LightsDevice.CREMA_CARTA_G] = CREMA_CARTA_G
         lightsMap[LightsDevice.MEEBOOK_P6] = MEEBOOK_P6
         lightsMap[LightsDevice.ONYX_C67] = ONYX_C67

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -28,6 +28,7 @@ object DeviceInfo {
 
     enum class EinkDevice {
         NONE,
+        BOYUE_C64P,
         BOYUE_K78W,
         BOYUE_K103,
         BOYUE_P6,
@@ -41,7 +42,6 @@ object DeviceInfo {
         BOYUE_T80D,
         BOYUE_T80S,
         BOYUE_T103D,
-        C64P,
         CREMA,
         CREMA_0650L,
         CREMA_CARTA_G,
@@ -101,8 +101,8 @@ object DeviceInfo {
 
     enum class LightsDevice {
         NONE,
+        BOYUE_C64P,
         BOYUE_S62,
-        C64P,
         CREMA_CARTA_G,
         MEEBOOK_P6,
         ONYX_C67,
@@ -168,6 +168,7 @@ object DeviceInfo {
     internal val TOLINO: Boolean
 
     // device probe
+    private val BOYUE_C64P: Boolean
     private val BOYUE_K78W: Boolean
     private val BOYUE_K103: Boolean
     private val BOYUE_P6: Boolean
@@ -181,7 +182,6 @@ object DeviceInfo {
     private val BOYUE_T80D: Boolean
     private val BOYUE_T80S: Boolean
     private val BOYUE_T103D: Boolean
-    private val C64P: Boolean
     private val CREMA: Boolean
     private val CREMA_0650L: Boolean
     private val CREMA_CARTA_G: Boolean
@@ -254,6 +254,10 @@ object DeviceInfo {
         BOYUE = MANUFACTURER.contentEquals("boeye")
             || MANUFACTURER.contentEquals("boyue")
 
+        // Boyue C64P (Boyue P6 Clone)
+        BOYUE_C64P = BRAND.contentEquals("c64p")
+            && PRODUCT.contentEquals("c64p")
+
         // Boyue Likebook Ares
         BOYUE_K78W = BOYUE
             && (PRODUCT.contentEquals("k78w") || PRODUCT.contentEquals("ares"))
@@ -301,10 +305,6 @@ object DeviceInfo {
         // Boyue Likebook Mimas
         BOYUE_T103D = BOYUE
             && (PRODUCT.contentEquals("t103d") || PRODUCT.contentEquals("mimas"))
-
-        // C64P (Boyue P6 Clone)
-        C64P = BRAND.contentEquals("c64p")
-            && PRODUCT.contentEquals("c64p")
 
         // Crema Note (1010P)
         CREMA = BRAND.contentEquals("crema")
@@ -611,6 +611,7 @@ object DeviceInfo {
 
         // e-ink devices
         val deviceMap = HashMap<EinkDevice, Boolean>()
+        deviceMap[EinkDevice.BOYUE_C64P] = BOYUE_C64P
         deviceMap[EinkDevice.BOYUE_K103] = BOYUE_K103
         deviceMap[EinkDevice.BOYUE_K78W] = BOYUE_K78W
         deviceMap[EinkDevice.BOYUE_P6] = BOYUE_P6
@@ -624,7 +625,6 @@ object DeviceInfo {
         deviceMap[EinkDevice.BOYUE_T80D] = BOYUE_T80D
         deviceMap[EinkDevice.BOYUE_T80S] = BOYUE_T80S
         deviceMap[EinkDevice.BOYUE_T103D] = BOYUE_T103D
-        deviceMap[EinkDevice.C64P] = C64P
         deviceMap[EinkDevice.CREMA] = CREMA
         deviceMap[EinkDevice.CREMA_0650L] = CREMA_0650L
         deviceMap[EinkDevice.CREMA_CARTA_G] = CREMA_CARTA_G
@@ -693,7 +693,6 @@ object DeviceInfo {
         // devices with custom lights
         val lightsMap = HashMap<LightsDevice, Boolean>()
         lightsMap[LightsDevice.BOYUE_S62] = BOYUE_S62
-        lightsMap[LightsDevice.C64P] = C64P
         lightsMap[LightsDevice.CREMA_CARTA_G] = CREMA_CARTA_G
         lightsMap[LightsDevice.MEEBOOK_P6] = MEEBOOK_P6
         lightsMap[LightsDevice.ONYX_C67] = ONYX_C67

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -18,10 +18,10 @@ object EPDFactory {
     val epdController: EPDInterface
         get() {
             return when (DeviceInfo.EINK) {
+                DeviceInfo.EinkDevice.BOYUE_C64P,
                 DeviceInfo.EinkDevice.BOYUE_T61,
                 DeviceInfo.EinkDevice.BOYUE_T62,
                 DeviceInfo.EinkDevice.BOYUE_T80S,
-                DeviceInfo.EinkDevice.C64P,
                 DeviceInfo.EinkDevice.CREMA_0650L,
                 DeviceInfo.EinkDevice.ENERGY,
                 DeviceInfo.EinkDevice.FIDIBOOK,

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -18,7 +18,6 @@ object EPDFactory {
     val epdController: EPDInterface
         get() {
             return when (DeviceInfo.EINK) {
-                DeviceInfo.EinkDevice.BOYUE_C64P,
                 DeviceInfo.EinkDevice.BOYUE_T61,
                 DeviceInfo.EinkDevice.BOYUE_T62,
                 DeviceInfo.EinkDevice.BOYUE_T80S,
@@ -34,6 +33,7 @@ object EPDFactory {
                     RK3026EPDController()
                 }
 
+                DeviceInfo.EinkDevice.BOYUE_C64P,
                 DeviceInfo.EinkDevice.BOYUE_K78W,
                 DeviceInfo.EinkDevice.BOYUE_K103,
                 DeviceInfo.EinkDevice.BOYUE_P6,

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -21,6 +21,7 @@ object EPDFactory {
                 DeviceInfo.EinkDevice.BOYUE_T61,
                 DeviceInfo.EinkDevice.BOYUE_T62,
                 DeviceInfo.EinkDevice.BOYUE_T80S,
+                DeviceInfo.EinkDevice.C64P,
                 DeviceInfo.EinkDevice.CREMA_0650L,
                 DeviceInfo.EinkDevice.ENERGY,
                 DeviceInfo.EinkDevice.FIDIBOOK,


### PR DESCRIPTION
commercial name of product: C64P (Boyue P6 Knockoff) android version: 8.1
driver(s) that work;
Rockchip RK3368
Rockchip RK3026

Other:
None of the light drivers work in the compatibility checker but light works in the app. My device only works in A2 mode.
*Tolino/NTX driver doesnt work.

Device info:
Manufacturer: c64p
Brand: c64p
Model: c64p
Device: c64p
Product: c64p
Hardware: rk30board
Platform: rk3326

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/474)
<!-- Reviewable:end -->
