### PR TITLE
Add suport for some InkBook Focus devices

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -59,6 +59,8 @@ object DeviceInfo {
         HANVON_960,
         HYREAD_MINI6,
         INKBOOK,
+        INKBOOKFOCUS,
+        INKBOOKFOCUS_PLUS,
         INKPALM_PLUS,
         JDREAD,
         LINFINY_ENOTE,
@@ -263,6 +265,14 @@ object DeviceInfo {
             // Artatech Inkbook Prime/Prime HD.
             MANUFACTURER == "artatech" && BRAND == "inkbook" && MODEL.startsWith("prime")
             -> Id.INKBOOK
+
+            // InkBook Focus
+            MANUFACTURER == STR_ROCKCHIP && PRODUCT == "r07801" && MODEL == "focus"
+            -> Id.INKBOOKFOCUS
+
+            // InkBook Focus Plus
+            MANUFACTURER == STR_ROCKCHIP && PRODUCT == "r07802" && MODEL == "focus plus"
+            -> Id.INKBOOKFOCUS_PLUS
 
             // InkPalm Plus
             MANUFACTURER == STR_ROCKCHIP && MODEL == "inkpalmplus"

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -26,6 +26,7 @@ object EPDFactory {
                 DeviceInfo.Id.ENERGY,
                 DeviceInfo.Id.FIDIBOOK,
                 DeviceInfo.Id.INKBOOK,
+                DeviceInfo.Id.INKBOOKFOCUS,
                 DeviceInfo.Id.MEEBOOK_P6,
                 DeviceInfo.Id.ONYX_C67,
                 DeviceInfo.Id.ONYX_MAGICBOOK,
@@ -141,6 +142,7 @@ object EPDFactory {
                 }
 
                 DeviceInfo.Id.HYREAD_MINI6,
+                DeviceInfo.Id.INKBOOKFOCUS_PLUS,
                 DeviceInfo.Id.INKPALM_PLUS,
                 DeviceInfo.Id.MEEBOOK_M6,
                 DeviceInfo.Id.MEEBOOK_M6C,


### PR DESCRIPTION
inkBook Focus 7,8"
Device info:
Manufacturer: rockchip
Brand: rockchip
Model: focus
Device: px30_eink
Product: r07801
Hardware: rk30board
Platform: rk3326
Android 8.1
Frontlight: all from list doesnt work
E-ink drivers: Rockchip RK3026 (works)


inkBook Focus Plus 7,8" (Carta 1300)
Device info:
Manufacturer: rockchip
Brand: rockchip
Model: focus plus
Device: rk3566_eink
Product: r07802
Hardware: rk30board
Platform: rk356
Android 8.1
Frontlight: none works
E-ink drivers: Rockchip RK3566 (refreshes screen in test, no option to adjust refresh rate in main KoReader menu)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/537)
<!-- Reviewable:end -->
