### PR TITLE
dlopen: fix `dl.open` on absolute path

### DIFF
--- a/assets/dl.lua
+++ b/assets/dl.lua
@@ -91,14 +91,20 @@ function dl.dlopen(library, load_func, depth)
     local padding = depth * 4
 
     for pspec in string.gmatch(
-            library:sub(1, 1) == "/" and "" or dl.library_path,
+            library:sub(1, 1) == "/" and "/" or dl.library_path,
             "([^;:]+)") do
 
-        local lname, matches = string.gsub(pspec, "%?", library)
-        if matches == 0 then
-            -- if pathspec does not contain a '?',
-            -- we append the library name to the pathspec
-            lname = lname .. '/' .. library
+        local lname
+        if library:sub(1, 1) == "/" and pspec == "/" then
+            lname = library
+        else
+            local matches
+            lname, matches = string.gsub(pspec, "%?", library)
+            if matches == 0 then
+                -- if pathspec does not contain a '?',
+                -- we append the library name to the pathspec
+                lname = lname .. '/' .. library
+            end
         end
 
         local ok, lib = pcall(Elf.open, lname)


### PR DESCRIPTION
Prerequisite for https://github.com/koreader/koreader/pull/12545.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/511)
<!-- Reviewable:end -->
