### PR TITLE
import files

### DIFF
--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -407,6 +407,7 @@ class MainActivity : NativeActivity(), LuaInterface,
 
     override fun getFilePathFromIntent(): String? {
         return intent?.let {
+            Log.i(tag, "New intent: $it.action")
             if (it.action == Intent.ACTION_VIEW) {
                 it.data?.absolutePath(this)
             } else null

--- a/app/src/main/java/org/koreader/launcher/extensions/UriExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/UriExtensions.kt
@@ -64,17 +64,17 @@ private fun pathFromFile(uri: Uri): String? {
     }
 }
 
-private fun pathFromImportedFile(uri: Uri, context: Context): String? {
+private fun pathFromImportedFile(uri: Uri, context: Context, reason: String): String? {
     return context.getExternalFilesDir(null)?.let { path ->
         val result = uri.toFile(context, path.absolutePath)
-        Log.i(TAG, "Imported to $result")
+        Log.i(TAG, "[$reason]: imported to $result")
         result
     }
 }
 
 private fun pathFromContent(uri: Uri, context: Context): String? {
     val path = uri.authority?.let { _ ->
-        Log.i(TAG,"Found content, trying to guess if it's a local file on a readable directory")
+        Log.i(TAG,"Found content, trying to guess its path")
         try {
             context.contentResolver.openFileDescriptor(uri, "r")?.use { parcel ->
                 try {
@@ -98,14 +98,12 @@ private fun pathFromContent(uri: Uri, context: Context): String? {
 
     return path?.let { p ->
         if (p.startsWith("/data") or p.contains("/Android/data")) {
-            Log.i(TAG, "Non readable file, importing it")
-            pathFromImportedFile(uri, context)
+            pathFromImportedFile(uri, context, "Non readable file")
         } else {
             Log.i(TAG, "Guessed path -> $p")
             p
         }
     }?: run {
-        Log.i(TAG, "Not a local file, importing it")
-        pathFromImportedFile(uri, context)
+        pathFromImportedFile(uri, context, "Not a local file")
     }
 }

--- a/app/src/main/java/org/koreader/launcher/extensions/UriExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/UriExtensions.kt
@@ -6,12 +6,14 @@ import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import android.system.Os
+import android.util.Log
 import org.koreader.launcher.MainApp
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
 
+private const val TAG = "UriGuesser"
 fun Uri.absolutePath(context: Context): String? {
     return when (this.scheme) {
         ContentResolver.SCHEME_FILE -> pathFromFile(this)
@@ -21,6 +23,7 @@ fun Uri.absolutePath(context: Context): String? {
 }
 
 fun Uri.toFile(context: Context, path: String): String? {
+    Log.i(TAG, "Uri.toFile-> $path")
     if (this.scheme != ContentResolver.SCHEME_CONTENT) {
         return null
     }
@@ -56,11 +59,15 @@ fun Uri.toFile(context: Context, path: String): String? {
 }
 
 private fun pathFromFile(uri: Uri): String? {
-    return uri.path?.let { filePath -> File(filePath) }?.absolutePath
+    val path = uri.path?.let { filePath -> File(filePath) }?.absolutePath
+    Log.i(TAG, "pathFromFile-> $path")
+    return path
 }
 
 private fun pathFromImportedFile(uri: Uri, context: Context): String? {
-    return uri.toFile(context, MainApp.app_storage_path)
+    val path = uri.toFile(context, MainApp.app_storage_path)
+    Log.i(TAG, "pathFromImportedFile-> $path")
+    return path
 }
 private fun pathFromContent(uri: Uri, context: Context): String? {
     val path = uri.authority?.let { _ ->
@@ -89,6 +96,7 @@ private fun pathFromContent(uri: Uri, context: Context): String? {
         if (filePath.contains("/Android/data"))
             pathFromImportedFile(uri, context)
         else
+            Log.i(TAG, "pathFromContent-> $filePath")
             filePath
     }?: pathFromImportedFile(uri, context)
 }

--- a/app/src/main/java/org/koreader/launcher/extensions/UriExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/UriExtensions.kt
@@ -14,7 +14,6 @@ import java.io.IOException
 
 private const val TAG = "UriHandler"
 fun Uri.absolutePath(context: Context): String? {
-    Log.i(TAG, "Absolute path guessing")
     return when (this.scheme) {
         ContentResolver.SCHEME_FILE -> pathFromFile(this)
         ContentResolver.SCHEME_CONTENT -> pathFromContent(this, context)
@@ -23,7 +22,6 @@ fun Uri.absolutePath(context: Context): String? {
 }
 
 fun Uri.toFile(context: Context, path: String): String? {
-    Log.i(TAG, "Uri.toFile-> $path")
     if (this.scheme != ContentResolver.SCHEME_CONTENT) {
         Log.e(TAG, "unsupported scheme")
         return null
@@ -61,7 +59,7 @@ fun Uri.toFile(context: Context, path: String): String? {
 
 private fun pathFromFile(uri: Uri): String? {
     return uri.path?.let {
-        Log.i(TAG, "found local file-> $it")
+        Log.i(TAG, "Found local file-> $it")
         File(it).absolutePath
     }
 }
@@ -76,7 +74,7 @@ private fun pathFromImportedFile(uri: Uri, context: Context): String? {
 
 private fun pathFromContent(uri: Uri, context: Context): String? {
     val path = uri.authority?.let { _ ->
-        Log.i(TAG,"found content, trying to guess if it's a local file on a readable directory")
+        Log.i(TAG,"Found content, trying to guess if it's a local file on a readable directory")
         try {
             context.contentResolver.openFileDescriptor(uri, "r")?.use { parcel ->
                 try {

--- a/app/src/main/java/org/koreader/launcher/extensions/UriExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/UriExtensions.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import android.system.Os
+import org.koreader.launcher.MainApp
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
@@ -13,42 +14,18 @@ import java.io.IOException
 
 fun Uri.absolutePath(context: Context): String? {
     return when (this.scheme) {
-        ContentResolver.SCHEME_FILE -> {
-            this.path?.let { filePath -> File(filePath) }?.absolutePath
-        }
-        ContentResolver.SCHEME_CONTENT -> {
-            this.authority?.let { _ ->
-                try {
-                    context.contentResolver.openFileDescriptor(this, "r")?.use { parcel ->
-                        try {
-                            val file = File("/proc/self/fd/" + parcel.fd)
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                                Os.readlink(file.absolutePath)
-                            } else {
-                                file.canonicalPath
-                            }
-                        } catch (e: IOException) {
-                            null
-                        } catch (e: Exception) {
-                            null
-                        }
-                    }
-                } catch (e: FileNotFoundException) {
-                    e.printStackTrace()
-                    null
-                }
-            }
-        }
+        ContentResolver.SCHEME_FILE -> pathFromFile(this)
+        ContentResolver.SCHEME_CONTENT -> pathFromContent(this, context)
         else -> null
     }
 }
 
-fun Uri.toFile(context: Context, path: String) {
+fun Uri.toFile(context: Context, path: String): String? {
     if (this.scheme != ContentResolver.SCHEME_CONTENT) {
-        return
+        return null
     }
 
-    this.authority ?: return
+    this.authority ?: return null
     val nameColumn = arrayOf(MediaStore.MediaColumns.DISPLAY_NAME)
     val contentResolver = context.contentResolver
     val name: String? = contentResolver.query(this, nameColumn,
@@ -57,9 +34,9 @@ fun Uri.toFile(context: Context, path: String) {
         it.getString(it.getColumnIndex(nameColumn[0]))
     }
 
-    name ?: return
+    name ?: return null
 
-    context.contentResolver.openInputStream(this)?.use {
+    return context.contentResolver.openInputStream(this)?.use {
         try {
             val file = File(path, name)
             FileOutputStream(file).use { target ->
@@ -70,8 +47,48 @@ fun Uri.toFile(context: Context, path: String) {
                     len = it.read(buffer)
                 }
             }
+            file.absolutePath
         } catch (e: IOException) {
             e.printStackTrace()
+            null
         }
     }
+}
+
+private fun pathFromFile(uri: Uri): String? {
+    return uri.path?.let { filePath -> File(filePath) }?.absolutePath
+}
+
+private fun pathFromImportedFile(uri: Uri, context: Context): String? {
+    return uri.toFile(context, MainApp.app_storage_path)
+}
+private fun pathFromContent(uri: Uri, context: Context): String? {
+    val path = uri.authority?.let { _ ->
+        try {
+            context.contentResolver.openFileDescriptor(uri, "r")?.use { parcel ->
+                try {
+                    val file = File("/proc/self/fd/" + parcel.fd)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        Os.readlink(file.absolutePath)
+                    } else {
+                        file.canonicalPath
+                    }
+                } catch (e: IOException) {
+                    null
+                } catch (e: Exception) {
+                    null
+                }
+            }
+        } catch (e: FileNotFoundException) {
+            e.printStackTrace()
+            null
+        }
+    }
+
+    return path?.let { filePath ->
+        if (filePath.contains("/Android/data"))
+            pathFromImportedFile(uri, context)
+        else
+            filePath
+    }?: pathFromImportedFile(uri, context)
 }


### PR DESCRIPTION
Fix for https://github.com/koreader/koreader/issues/9787

**TODO**
- make `dest` dir configurable.

The new behaviour is:

guess the path if the content seems a local file on a readable path.
fallback to copy to `dest` dir

Logs:

* opening content without copy from a guessed file path

```logcat
06-27 01:06:12.490  8662  8684 I MainActivity: New intent: Intent { act=android.intent.action.VIEW dat=content://me.zhanghai.android.files.file_provider/... typ=application/epub+zip flg=0x13000003 cmp=org.koreader.launcher/.MainActivity (has extras) }.action
06-27 01:06:12.491  8662  8684 I UriHandler: Found content, trying to guess if it's a local file on a readable directory
06-27 01:06:12.500  8662  8684 I UriHandler: Guessed path -> /storage/emulated/0/La peste - Albert Camus.epub
```

* opening content by importing it

```logcat
06-27 01:06:40.266  8742  8765 I MainActivity: New intent: Intent { act=android.intent.action.VIEW dat=content://com.microsoft.skydrive.content.StorageAccessProvider/... typ=application/epub+zip flg=0x33000001 cmp=org.koreader.launcher/.MainActivity }.action
06-27 01:06:40.266  8742  8765 I UriHandler: Found content, trying to guess if it's a local file on a readable directory
06-27 01:06:40.290  8742  8765 I UriHandler: Non readable file, importing it
06-27 01:06:40.332  8742  8765 I UriHandler: Imported to /storage/emulated/0/Android/data/org.koreader.launcher/files/La peste - Albert Camus.epub
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/491)
<!-- Reviewable:end -->
