### PR TITLE
gradle: support changing the location of the assets / libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,8 +24,8 @@ android {
 
     sourceSets {
         main {
-            assets.srcDirs = [ '../assets' ]
-            jniLibs.srcDirs = [ '../libs' ]
+            assets.srcDirs = [ '../assets', assetsPath ]
+            jniLibs.srcDirs = [ libsPath ]
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,8 @@ projectName=luajit-launcher
 versCode=1
 versName=1.0
 ndkCustomPath=.
+assetsPath=../assets
+libsPath=../libs
 
 # Compilation features
 android.defaults.buildfeatures.aidl=false


### PR DESCRIPTION
This allow for out-of-tree builds (when combined with `--project-cache-dir` and `--project-cache-dir`).

Necessary for https://github.com/koreader/koreader/pull/12285.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/505)
<!-- Reviewable:end -->
