### PR TITLE
add light controller for Tolino Epos 3

### DIFF
--- a/app/src/main/java/org/koreader/launcher/TestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/TestActivity.kt
@@ -27,6 +27,7 @@ import org.koreader.launcher.device.lights.OnyxWarmthController
 import org.koreader.launcher.device.lights.TolinoRootController
 import org.koreader.launcher.device.lights.TolinoNtxController
 import org.koreader.launcher.device.lights.TolinoNtxNoWarmthController
+import org.koreader.launcher.device.lights.TolinoEpos3Controller
 import org.koreader.launcher.device.lights.BoyueS62RootController
 import org.koreader.launcher.dialog.LightDialog
 import org.koreader.launcher.dialog.ToolTip
@@ -81,6 +82,7 @@ class TestActivity: AppCompatActivity() {
         lightsMap["Tolino Root"] = TolinoRootController()
         lightsMap["Tolino Ntx"] = TolinoNtxController()
         lightsMap["Tolino Ntx (no warmth)"] = TolinoNtxNoWarmthController()
+        lightsMap["Tolino Epos 3"] = TolinoEpos3Controller()
 
         // Device ID
         binding.info.append("Manufacturer: ${DeviceInfo.MANUFACTURER}\n")

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -164,6 +164,7 @@ object DeviceInfo {
         RIDI_PAPER_3,
         TAGUS_GEA,
         TOLINO_EPOS1,
+        TOLINO_EPOS3,
         TOLINO_PAGE2,
         TOLINO_SHINE3,
         TOLINO_VISION4,
@@ -840,6 +841,7 @@ object DeviceInfo {
         lightsMap[LightsDevice.RIDI_PAPER_3] = RIDI_PAPER_3
         lightsMap[LightsDevice.TAGUS_GEA] = TAGUS_GEA
         lightsMap[LightsDevice.TOLINO_EPOS1] = TOLINO_EPOS1
+        lightsMap[LightsDevice.TOLINO_EPOS3] = TOLINO_EPOS3
         lightsMap[LightsDevice.TOLINO_PAGE2] = TOLINO_PAGE2
         lightsMap[LightsDevice.TOLINO_SHINE3] = TOLINO_SHINE3
         lightsMap[LightsDevice.TOLINO_VISION4] = TOLINO_VISION4

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -28,6 +28,10 @@ object LightsFactory {
                     logController("TolinoNTXNoWarmth")
                     TolinoNtxNoWarmthController()
                 }
+                DeviceInfo.LightsDevice.TOLINO_EPOS3 -> {
+                    logController("TolinoEpos3Controller")
+                    TolinoEpos3Controller()
+                }
                 DeviceInfo.LightsDevice.ONYX_DARWIN7,
                 DeviceInfo.LightsDevice.ONYX_EDISON,
                 DeviceInfo.LightsDevice.ONYX_FAUST3,

--- a/app/src/main/java/org/koreader/launcher/device/lights/TolinoEpos3Controller.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/TolinoEpos3Controller.kt
@@ -1,0 +1,129 @@
+package org.koreader.launcher.device.lights
+
+import android.app.Activity
+import android.provider.Settings
+import android.util.Log
+import org.koreader.launcher.device.Ioctl
+import org.koreader.launcher.device.LightsInterface
+
+// Special controller for Tolino Epos 3
+class TolinoEpos3Controller : Ioctl(), LightsInterface {
+
+    companion object {
+        private const val TAG = "Lights"
+        private const val BRIGHTNESS_MAX = 100
+        private const val WARMTH_MAX = 10
+        private const val MIN = 0
+    }
+
+    override fun getPlatform(): String {
+        return "tolino"
+    }
+
+    override fun hasFallback(): Boolean {
+        return false
+    }
+
+    override fun hasWarmth(): Boolean {
+        return true
+    }
+
+    override fun needsPermission(): Boolean {
+        return true
+    }
+
+    override fun enableFrontlightSwitch(activity: Activity): Int {
+        return 1
+    }
+
+    override fun getBrightness(activity: Activity): Int {
+        return try {
+            Settings.System.getInt(activity.applicationContext.contentResolver, "screen_brightness")
+        } catch (e: Exception) {
+            Log.w(TAG, e.toString())
+            0
+        }
+    }
+
+    override fun getWarmth(activity: Activity): Int {
+        return try {
+            Settings.System.getInt(
+                    activity.applicationContext.contentResolver,
+                    "screen_brightness_color"
+            )
+        } catch (e: Exception) {
+            Log.w(TAG, e.toString())
+        }
+    }
+
+    override fun setBrightness(activity: Activity, brightness: Int) {
+        if (brightness < MIN || brightness > BRIGHTNESS_MAX) {
+            Log.w(TAG, "brightness value of of range: $brightness")
+            return
+        }
+        Log.v(TAG, "Setting brightness to $brightness")
+        try {
+            Settings.System.putInt(
+                    activity.applicationContext.contentResolver,
+                    "screen_brightness",
+                    brightness
+            )
+        } catch (e: Exception) {
+            Log.w(TAG, "$e")
+        }
+    }
+
+    override fun setWarmth(activity: Activity, warmth: Int) {
+        if (warmth < MIN || warmth > WARMTH_MAX) {
+            Log.w(TAG, "warmth value of of range: $warmth")
+            return
+        }
+        Log.v(TAG, "Setting warmth to $warmth")
+        try {
+            Settings.System.putInt(
+                    activity.applicationContext.contentResolver,
+                    "screen_brightness_color",
+                    warmth
+            )
+
+            // crappy toggle brightness to force warmth refresh
+            val currentBrightness: Int =
+            Settings.System.getInt(
+                    activity.applicationContext.contentResolver,
+                    "screen_brightness"
+            )
+            Settings.System.putInt(
+                    activity.applicationContext.contentResolver,
+                    "screen_brightness",
+                    currentBrightness + 1
+            )
+            Settings.System.putInt(
+                    activity.applicationContext.contentResolver,
+                    "screen_brightness",
+                    currentBrightness
+            )
+        } catch (e: Exception) {
+            Log.w(TAG, "$e")
+        }
+    }
+
+    override fun getMinWarmth(): Int {
+        return MIN
+    }
+
+    override fun getMaxWarmth(): Int {
+        return WARMTH_MAX
+    }
+
+    override fun getMinBrightness(): Int {
+        return MIN
+    }
+
+    override fun getMaxBrightness(): Int {
+        return BRIGHTNESS_MAX
+    }
+
+    override fun hasStandaloneWarmth(): Boolean {
+        return false
+    }
+}


### PR DESCRIPTION
Built a specific light controller for the Tolino Epos 3. The NTX controller does not seem to change the warmth value (I guess without root) and the lighting max value is 255 there while the Epos 3 caps out at 100.

Has been tested now for a few weeks, can confirm it works rock-solid on my device. Only thing that I had to do, is to manually allow "Modify system settings" for KOReader in the Android settings. Not sure if there is supposed to be a Popup when opening the App the first time.. 

