### PR TITLE
Change Onyx Poke 5 to adb driver

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -53,7 +53,6 @@ object LightsFactory {
                 DeviceInfo.LightsDevice.ONYX_NOVA_AIR_C,
                 DeviceInfo.LightsDevice.ONYX_PAGE,
                 DeviceInfo.LightsDevice.ONYX_POKE4,
-                DeviceInfo.LightsDevice.ONYX_POKE5,
                 DeviceInfo.LightsDevice.ONYX_POKE4LITE,
                 DeviceInfo.LightsDevice.ONYX_TAB_ULTRA -> {
                     logController("Onyx/Sdk")
@@ -65,6 +64,7 @@ object LightsFactory {
                     OnyxColorController()
                 }
                 DeviceInfo.LightsDevice.ONYX_NOVA_AIR,
+                DeviceInfo.LightsDevice.ONYX_POKE5,
                 DeviceInfo.LightsDevice.ONYX_TAB_ULTRA_C -> {
                     logController("Onyx Adb")
                     OnyxAdbLightsController()


### PR DESCRIPTION
Onyx has released new firmware several months ago already. Fix: https://github.com/koreader/koreader/issues/8482#issuecomment-2198002349

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/492)
<!-- Reviewable:end -->
