### PR TITLE
support PUBU Pubook device

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -96,13 +96,13 @@ object DeviceInfo {
         ONYX_POKE_PRO,
         ONYX_TAB_ULTRA,
         ONYX_TAB_ULTRA_C,
+        PUBU_PUBOOK,
         RIDI_PAPER_3,
         SONY_CP1,
         SONY_RP1,
         TAGUS_GEA,
         TOLINO,
-        XIAOMI_READER,
-        PUBU_PUBOOK,
+        XIAOMI_READER
     }
 
     enum class LightsDevice {
@@ -151,8 +151,7 @@ object DeviceInfo {
         TOLINO_SHINE3,
         TOLINO_VISION4,
         TOLINO_VISION5,
-        XIAOMI_READER,
-        PUBU_PUBOOK
+        XIAOMI_READER
     }
 
     enum class QuirkDevice {
@@ -245,6 +244,7 @@ object DeviceInfo {
     private val ONYX_POKE_PRO: Boolean
     private val ONYX_TAB_ULTRA: Boolean
     private val ONYX_TAB_ULTRA_C: Boolean
+    private val PUBU_PUBOOK: Boolean
     private val RIDI_PAPER_3: Boolean
     private val SONY_CP1: Boolean
     private val SONY_RP1: Boolean
@@ -255,7 +255,6 @@ object DeviceInfo {
     private val TOLINO_VISION4: Boolean
     private val TOLINO_VISION5: Boolean
     private val XIAOMI_READER: Boolean
-    private val PUBU_PUBOOK: Boolean
 
     init {
         MANUFACTURER = lowerCase(getBuildField("MANUFACTURER"))
@@ -563,6 +562,13 @@ object DeviceInfo {
         ONYX_TAB_ULTRA_C = MANUFACTURER.contentEquals("onyx")
             && MODEL.contentEquals("tabultrac")
 
+        // Pubu Pubook
+        PUBU_PUBOOK = MANUFACTURER.contentEquals("rockchip")
+            && BRAND.contentEquals("rockchip")
+            && MODEL.contentEquals("pubook")
+            && DEVICE.contentEquals("pubook")
+            && HARDWARE.contentEquals("rk30board")
+
         // Ridi Paper 3
         RIDI_PAPER_3 = BRAND.contentEquals("ridi")
             && MODEL.contentEquals("ridipaper")
@@ -622,12 +628,6 @@ object DeviceInfo {
             && BRAND.contentEquals("xiaomi")
             && MODEL.contentEquals("xiaomi_reader")
             && DEVICE.contentEquals("rk3566_eink")
-            && HARDWARE.contentEquals("rk30board")
-
-        PUBU_PUBOOK = MANUFACTURER.contentEquals("rockchip")
-            && BRAND.contentEquals("rockchip")
-            && MODEL.contentEquals("pubook")
-            && DEVICE.contentEquals("pubook")
             && HARDWARE.contentEquals("rk30board")
 
         // devices with known bugs
@@ -715,13 +715,13 @@ object DeviceInfo {
         deviceMap[EinkDevice.ONYX_POKE_PRO] = ONYX_POKE_PRO
         deviceMap[EinkDevice.ONYX_TAB_ULTRA] = ONYX_TAB_ULTRA
         deviceMap[EinkDevice.ONYX_TAB_ULTRA_C] = ONYX_TAB_ULTRA_C
+        deviceMap[EinkDevice.PUBU_PUBOOK] = PUBU_PUBOOK
         deviceMap[EinkDevice.RIDI_PAPER_3] = RIDI_PAPER_3
         deviceMap[EinkDevice.SONY_CP1] = SONY_CP1
         deviceMap[EinkDevice.SONY_RP1] = SONY_RP1
         deviceMap[EinkDevice.TAGUS_GEA] = TAGUS_GEA
         deviceMap[EinkDevice.TOLINO] = TOLINO
         deviceMap[EinkDevice.XIAOMI_READER] = XIAOMI_READER
-        deviceMap[EinkDevice.PUBU_PUBOOK] = PUBU_PUBOOK
 
         deviceMap.keys.iterator().run {
             while (this.hasNext()) {
@@ -779,7 +779,6 @@ object DeviceInfo {
         lightsMap[LightsDevice.TOLINO_VISION4] = TOLINO_VISION4
         lightsMap[LightsDevice.TOLINO_VISION5] = TOLINO_VISION5
         lightsMap[LightsDevice.XIAOMI_READER] = XIAOMI_READER
-        lightsMap[LightsDevice.PUBU_PUBOOK] = PUBU_PUBOOK
 
         lightsMap.keys.iterator().run {
             while (this.hasNext()) {

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -101,7 +101,8 @@ object DeviceInfo {
         SONY_RP1,
         TAGUS_GEA,
         TOLINO,
-        XIAOMI_READER
+        XIAOMI_READER,
+        PUBU_PUBOOK,
     }
 
     enum class LightsDevice {
@@ -150,7 +151,8 @@ object DeviceInfo {
         TOLINO_SHINE3,
         TOLINO_VISION4,
         TOLINO_VISION5,
-        XIAOMI_READER
+        XIAOMI_READER,
+        PUBU_PUBOOK
     }
 
     enum class QuirkDevice {
@@ -253,6 +255,7 @@ object DeviceInfo {
     private val TOLINO_VISION4: Boolean
     private val TOLINO_VISION5: Boolean
     private val XIAOMI_READER: Boolean
+    private val PUBU_PUBOOK: Boolean
 
     init {
         MANUFACTURER = lowerCase(getBuildField("MANUFACTURER"))
@@ -621,6 +624,12 @@ object DeviceInfo {
             && DEVICE.contentEquals("rk3566_eink")
             && HARDWARE.contentEquals("rk30board")
 
+        PUBU_PUBOOK = MANUFACTURER.contentEquals("rockchip")
+            && BRAND.contentEquals("rockchip")
+            && MODEL.contentEquals("pubook")
+            && DEVICE.contentEquals("pubook")
+            && HARDWARE.contentEquals("rk30board")
+
         // devices with known bugs
         val bugMap = HashMap<QuirkDevice, Boolean>()
         bugMap[QuirkDevice.EMULATOR] = EMULATOR_X86
@@ -712,6 +721,7 @@ object DeviceInfo {
         deviceMap[EinkDevice.TAGUS_GEA] = TAGUS_GEA
         deviceMap[EinkDevice.TOLINO] = TOLINO
         deviceMap[EinkDevice.XIAOMI_READER] = XIAOMI_READER
+        deviceMap[EinkDevice.PUBU_PUBOOK] = PUBU_PUBOOK
 
         deviceMap.keys.iterator().run {
             while (this.hasNext()) {
@@ -769,6 +779,7 @@ object DeviceInfo {
         lightsMap[LightsDevice.TOLINO_VISION4] = TOLINO_VISION4
         lightsMap[LightsDevice.TOLINO_VISION5] = TOLINO_VISION5
         lightsMap[LightsDevice.XIAOMI_READER] = XIAOMI_READER
+        lightsMap[LightsDevice.PUBU_PUBOOK] = PUBU_PUBOOK
 
         lightsMap.keys.iterator().run {
             while (this.hasNext()) {

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -120,6 +120,7 @@ object EPDFactory {
                 DeviceInfo.EinkDevice.MEEBOOK_M6,
                 DeviceInfo.EinkDevice.MEEBOOK_M7,
                 DeviceInfo.EinkDevice.MOAAN_MIX7,
+                DeviceInfo.EinkDevice.PUBU_PUBOOK,
                 DeviceInfo.EinkDevice.XIAOMI_READER -> {
                     logController("Rockchip RK3566")
                     RK3566EPDController()


### PR DESCRIPTION
Support [PUBU Pubook](https://www.pubu.com.tw/campaign/ebook/pubook_se.html).

Android version: 11

```
Device info:
Manufacturer: rockchip
Brand: rockchip
Model: pubook
Device: pubook
Product: pubook
Hardware: rk30board
Platform: rk356x
```

[test.log](https://github.com/koreader/android-luajit-launcher/files/15289893/test.log)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/482)
<!-- Reviewable:end -->
