### PR TITLE
fix STL

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,1 +1,3 @@
 # see https://developer.android.com/ndk/guides/application_mk
+
+APP_STL := c++_shared


### PR DESCRIPTION
We need to use `APP_STL := c++_shared` to ensure our JNI C++ libraries will use the same `libc++_shared.so` library our main project uses, or they will end-up linking with the system `libstdc++.so` instead, which can cause issues with the dynamic linker (and possibly break the ODR).

See https://github.com/koreader/koreader/issues/13575#issuecomment-2799980409.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/548)
<!-- Reviewable:end -->
