### PR TITLE
Remove Boox Go7 from EDP driver and add support for Hisense Touch Lite

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -57,6 +57,7 @@ object DeviceInfo {
         ENERGY,
         FIDIBOOK,
         HANVON_960,
+        HISENSE_TOUCH_LITE,
         HYREAD_GAZE_NOTE,
         HYREAD_GAZE_NOTE_CC,
         HYREAD_MINI6,
@@ -269,6 +270,10 @@ object DeviceInfo {
             // Hanvon 960
             BRAND == "freescale" && PRODUCT == "evk_6sl_eink"
             -> Id.HANVON_960
+
+            // Hisense Touch Lite
+            BRAND == "hisense" && MODEL == "hitv205n"
+            -> Id.HISENSE_TOUCH_LITE
 
             // Hyread Gaze Note
             MANUFACTURER == "hyread" && MODEL == "r08p"

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -97,7 +97,6 @@ object EPDFactory {
                 DeviceInfo.Id.ONYX_GO_103,
                 DeviceInfo.Id.ONYX_GO_COLOR7,
                 DeviceInfo.Id.ONYX_GO6,
-                DeviceInfo.Id.ONYX_GO7,
                 DeviceInfo.Id.ONYX_KON_TIKI2,
                 DeviceInfo.Id.ONYX_LEAF,
                 DeviceInfo.Id.ONYX_LEAF2,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -94,6 +94,7 @@ object LightsFactory {
                     logController("TolinoNTX")
                     TolinoNtxController()
                 }
+                DeviceInfo.Id.HISENSE_TOUCH_LITE,
                 DeviceInfo.Id.TOLINO_PAGE2,
                 -> {
                     logController("TolinoNTXNoWarmth")

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -17,6 +17,7 @@ object LightsFactory {
                 DeviceInfo.Id.ONYX_GALILEO2,
                 DeviceInfo.Id.ONYX_GO_COLOR7,
                 DeviceInfo.Id.ONYX_GO6,
+                DeviceInfo.Id.ONYX_GO7,
                 DeviceInfo.Id.ONYX_NOTE_AIR_3C,
                 DeviceInfo.Id.ONYX_NOTE_AIR_4C,
                 DeviceInfo.Id.ONYX_NOVA_AIR,
@@ -63,7 +64,6 @@ object LightsFactory {
                     OnyxWarmthController()
                 }
                 DeviceInfo.Id.ONYX_DARWIN9,
-                DeviceInfo.Id.ONYX_GO7,
                 DeviceInfo.Id.ONYX_LEAF2,
                 DeviceInfo.Id.ONYX_LIVINGSTONE3,
                 DeviceInfo.Id.ONYX_NOTE4,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -22,6 +22,7 @@ object LightsFactory {
                 DeviceInfo.Id.ONYX_NOTE_AIR_4C,
                 DeviceInfo.Id.ONYX_NOVA_AIR,
                 DeviceInfo.Id.ONYX_PAGE,
+                DeviceInfo.Id.ONYX_PALMA,
                 DeviceInfo.Id.ONYX_PALMA2,
                 DeviceInfo.Id.ONYX_POKE5,
                 DeviceInfo.Id.ONYX_POKE6,


### PR DESCRIPTION
Removed Boox Go7 from EDP driver, and Added Support for Hisense Touch Lite

Reason: new
Commercial name of product: Hisense Touch Lite
Android version: 11

Device info:
Manufacturer: hisense
Brand: hisense
Model: hitv205n
Device: hitv205n
Product: hitv205n
Hardware: qcom
Platform: bengal

light control works with Tolino driver, but warmth doesn't work.
no e-ink driver works.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/562)
<!-- Reviewable:end -->
