### PR TITLE
Tolino Epos 1 warmth lights support

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -163,7 +163,6 @@ object DeviceInfo {
         ONYX_TAB_ULTRA_C,
         RIDI_PAPER_3,
         TAGUS_GEA,
-        TOLINO_EPOS,
         TOLINO_EPOS1,
         TOLINO_PAGE2,
         TOLINO_SHINE3,
@@ -273,7 +272,6 @@ object DeviceInfo {
     private val SONY_CP1: Boolean
     private val SONY_RP1: Boolean
     private val TAGUS_GEA: Boolean
-    private val TOLINO_EPOS: Boolean
     private val TOLINO_EPOS1: Boolean
     private val TOLINO_EPOS3: Boolean
     private val TOLINO_PAGE2: Boolean
@@ -642,17 +640,7 @@ object DeviceInfo {
             || MODEL.contentEquals(STR_TOLINO) && (DEVICE.contentEquals("tolino_vision2")
             || DEVICE.contentEquals(STR_NTX))
 
-        // Tolino Epos 2 also have warmth lights
-        TOLINO_EPOS = BRAND.contentEquals(STR_KOBO)
-            && MODEL.contentEquals(STR_TOLINO)
-            && DEVICE.contentEquals(STR_NTX)
-            && !HARDWARE.contentEquals("e60k00")
-            && !HARDWARE.contentEquals("e60q50")
-            && !HARDWARE.contentEquals("e60qv0")
-            && !HARDWARE.contentEquals("e70k00")
-            && !HARDWARE.contentEquals("e70q20")
-
-        // Tolino Epos 1 also has warmth lights, but with ntx_io file
+        // Tolino Epos 1
         TOLINO_EPOS1 = BRAND.contentEquals(STR_KOBO)
             && MODEL.contentEquals(STR_TOLINO)
             && DEVICE.contentEquals(STR_NTX)
@@ -851,7 +839,6 @@ object DeviceInfo {
         lightsMap[LightsDevice.ONYX_TAB_ULTRA_C] = ONYX_TAB_ULTRA_C
         lightsMap[LightsDevice.RIDI_PAPER_3] = RIDI_PAPER_3
         lightsMap[LightsDevice.TAGUS_GEA] = TAGUS_GEA
-        lightsMap[LightsDevice.TOLINO_EPOS] = TOLINO_EPOS
         lightsMap[LightsDevice.TOLINO_EPOS1] = TOLINO_EPOS1
         lightsMap[LightsDevice.TOLINO_PAGE2] = TOLINO_PAGE2
         lightsMap[LightsDevice.TOLINO_SHINE3] = TOLINO_SHINE3

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -164,6 +164,7 @@ object DeviceInfo {
         RIDI_PAPER_3,
         TAGUS_GEA,
         TOLINO_EPOS,
+        TOLINO_EPOS1,
         TOLINO_PAGE2,
         TOLINO_SHINE3,
         TOLINO_VISION4,
@@ -273,6 +274,7 @@ object DeviceInfo {
     private val SONY_RP1: Boolean
     private val TAGUS_GEA: Boolean
     private val TOLINO_EPOS: Boolean
+    private val TOLINO_EPOS1: Boolean
     private val TOLINO_EPOS3: Boolean
     private val TOLINO_PAGE2: Boolean
     private val TOLINO_SHINE3: Boolean
@@ -648,6 +650,13 @@ object DeviceInfo {
             && !HARDWARE.contentEquals("e60q50")
             && !HARDWARE.contentEquals("e60qv0")
             && !HARDWARE.contentEquals("e70k00")
+            && !HARDWARE.contentEquals("e70q20")
+
+        // Tolino Epos 1 also has warmth lights, but with ntx_io file
+        TOLINO_EPOS1 = BRAND.contentEquals(STR_KOBO)
+            && MODEL.contentEquals(STR_TOLINO)
+            && DEVICE.contentEquals(STR_NTX)
+            && HARDWARE.contentEquals("e70q20")
 
         // Tolino Epos 3
         TOLINO_EPOS3 = BRAND.contentEquals(STR_KOBO)
@@ -843,6 +852,7 @@ object DeviceInfo {
         lightsMap[LightsDevice.RIDI_PAPER_3] = RIDI_PAPER_3
         lightsMap[LightsDevice.TAGUS_GEA] = TAGUS_GEA
         lightsMap[LightsDevice.TOLINO_EPOS] = TOLINO_EPOS
+        lightsMap[LightsDevice.TOLINO_EPOS1] = TOLINO_EPOS1
         lightsMap[LightsDevice.TOLINO_PAGE2] = TOLINO_PAGE2
         lightsMap[LightsDevice.TOLINO_SHINE3] = TOLINO_SHINE3
         lightsMap[LightsDevice.TOLINO_VISION4] = TOLINO_VISION4

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -18,6 +18,7 @@ object LightsFactory {
                 DeviceInfo.LightsDevice.CREMA_CARTA_G,
                 DeviceInfo.LightsDevice.MEEBOOK_P6,
                 DeviceInfo.LightsDevice.RIDI_PAPER_3,
+                DeviceInfo.LightsDevice.TOLINO_EPOS1,
                 DeviceInfo.LightsDevice.TOLINO_SHINE3,
                 DeviceInfo.LightsDevice.TOLINO_VISION4,
                 DeviceInfo.LightsDevice.TOLINO_VISION5 -> {

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -9,8 +9,7 @@ object LightsFactory {
     val lightsController: LightsInterface
         get() {
             return when (DeviceInfo.LIGHTS) {
-                DeviceInfo.LightsDevice.NOOK_GL4,
-                DeviceInfo.LightsDevice.TOLINO_EPOS -> {
+                DeviceInfo.LightsDevice.NOOK_GL4 -> {
                     logController("TolinoRoot")
                     TolinoRootController()
                 }


### PR DESCRIPTION
Manufacturer: rakuten kobo inc
    Brand: rakutenkobo
    Model: tolino
    Device: ntx_6sl
    Product: ntx_6sl
    Hardware: e70q20
    Platform: imx6
    Friendly name:
    [test.log](https://github.com/user-attachments/files/17102791/test.log)
    Tolino Epos 1
    Android 4.4
    Tolino Ntx, Freescale/NTX
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/513)
<!-- Reviewable:end -->
