### PR TITLE
Add support for Hyread Gaze Note devices

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -57,6 +57,8 @@ object DeviceInfo {
         ENERGY,
         FIDIBOOK,
         HANVON_960,
+        HYREAD_GAZE_NOTE,
+        HYREAD_GAZE_NOTE_CC,
         HYREAD_MINI6,
         INKBOOK,
         INKBOOKFOCUS,
@@ -264,6 +266,14 @@ object DeviceInfo {
             // Hanvon 960
             BRAND == "freescale" && PRODUCT == "evk_6sl_eink"
             -> Id.HANVON_960
+
+            // Hyread Gaze Note
+            MANUFACTURER == "hyread" && MODEL == "r08p"
+            -> Id.HYREAD_GAZE_NOTE
+
+            // Hyread Gaze Note Plus CC
+            MANUFACTURER == "hyread" && MODEL == "k08cc"
+            -> Id.HYREAD_GAZE_NOTE_CC
 
             // Hyread Mini 6
             MANUFACTURER == "hyread" && MODEL == "k06nu"

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -47,6 +47,7 @@ object EPDFactory {
                 DeviceInfo.Id.BOYUE_T78D,
                 DeviceInfo.Id.BOYUE_T80D,
                 DeviceInfo.Id.BOYUE_T103D,
+                DeviceInfo.Id.HYREAD_GAZE_NOTE,
                 -> {
                     logController("Rockchip RK3368")
                     RK3368EPDController()
@@ -148,6 +149,7 @@ object EPDFactory {
                     OldTolinoEPDController()
                 }
 
+                DeviceInfo.Id.HYREAD_GAZE_NOTE_CC,
                 DeviceInfo.Id.HYREAD_MINI6,
                 DeviceInfo.Id.INKBOOKFOCUS_PLUS,
                 DeviceInfo.Id.INKPALM_PLUS,


### PR DESCRIPTION
commercial name of product: Hyread Gaze Note Plus CC
android version: 11
driver(s) that work: E-ink: Rockchip RK3566 (lights no work)
Manufacturer: hyread
Brand: hyread
Model: k08cc
Device: k08c
Product: rk3566_eink
Hardware: rk30board
Platform: rk356x

commercial name of product: Hyread Gaze Note
android version: 8.1
driver(s) that work: E-ink: Rockchip RK3368 (lights no work)
Manufacturer: hyread
Brand: hyread
Model: r08p
Device: k78w
Product: r08p
Hardware: rk30board
Platform: rk3368

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/550)
<!-- Reviewable:end -->
