### PR TITLE
Add Hyread Gaze Note Plus CC to color devices

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -663,6 +663,7 @@ object DeviceInfo {
         }
 
         HAS_COLOR_SCREEN = when (ID) {
+            Id.HYREAD_GAZE_NOTE_CC,
             Id.MEEBOOK_M6C,
             Id.MOOINKPLUS2C,
             Id.NONE,


### PR DESCRIPTION
Fix Hyread Gaze Note Plus CC missing color parameter: https://github.com/koreader/android-luajit-launcher/issues/566