### PR TITLE
Support for Boyue P6 Knockoff

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -28,6 +28,7 @@ object DeviceInfo {
 
     enum class EinkDevice {
         NONE,
+        BOYUE_C64P,
         BOYUE_K78W,
         BOYUE_K103,
         BOYUE_P6,
@@ -166,6 +167,7 @@ object DeviceInfo {
     internal val TOLINO: Boolean
 
     // device probe
+    private val BOYUE_C64P: Boolean
     private val BOYUE_K78W: Boolean
     private val BOYUE_K103: Boolean
     private val BOYUE_P6: Boolean
@@ -250,6 +252,10 @@ object DeviceInfo {
         HARDWARE = lowerCase(getBuildField("HARDWARE"))
         BOYUE = MANUFACTURER.contentEquals("boeye")
             || MANUFACTURER.contentEquals("boyue")
+
+        // Boyue P6 Knockoff
+        BOYUE_C64P = MANUFACTURER.contentEquals("c64p")
+            && PRODUCT.contentEquals("c64p")
 
         // Boyue Likebook Ares
         BOYUE_K78W = BOYUE
@@ -604,6 +610,7 @@ object DeviceInfo {
 
         // e-ink devices
         val deviceMap = HashMap<EinkDevice, Boolean>()
+        deviceMap[EinkDevice.BOYUE_C64P] = BOYUE_C64P
         deviceMap[EinkDevice.BOYUE_K103] = BOYUE_K103
         deviceMap[EinkDevice.BOYUE_K78W] = BOYUE_K78W
         deviceMap[EinkDevice.BOYUE_P6] = BOYUE_P6

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -33,6 +33,7 @@ object EPDFactory {
                     RK3026EPDController()
                 }
 
+                DeviceInfo.EinkDevice.BOYUE_C64P,
                 DeviceInfo.EinkDevice.BOYUE_K78W,
                 DeviceInfo.EinkDevice.BOYUE_K103,
                 DeviceInfo.EinkDevice.BOYUE_P6,


### PR DESCRIPTION
commercial name of product: C64P (Boyue P6 Knockoff) android version: 8.1
driver(s) that work;
Rockchip RK3368
Rockchip RK3026

Other:
None of the light drivers work in the compatibility checker but light works in the app. My device only works in A2 mode.
*Tolino/NTX driver doesnt work.

Device info:
Manufacturer: c64p
Brand: c64p
Model: c64p
Device: c64p
Product: c64p
Hardware: rk30board
Platform: rk3326

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/475)
<!-- Reviewable:end -->
