### PR TITLE
Support for a bunch of rockchip devices

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -49,9 +49,13 @@ object DeviceInfo {
         FIDIBOOK,
         HANVON_960,
         INKBOOK,
+        INKPALM_PLUS,
         JDREAD,
         LINFINY_ENOTE,
+        MEEBOOK_M6,
+        MEEBOOK_M7,
         MEEBOOK_P6,
+        MOAAN_MIX7,
         NABUK,
         NOOK,
         NOOK_GL4,
@@ -191,9 +195,13 @@ object DeviceInfo {
     private val FIDIBOOK: Boolean
     private val HANVON_960: Boolean
     private val INKBOOK: Boolean
+    private val INKPALM_PLUS: Boolean
     private val JDREAD: Boolean
     private val LINFINY_ENOTE: Boolean
+    private val MEEBOOK_M6: Boolean
+    private val MEEBOOK_M7: Boolean
     private val MEEBOOK_P6: Boolean
+    private val MOAAN_MIX7: Boolean
     private val NABUK_REGAL_HD: Boolean
     private val NOOK: Boolean
     private val NOOK_GL4: Boolean
@@ -340,17 +348,33 @@ object DeviceInfo {
             && BRAND.contentEquals("inkbook")
             && MODEL.startsWith("prime"))
 
+        // InkPalm Plus
+        INKPALM_PLUS = MANUFACTURER.contentEquals("rockchip")
+            && MODEL.contentEquals("inkpalmplus")
+
         // JDRead1
         JDREAD = MANUFACTURER.contentEquals("onyx")
             && MODEL.contentEquals("jdread")
 
         // Linfiny A4 (13.3") eNote / Avalue ENT-13T1 / QuirkLogic Papyr
         LINFINY_ENOTE = MANUFACTURER.contentEquals("linfiny")
-	    && MODEL.contentEquals("ent-13t1")
+        && MODEL.contentEquals("ent-13t1")
+
+        // Meebook M6
+        MEEBOOK_M6 = MANUFACTURER.contentEquals("haoqing")
+            && MODEL.contentEquals("m6")
+
+        // Meebook M7
+        MEEBOOK_M7 = MANUFACTURER.contentEquals("haoqing")
+            && MODEL.contentEquals("m7")
 
         // Meebook P6
         MEEBOOK_P6 = MANUFACTURER.contentEquals("haoqing")
             && MODEL.contentEquals("p6")
+
+        // Moaan Mix7
+        MOAAN_MIX7 = MANUFACTURER.contentEquals("rockchip")
+            && MODEL.contentEquals("moaanmix7")
 
         // Nabuk Regal HD
         NABUK_REGAL_HD = MANUFACTURER.contentEquals("onyx")

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -116,6 +116,10 @@ object EPDFactory {
                     OldTolinoEPDController()
                 }
 
+                DeviceInfo.EinkDevice.INKPALM_PLUS,
+                DeviceInfo.EinkDevice.MEEBOOK_M6,
+                DeviceInfo.EinkDevice.MEEBOOK_M7,
+                DeviceInfo.EinkDevice.MOAAN_MIX7,
                 DeviceInfo.EinkDevice.XIAOMI_READER -> {
                     logController("Rockchip RK3566")
                     RK3566EPDController()


### PR DESCRIPTION
Device info:
Manufacturer: haoqing
Brand: haoqing
Model: m6
Device: m6
Product: rk3566_eink
Hardware: rk30board
Platform: rk356x

Working EPD Driver: RK3566

Device info:
Manufacturer: haoqing
Brand: haoqing
Model: m7
Device: m7
Product: rk3566_eink
Hardware: rk30board
Platform: rk356x

Working EPD Driver: RK3566

Device info:
Manufacturer: rockchip
Brand: rockchip
Model: moaanmix7
Device: rk3566_eink
Product: moaan
Hardware: rk30board
Platform: rk356x

Working EPD Driver: RK3566

Device info:
Manufacturer: rockchip
Brand: rockchip
Model: inkpalmplus
Device: rk3566_eink
Product: moaan
Hardware: rk30board
Platform: rk356x

Working EPD Driver: RK3566

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/483)
<!-- Reviewable:end -->
