### PR TITLE
Update gradle & kotlin, drop desugaring

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'org.koreader.launcher'
+    ndkVersion '23.2.8568313'
     ndkPath ndkCustomPath
-    compileSdkVersion rootProject.ext.compileSdk
+    compileSdk rootProject.ext.compileSdk
     def baseVersionCode = versCode as Integer
 
     defaultConfig {
@@ -55,7 +57,16 @@ android {
         }
     }
 
-    flavorDimensions 'ABI', 'CHANNEL'
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+
+    flavorDimensions = [ 'ABI', 'CHANNEL'  ]
     productFlavors {
         arm {
             ndk { abiFilters "armeabi-v7a" }
@@ -89,25 +100,28 @@ android {
         }
     }
 
-    compileOptions {
-        coreLibraryDesugaringEnabled true
-    }
-
     packagingOptions {
-        exclude '/kotlin/**.kotlin_builtins'
-        exclude '/kotlin/**.kotlin_metadata'
-        exclude '/META-INF/**.kotlin_module'
-        exclude '/META-INF/**.version'
+        jniLibs {
+            useLegacyPackaging true
+        }
+        resources {
+            excludes += '/kotlin/**.kotlin_builtins'
+            excludes += '/kotlin/**.kotlin_metadata'
+            excludes += '/META-INF/**.kotlin_module'
+            excludes += '/META-INF/**.version'
+        }
     }
 
-    lintOptions {
-        xmlReport false
-        htmlReport false
+    lint {
+        disable 'ChromeOsAbiSupport'
+        disable 'GradleDependency'
         disable 'QueryAllPackagesPermission'
+        htmlReport false
+        xmlReport false
     }
 
-    applicationVariants.all { variant ->
-        variant.outputs.all {
+    applicationVariants.configureEach { variant ->
+        variant.outputs.configureEach {
             outputFileName = "NativeActivity.apk"
         }
     }
@@ -119,16 +133,9 @@ repositories {
 }
 
 dependencies {
-    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$android_desugar_jdk"
-
-    //noinspection GradleDependency
     implementation "androidx.core:core-ktx:$androidx_core_version"
-    //noinspection GradleDependency
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
-    //noinspection GradleDependency
     implementation "androidx.legacy:legacy-support-v4:$androidx_supportv4_version"
-    //noinspection GradleDependency
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_plugin_version"
     implementation "org.apache.commons:commons-compress:$commons_compress_version"
-
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,6 +1,7 @@
 # proguard is used to shrink and optimize dependencies.
 -dontobfuscate
 -keep class org.koreader.launcher.** { *; }
+-dontwarn org.tukaani.xz.LZMAInputStream
 
 # keep kotlin.Metadata annotations
 -keepattributes RuntimeVisibleAnnotations

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="org.koreader.launcher" >
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- only used by application stores, to filter the app on unsupported devices -->
     <uses-feature android:name="android.software.leanback" android:required="false" />
@@ -33,8 +32,7 @@
         android:fullBackupContent="false"
         android:usesCleartextTraffic="true"
         android:requestLegacyExternalStorage="true"
-        android:supportsRtl="true"
-        android:extractNativeLibs="true" >
+        android:supportsRtl="true">
         <meta-data android:name="android.max_aspect" android:value="3.1" />
         <activity
             android:name=".MainActivity"

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,11 @@ buildscript {
     ext.targetSdk = 30
     ext.minSdk = 18
 
-    ext.gradle_plugin_version = '7.4.2'
-    ext.kotlin_plugin_version = '1.6.21'
+    ext.gradle_plugin_version = '8.4.2'
+    ext.kotlin_plugin_version = '1.9.24'
     ext.androidx_core_version = '1.6.0'
     ext.androidx_appcompat_version = '1.3.1'
     ext.androidx_supportv4_version = '1.0.0'
-    ext.android_desugar_jdk = '1.1.5'
     ext.commons_compress_version = '1.20'
 
     repositories {
@@ -18,11 +17,10 @@ buildscript {
 
     dependencies {
         classpath "com.android.tools.build:gradle:$gradle_plugin_version"
-        //noinspection DifferentKotlinGradleVersion
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_plugin_version"
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register('clean', Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,5 @@ android.defaults.buildfeatures.buildconfig=true
 android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=true
 android.defaults.buildfeatures.shaders=false
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* Bump gradle
* Bump kotlin sdk
* Specify ndkVersion, as required by current gradle builds.
* R8 no longers needs java1.8, so we don't need desugaring anymore.
* Fixes a few deprecations

Other deps stay as is. Most of them require a bump in the compileSdk to something modern (33-34).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/487)
<!-- Reviewable:end -->
