### PR TITLE
add noteair4c

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -99,6 +99,7 @@ object DeviceInfo {
         ONYX_NOTE_AIR,
         ONYX_NOTE_AIR2,
         ONYX_NOTE_AIR_3C,
+        ONYX_NOTE_AIR_4C,
         ONYX_NOTE_MAX,
         ONYX_NOTE_PRO,
         ONYX_NOTE_X2,
@@ -444,6 +445,10 @@ object DeviceInfo {
             BRAND == "onyx" && MODEL == "noteair3c"
             -> Id.ONYX_NOTE_AIR_3C
 
+            // Onyx Note Air 4C
+            BRAND == "onyx" && MODEL == "noteair4c"
+            -> Id.ONYX_NOTE_AIR_4C
+
             // Onyx Boox Note Max
             BRAND == "onyx" && PRODUCT == "notemax" && DEVICE == "notemax"
             -> Id.ONYX_NOTE_MAX
@@ -640,6 +645,7 @@ object DeviceInfo {
             Id.ONYX_NOVA3_COLOR,
             Id.ONYX_NOVA_AIR_C,
             Id.ONYX_NOTE_AIR_3C,
+            Id.ONYX_NOTE_AIR_4C,
             Id.ONYX_TAB_ULTRA_C,
             Id.ONYX_TAB_ULTRA_C_PRO,
             -> true else -> false

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -109,6 +109,7 @@ object EPDFactory {
                 DeviceInfo.Id.ONYX_NOTE_AIR,
                 DeviceInfo.Id.ONYX_NOTE_AIR2,
                 DeviceInfo.Id.ONYX_NOTE_AIR_3C,
+                DeviceInfo.Id.ONYX_NOTE_AIR_4C,
                 DeviceInfo.Id.ONYX_NOTE_MAX,
                 DeviceInfo.Id.ONYX_NOTE_PRO,
                 DeviceInfo.Id.ONYX_NOTE_X2,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -17,6 +17,7 @@ object LightsFactory {
                 DeviceInfo.Id.ONYX_GALILEO2,
                 DeviceInfo.Id.ONYX_GO_COLOR7,
                 DeviceInfo.Id.ONYX_NOTE_AIR_3C,
+                DeviceInfo.Id.ONYX_NOTE_AIR_4C,
                 DeviceInfo.Id.ONYX_NOVA_AIR,
                 DeviceInfo.Id.ONYX_PAGE,
                 DeviceInfo.Id.ONYX_PALMA2,


### PR DESCRIPTION
Hi,

first time i'm doing this, hope is all correct.

Reason:  new
commercial name of product: Boox Note Air4 C
android version: 13 
driver(s) that work:
    Lights: Onyx ADB (lights) 
    E-ink: Onyx/Qualcomm
[test.log](https://github.com/user-attachments/files/20079576/test.log)

   
Device info:
Manufacturer: qualcomm
Brand: onyx
Model: noteair4c
Device: noteair4c
Product: noteair4c
Hardware: qcom
Platform: lito

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/551)
<!-- Reviewable:end -->
