### PR TITLE
Add support for Onyx Boox Galileo 2

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -79,6 +79,7 @@ object DeviceInfo {
         ONYX_DARWIN9,
         ONYX_EDISON,
         ONYX_FAUST3,
+        ONYX_GALILEO2,
         ONYX_GO_103,
         ONYX_GO_COLOR7,
         ONYX_JDREAD,
@@ -356,6 +357,10 @@ object DeviceInfo {
             // Onyx Faust 3
             MANUFACTURER == "onyx" && PRODUCT == "mc_faust3" && DEVICE == "mc_faust3"
             -> Id.ONYX_FAUST3
+
+            // Onyx Boox Galileo 2
+            BRAND == "onyx" && MODEL == "galileo2"
+            -> Id.ONYX_GALILEO2
 
             // Onyx Boox Go 10.3
             BRAND == "onyx" && MODEL == "go103"

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -92,6 +92,7 @@ object EPDFactory {
 
                 DeviceInfo.Id.ONYX_DARWIN9,
                 DeviceInfo.Id.ONYX_EDISON,
+                DeviceInfo.Id.ONYX_GALILEO2,
                 DeviceInfo.Id.ONYX_GO_103,
                 DeviceInfo.Id.ONYX_GO_COLOR7,
                 DeviceInfo.Id.ONYX_KON_TIKI2,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -14,6 +14,7 @@ object LightsFactory {
                     logController("Boyue S62")
                     BoyueS62RootController()
                 }
+                DeviceInfo.Id.ONYX_GALILEO2,
                 DeviceInfo.Id.ONYX_GO_COLOR7,
                 DeviceInfo.Id.ONYX_NOTE_AIR_3C,
                 DeviceInfo.Id.ONYX_NOVA_AIR,


### PR DESCRIPTION
Onyx Boox Galileo 2 - maybe similar to Onyx Boox Page? Reason: new
commercial name of product: Onyx Boox Galileo 2
android version: 11
driver(s) that work: Onyx ADB (lights), Onyx/Qualcomm (E-ink) Manufacturer: onyx
Brand: onyx
Model: galileo2
Device: boox
Product: boox
Hardware: qcom
Platform: bengal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/544)
<!-- Reviewable:end -->
