### PR TITLE
do not compress 7z files in APK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,10 @@ android {
     compileSdk rootProject.ext.compileSdk
     def baseVersionCode = versCode as Integer
 
+    aaptOptions {
+        noCompress '7z'
+    }
+
     defaultConfig {
         applicationId "org.koreader.launcher"
         versionName versName


### PR DESCRIPTION
The deflated version of `koreader.7z` is 5920 bytes bigger!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/559)
<!-- Reviewable:end -->
