### PR TITLE
JNI: always use the C interface

### DIFF
--- a/jni/7z/unarchive.c
+++ b/jni/7z/unarchive.c
@@ -1,5 +1,3 @@
-extern "C" {
-
 #include <limits.h>
 #include <stdlib.h>
 
@@ -82,15 +80,13 @@ Java_org_koreader_launcher_Assets_extract(JNIEnv *env,
                                           jstring payload,
                                           jstring output)
 {
-    const char *name = env->GetStringUTFChars(payload, nullptr);
-    const char *destination = env->GetStringUTFChars(output, nullptr);
+    const char *name = (*env)->GetStringUTFChars(env, payload, NULL);
+    const char *destination = (*env)->GetStringUTFChars(env, output, NULL);
 
     int r = extract_asset(AAssetManager_fromJava(env, assetsManager), name, destination);
 
-    env->ReleaseStringUTFChars(payload, name);
-    env->ReleaseStringUTFChars(output, destination);
+    (*env)->ReleaseStringUTFChars(env, payload, name);
+    (*env)->ReleaseStringUTFChars(env, output, destination);
 
     return r != ARCHIVE_OK && r != ARCHIVE_EOF;
-}
-
 }

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16.3)
-project(android-luajit-launcher LANGUAGES C CXX)
+project(android-luajit-launcher LANGUAGES C)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LuaJIT luajit REQUIRED IMPORTED_TARGET)
@@ -12,15 +12,13 @@ if(NOT Threads_FOUND OR NOT CMAKE_USE_PTHREADS_INIT)
 endif()
 
 add_library(7z)
-set_target_properties(7z PROPERTIES CXX_VISIBILITY_PRESET hidden)
-set_target_properties(7z PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
+set_target_properties(7z PROPERTIES C_VISIBILITY_PRESET hidden)
 target_link_libraries(7z PRIVATE PkgConfig::libarchive android log)
-target_sources(7z PRIVATE 7z/unarchive.cpp)
+target_sources(7z PRIVATE 7z/unarchive.c)
 
 add_library(ioctl SHARED)
-set_target_properties(ioctl PROPERTIES CXX_VISIBILITY_PRESET hidden)
-set_target_properties(ioctl PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
-target_sources(ioctl PRIVATE ioctl/ioctl.cpp)
+set_target_properties(ioctl PROPERTIES C_VISIBILITY_PRESET hidden)
+target_sources(ioctl PRIVATE ioctl/ioctl.c)
 
 add_library(luajit-launcher SHARED)
 set_target_properties(luajit-launcher PROPERTIES C_VISIBILITY_PRESET hidden)

--- a/jni/ioctl/ioctl.c
+++ b/jni/ioctl/ioctl.c
@@ -1,7 +1,3 @@
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <jni.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -29,15 +25,14 @@ int _ioctl(const char* device, int command, int args)
 }
 
 JNIEXPORT jint JNICALL
-Java_org_koreader_launcher_device_Ioctl_ioctl(JNIEnv *env, __unused jobject,
-        jstring device, jint command, jint args)
+Java_org_koreader_launcher_device_Ioctl_ioctl(JNIEnv *env,
+                                              __unused jobject obj,
+                                              jstring device,
+                                              jint command,
+                                              jint args)
 {
-    const char *dev = env->GetStringUTFChars(device, nullptr);
+    const char *dev = (*env)->GetStringUTFChars(env, device, NULL);
     jint res = _ioctl(dev, command, args);
-    env->ReleaseStringUTFChars(device, dev);
+    (*env)->ReleaseStringUTFChars(env, device, dev);
     return res;
 }
-
-#ifdef __cplusplus
-}
-#endif


### PR DESCRIPTION
To make sure we don't pull in some C++ that would break the ODR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/561)
<!-- Reviewable:end -->
