### PR TITLE
Add support for boyue P101

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -39,6 +39,7 @@ object DeviceInfo {
         BOYUE_P6,
         BOYUE_P61,
         BOYUE_P78,
+        BOYUE_P101,
         BOYUE_S62,
         BOYUE_T61,
         BOYUE_T62,
@@ -197,6 +198,7 @@ object DeviceInfo {
     private val BOYUE_P6: Boolean
     private val BOYUE_P61: Boolean
     private val BOYUE_P78: Boolean
+    private val BOYUE_P101: Boolean
     private val BOYUE_S62: Boolean
     private val BOYUE_T61: Boolean
     private val BOYUE_T62: Boolean
@@ -311,6 +313,9 @@ object DeviceInfo {
 
         // Boyue Likebook P78
         BOYUE_P78 = BOYUE && PRODUCT.contentEquals("p78")
+
+        // Boyue Likebook P101
+        BOYUE_P101 = BOYUE && PRODUCT.contentEquals("p101")
 
         // Boyue Likebook LemonRead S62A
         BOYUE_S62 = BOYUE && PRODUCT.contentEquals("s62")
@@ -714,6 +719,7 @@ object DeviceInfo {
         deviceMap[EinkDevice.BOYUE_P6] = BOYUE_P6
         deviceMap[EinkDevice.BOYUE_P61] = BOYUE_P61
         deviceMap[EinkDevice.BOYUE_P78] = BOYUE_P78
+        deviceMap[EinkDevice.BOYUE_P101] = BOYUE_P101
         deviceMap[EinkDevice.BOYUE_S62] = BOYUE_S62
         deviceMap[EinkDevice.BOYUE_T61] = BOYUE_T61
         deviceMap[EinkDevice.BOYUE_T62] = BOYUE_T62

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -40,6 +40,7 @@ object EPDFactory {
                 DeviceInfo.EinkDevice.BOYUE_P6,
                 DeviceInfo.EinkDevice.BOYUE_P61,
                 DeviceInfo.EinkDevice.BOYUE_P78,
+                DeviceInfo.EinkDevice.BOYUE_P101,
                 DeviceInfo.EinkDevice.BOYUE_S62,
                 DeviceInfo.EinkDevice.BOYUE_T78D,
                 DeviceInfo.EinkDevice.BOYUE_T80D,


### PR DESCRIPTION
Reason: new eink model support
commercial name of product: P101 (Boyue P101)
android version: 8.1
driver(s) that work:
- Rockchip RK3368
- Rockchip RK3026

Device info:
Manufacturer: boyue
Brand: boyue
Model: likebook-p101
Device: p101
Product: p101
Hardware: rk30board
Platform: rk3326

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/522)
<!-- Reviewable:end -->
