### PR TITLE
Add support for Onyx Boox Note Max

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -97,6 +97,7 @@ object DeviceInfo {
         ONYX_NOTE_AIR,
         ONYX_NOTE_AIR2,
         ONYX_NOTE_AIR_3C,
+        ONYX_NOTE_MAX,
         ONYX_NOTE_PRO,
         ONYX_NOTE_X2,
         ONYX_NOVA,
@@ -430,6 +431,10 @@ object DeviceInfo {
             // Onyx Note Air 3C
             BRAND == "onyx" && MODEL == "noteair3c"
             -> Id.ONYX_NOTE_AIR_3C
+
+            // Onyx Boox Note Max
+            BRAND == "onyx" && PRODUCT == "notemax" && DEVICE == "notemax"
+            -> Id.ONYX_NOTE_MAX
 
             // Onyx Note Pro
             MANUFACTURER == "onyx" && PRODUCT == "notepro" && DEVICE == "notepro"

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -107,6 +107,7 @@ object EPDFactory {
                 DeviceInfo.Id.ONYX_NOTE_AIR,
                 DeviceInfo.Id.ONYX_NOTE_AIR2,
                 DeviceInfo.Id.ONYX_NOTE_AIR_3C,
+                DeviceInfo.Id.ONYX_NOTE_MAX,
                 DeviceInfo.Id.ONYX_NOTE_PRO,
                 DeviceInfo.Id.ONYX_NOTE_X2,
                 DeviceInfo.Id.ONYX_NOVA,


### PR DESCRIPTION
Reason: new
commercial name of product: Onyx Boox Note Max
android version: 13
driver(s) that work: E-ink: Onyx/Qualcomm (it has no frontlight)

Manufacturer: qualcomm
Brand: onyx
Model: notemax
Device: notemax
Product: notemax
Hardware: qcom
Platform: msmnile

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/542)
<!-- Reviewable:end -->
