### PR TITLE
Tolino Epos 2 support

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -113,7 +113,6 @@ object DeviceInfo {
         SONY_RP1,
         TAGUS_GEA,
         TOLINO,
-        TOLINO_EPOS1,
         TOLINO_EPOS3,
         TOLINO_VISION6,
         XIAOMI_READER
@@ -791,7 +790,6 @@ object DeviceInfo {
         deviceMap[EinkDevice.SONY_RP1] = SONY_RP1
         deviceMap[EinkDevice.TAGUS_GEA] = TAGUS_GEA
         deviceMap[EinkDevice.TOLINO] = TOLINO
-        deviceMap[EinkDevice.TOLINO_EPOS1] = TOLINO_EPOS1
         deviceMap[EinkDevice.TOLINO_EPOS3] = TOLINO_EPOS3
         deviceMap[EinkDevice.XIAOMI_READER] = XIAOMI_READER
 

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -113,6 +113,7 @@ object DeviceInfo {
         SONY_RP1,
         TAGUS_GEA,
         TOLINO,
+        TOLINO_EPOS1,
         TOLINO_EPOS3,
         TOLINO_VISION6,
         XIAOMI_READER
@@ -164,6 +165,7 @@ object DeviceInfo {
         RIDI_PAPER_3,
         TAGUS_GEA,
         TOLINO_EPOS1,
+        TOLINO_EPOS2,
         TOLINO_PAGE2,
         TOLINO_SHINE3,
         TOLINO_VISION4,
@@ -273,6 +275,7 @@ object DeviceInfo {
     private val SONY_RP1: Boolean
     private val TAGUS_GEA: Boolean
     private val TOLINO_EPOS1: Boolean
+    private val TOLINO_EPOS2: Boolean
     private val TOLINO_EPOS3: Boolean
     private val TOLINO_PAGE2: Boolean
     private val TOLINO_SHINE3: Boolean
@@ -646,6 +649,12 @@ object DeviceInfo {
             && DEVICE.contentEquals(STR_NTX)
             && HARDWARE.contentEquals("e70q20")
 
+        // Tolino Epos 2
+        TOLINO_EPOS2 = BRAND.contentEquals(STR_KOBO)
+            && MODEL.contentEquals(STR_TOLINO)
+            && DEVICE.contentEquals(STR_NTX)
+            && HARDWARE.contentEquals("e80k00")
+
         // Tolino Epos 3
         TOLINO_EPOS3 = BRAND.contentEquals(STR_KOBO)
             && MODEL.contentEquals("tolino epos 3")
@@ -782,6 +791,7 @@ object DeviceInfo {
         deviceMap[EinkDevice.SONY_RP1] = SONY_RP1
         deviceMap[EinkDevice.TAGUS_GEA] = TAGUS_GEA
         deviceMap[EinkDevice.TOLINO] = TOLINO
+        deviceMap[EinkDevice.TOLINO_EPOS1] = TOLINO_EPOS1
         deviceMap[EinkDevice.TOLINO_EPOS3] = TOLINO_EPOS3
         deviceMap[EinkDevice.XIAOMI_READER] = XIAOMI_READER
 
@@ -840,6 +850,7 @@ object DeviceInfo {
         lightsMap[LightsDevice.RIDI_PAPER_3] = RIDI_PAPER_3
         lightsMap[LightsDevice.TAGUS_GEA] = TAGUS_GEA
         lightsMap[LightsDevice.TOLINO_EPOS1] = TOLINO_EPOS1
+        lightsMap[LightsDevice.TOLINO_EPOS2] = TOLINO_EPOS2
         lightsMap[LightsDevice.TOLINO_PAGE2] = TOLINO_PAGE2
         lightsMap[LightsDevice.TOLINO_SHINE3] = TOLINO_SHINE3
         lightsMap[LightsDevice.TOLINO_VISION4] = TOLINO_VISION4

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -72,7 +72,8 @@ object EPDFactory {
                 DeviceInfo.EinkDevice.HANVON_960,
                 DeviceInfo.EinkDevice.ONYX_JDREAD,
                 DeviceInfo.EinkDevice.RIDI_PAPER_3,
-                DeviceInfo.EinkDevice.TOLINO -> {
+                DeviceInfo.EinkDevice.TOLINO,
+                DeviceInfo.EinkDevice.TOLINO_EPOS1 -> {
                     logController("Tolino/NTX")
                     TolinoEPDController()
                 }

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -72,8 +72,7 @@ object EPDFactory {
                 DeviceInfo.EinkDevice.HANVON_960,
                 DeviceInfo.EinkDevice.ONYX_JDREAD,
                 DeviceInfo.EinkDevice.RIDI_PAPER_3,
-                DeviceInfo.EinkDevice.TOLINO,
-                DeviceInfo.EinkDevice.TOLINO_EPOS1 -> {
+                DeviceInfo.EinkDevice.TOLINO -> {
                     logController("Tolino/NTX")
                     TolinoEPDController()
                 }

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -18,6 +18,7 @@ object LightsFactory {
                 DeviceInfo.LightsDevice.MEEBOOK_P6,
                 DeviceInfo.LightsDevice.RIDI_PAPER_3,
                 DeviceInfo.LightsDevice.TOLINO_EPOS1,
+                DeviceInfo.LightsDevice.TOLINO_EPOS2,
                 DeviceInfo.LightsDevice.TOLINO_SHINE3,
                 DeviceInfo.LightsDevice.TOLINO_VISION4,
                 DeviceInfo.LightsDevice.TOLINO_VISION5 -> {


### PR DESCRIPTION
Tolino Epos 2

Device info:
Manufacturer: rakuten kobo inc.
Brand: rakutenkobo
Model: tolino
Device: ntx_6sl
Product: ntx_6sl
Hardware: e80k00
Platform: imx6

test.log

Lights: tolino/ntx


Also adds Tolino Epos 1 to EPD driver

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/521)
<!-- Reviewable:end -->
