### PR TITLE
lzma: minor cleanup

### DIFF
--- a/jni/lzma/un7zip/7zAssetFile.h
+++ b/jni/lzma/un7zip/7zAssetFile.h
@@ -22,11 +22,6 @@ WRes InAssetFile_Open(struct AAssetManager *mgr, CSzAssetFile *p, const char *na
 
 WRes AssetFile_Close(CSzAssetFile *p);
 
-/* reads max(*size, remain file's size) bytes */
-static SRes AssetFileInStream_Read(const ISeekInStream *pp, void *buf, size_t *size);
-
-static SRes AssetFileInStream_Seek(const ISeekInStream *pp, Int64 *pos, ESzSeek origin);
-
 typedef struct {
     ISeekInStream vt;
     CSzAssetFile assetFile;


### PR DESCRIPTION
Remove unnecessary static function declarations in header.

(Since `7zExtractor.cpp` also includes `7zAssetFile.h` this can result in compilation warnings).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/485)
<!-- Reviewable:end -->
