### PR TITLE
Compile against SDK 34

### DIFF
--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -137,7 +137,11 @@ class MainActivity : NativeActivity(), LuaInterface,
         Log.v(tag, String.format(Locale.US,
             "native orientation: %s", if (this.screenIsLandscape) "landscape" else "portrait"))
 
-        registerReceiver(event, event.filter)
+        if (Build.VERSION.SDK_INT >= 33) {
+            registerReceiver(event, event.filter, Context.RECEIVER_EXPORTED)
+        } else {
+            registerReceiver(event, event.filter)
+        }
 
         if (!hasMandatoryPermissions()) {
             requestMandatoryPermissions()

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
-    ext.compileSdk = 30
-    ext.targetSdk = 30
+    ext.compileSdk = 34
+    ext.targetSdk = 34
     ext.minSdk = 18
 
     ext.gradle_plugin_version = '8.4.2'
     ext.kotlin_plugin_version = '1.9.24'
-    ext.androidx_core_version = '1.6.0'
+    ext.androidx_core_version = '1.9.0'
     ext.androidx_appcompat_version = '1.3.1'
     ext.androidx_supportv4_version = '1.0.0'
 


### PR DESCRIPTION
Without this Android provides an annoying error message, see <https://www.mobileread.com/forums/showthread.php?p=4537017#post4537017>.

I don't think a change like this should affect older devices but the oldest I can test is Android 6. (And the emulator doesn't go below 7.)

It'd also necessitate a minor bump like <https://github.com/koreader/koreader-base/pull/1897>.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/572)
<!-- Reviewable:end -->
