### PR TITLE
fix `os.execute` implementation

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2725,13 +2725,7 @@ local function run(android_app_state)
 
     os.execute = function(command) -- luacheck: ignore 122
         if command == nil then return -1 end
-        local argv = {}
-        command:gsub("([^ ]+)", function(arg)
-            -- strip quotes around argument, since they are not necessary here
-            arg = arg:gsub('"(.*)"', "%1") -- strip double quotes
-            arg = arg:gsub("'(.*)'", "%1") -- strip single quotes
-            table.insert(argv, arg)
-        end)
+        local argv = {'sh', '-c', command}
         return android.execute(unpack(argv))
     end
 


### PR DESCRIPTION
Just forward the whole command to `sh -c`, so there's no need to muck around with escaping, and all KOReader's use-cases are supported (redirection, multiple commands, etc…).

Cf. https://github.com/koreader/koreader/pull/12375#issuecomment-2297862418, https://github.com/koreader/koreader/pull/12384 & https://github.com/koreader/koreader/issues/12613#issuecomment-2400879766.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/524)
<!-- Reviewable:end -->
