### PR TITLE
Add support for Android 13 themed icons

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/icon.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/icon.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/icon_release"/>
     <foreground android:drawable="@mipmap/icon_foreground"/>
+    <monochrome android:drawable="@mipmap/icon_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
Closes #409 .

Adds support for android 13 themed icons. 
As the icons were already monochrome, used the current icons as monochrome variants.

![tempFileForShare_20240716-010407](https://github.com/user-attachments/assets/2e771272-d5eb-45ff-9a07-ae34c7c1fb1e)
Tested by building and installing on Samsung S21 FE.

Currently only enabled for release builds so as to still differentiate release and debug builds but can also enable to debug build if you would like.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/496)
<!-- Reviewable:end -->
