### PR TITLE
fix gradle warning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android'
 android {
     namespace 'org.koreader.launcher'
     ndkVersion '23.2.8568313'
+    ndkPath System.getenv('ANDROID_NDK_HOME')
     compileSdk rootProject.ext.compileSdk
     def baseVersionCode = versCode as Integer
 


### PR DESCRIPTION
```
Unable to strip the following libraries, packaging them as they are:
libc++_shared.so, libioctl.so, libkoreader-monolibtic.so,
libluajit-launcher.so, libluajit.so, libsdcv.so.
```

Those have already been stripped by the main project build system, but add back the `ndkPath` build setting to make gradle happy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/558)
<!-- Reviewable:end -->
