### PR TITLE
bump 7z 

### DIFF
--- a/jni/lzma/un7zip/7zExtractor.cpp
+++ b/jni/lzma/un7zip/7zExtractor.cpp
@@ -51,7 +51,7 @@ extractStream(JNIEnv *env, ISeekInStream *seekStream, const char *destDir,
     else {
         lookStream.bufSize = inBufSize;
         lookStream.realStream = seekStream;
-        LookToRead2_Init(&lookStream);
+        LookToRead2_INIT(&lookStream);
     }
 
     CrcGenerateTable();


### PR DESCRIPTION
from 19.00 to 24.06

It seems faster uncompressing on arm64 but I didn't benchmark.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/517)
<!-- Reviewable:end -->
