### PR TITLE
dlopen: fix handling of versioned libraries

### DIFF
--- a/assets/dl.lua
+++ b/assets/dl.lua
@@ -102,8 +102,8 @@ function dl.dlopen(library, load_func, depth)
         end
 
         local ok, lib = pcall(Elf.open, lname)
-        if not ok and lname:find("%.so%.%d+$") then
-            lname = lname:gsub("%.so%.%d+$", "%.so")
+        if not ok and lname:find("%.so%.%d[.%d]*$") then
+            lname = lname:gsub("%.so%.%d[.%d]*$", "%.so")
             ok, lib = pcall(Elf.open, lname)
         end
         if ok then


### PR DESCRIPTION
Support multi-parts versions, like `libcrypto.so.1.1`.

Necessary for https://github.com/koreader/koreader/pull/12285.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/503)
<!-- Reviewable:end -->
