### PR TITLE
speedup gradle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ NAME?=1.0
 VERSION?=1
 APPNAME?="luajit-launcher"
 
+ifneq (,$(CI))
+  GRADLE_FLAGS ?= --console=plain --no-daemon -x lintVitalArmRocksRelease
+endif
+
 update:
 	@echo "Updating sources"
 	git submodule init
@@ -80,7 +84,7 @@ prepare: update
 debug: update build-luajit-debug
 	@echo "Building $(APPNAME) debug APK: Version $(NAME), release $(VERSION), flavor $(FLAVOR)"
 	./gradlew -q -PversName=$(NAME) -PversCode=$(VERSION) -PprojectName=$(APPNAME) \
-		-PndkCustomPath=$(ANDROID_NDK_FULLPATH) app:$(BUILD_TASK)Debug
+		-PndkCustomPath=$(ANDROID_NDK_FULLPATH) $(GRADLE_FLAGS) app:$(BUILD_TASK)Debug
 	mkdir -p bin/
 	find app/build/outputs/apk/ -type f -name '*.apk' -exec mv -v {} bin/ \;
 	@echo "Application $(APPNAME) was built, type: debug (signed), flavor: $(FLAVOR), version: $(NAME), release $(VERSION)"
@@ -88,7 +92,7 @@ debug: update build-luajit-debug
 release: update build-luajit
 	@echo "Building $(APPNAME) release APK: Version $(NAME), release $(VERSION), flavor $(FLAVOR)"
 	./gradlew -q -PversName=$(NAME) -PversCode=$(VERSION) -PprojectName=$(APPNAME) \
-		-PndkCustomPath=$(ANDROID_NDK_FULLPATH) app:$(BUILD_TASK)Release
+		-PndkCustomPath=$(ANDROID_NDK_FULLPATH) $(GRADLE_FLAGS) app:$(BUILD_TASK)Release
 	mkdir -p bin/
 	find app/build/outputs/apk/ -type f -name '*.apk' -exec mv -v {} bin/ \;
 	@echo "Application $(APPNAME) was built, type: release (unsigned), flavor: $(FLAVOR), version: $(NAME), release $(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ APPNAME?="luajit-launcher"
 ifneq (,$(CI))
   GRADLE_FLAGS ?= --console=plain --no-daemon -x lintVitalArmRocksRelease
 endif
+GRADLE_FLAGS += $(PARALLEL_JOBS:%=--max-workers=%)
 
 update:
 	@echo "Updating sources"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
-# Prevent OOM in Java heap space
-org.gradle.jvmargs=-Xmx2048m
 org.gradle.warning.mode=all
 org.gradle.caching=true
 org.gradle.configuration-cache=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,10 @@
 # Prevent OOM in Java heap space
 org.gradle.jvmargs=-Xmx2048m
 org.gradle.warning.mode=all
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configureondemand=true
+org.gradle.parallel=true
 
 # Use AndroidX compat libraries
 android.useAndroidX=true


### PR DESCRIPTION
- increase JVM heap space
- disable `lintVitalArmRocksRelease` on CI
- enable caching, parallelization and configuration on demand

Locally, starting with no `~/.gradle` directory and pristine `luajit-launcher` checkout, the time spent running `./gradlew …` is:

|                | no daemon & no cache | no daemon & cache | daemon & cache |
-----------------|---------------------:|------------------:|---------------:|
| master         |                2m52s |             1m27s |            48s |
| PR             |                2m56s |               16s |             7s |
| PR (`CI=true`) |                1m44s |               16s |            N/A |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/486)
<!-- Reviewable:end -->
