### PR TITLE
Add Boox Go6 support

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -83,6 +83,7 @@ object DeviceInfo {
         ONYX_FAUST3,
         ONYX_GALILEO2,
         ONYX_GO_103,
+        ONYX_GO6,
         ONYX_GO_COLOR7,
         ONYX_JDREAD,
         ONYX_KON_TIKI2,
@@ -380,6 +381,10 @@ object DeviceInfo {
             // Onyx Boox Go 10.3
             BRAND == "onyx" && MODEL == "go103"
             -> Id.ONYX_GO_103
+
+            // Onyx Boox Go 6
+            BRAND == "onyx" && MODEL == "go6"
+            -> Id.ONYX_GO6
 
             // Onyx Boox Go Color 7
             BRAND == "onyx" && MODEL == "gocolor7"

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -95,6 +95,7 @@ object EPDFactory {
                 DeviceInfo.Id.ONYX_EDISON,
                 DeviceInfo.Id.ONYX_GALILEO2,
                 DeviceInfo.Id.ONYX_GO_103,
+                DeviceInfo.Id.ONYX_GO6,
                 DeviceInfo.Id.ONYX_GO_COLOR7,
                 DeviceInfo.Id.ONYX_KON_TIKI2,
                 DeviceInfo.Id.ONYX_LEAF,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -15,6 +15,7 @@ object LightsFactory {
                     BoyueS62RootController()
                 }
                 DeviceInfo.Id.ONYX_GALILEO2,
+                DeviceInfo.Id.ONYX_GO6,
                 DeviceInfo.Id.ONYX_GO_COLOR7,
                 DeviceInfo.Id.ONYX_NOTE_AIR_3C,
                 DeviceInfo.Id.ONYX_NOTE_AIR_4C,


### PR DESCRIPTION
add ONYX_GO6 device entry and detection

```
Device info:
Manufacturer: onyx
Brand: onyx
Model: go6
Device: boox
Product: boox
Hardware: qcom
Platform: bengal
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/553)
<!-- Reviewable:end -->
