### PR TITLE
add light controller for Rockchip3566 (Inkbook Focus Plus)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ app/build
 assets/libs
 assets/module
 jni/luajit/build
+.DS_Store

--- a/app/src/main/java/org/koreader/launcher/TestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/TestActivity.kt
@@ -28,6 +28,7 @@ import org.koreader.launcher.device.lights.TolinoRootController
 import org.koreader.launcher.device.lights.TolinoNtxController
 import org.koreader.launcher.device.lights.TolinoNtxNoWarmthController
 import org.koreader.launcher.device.lights.BoyueS62RootController
+import org.koreader.launcher.device.lights.Rockchip3566Controller
 import org.koreader.launcher.dialog.LightDialog
 import org.koreader.launcher.dialog.ToolTip
 
@@ -81,6 +82,7 @@ class TestActivity: AppCompatActivity() {
         lightsMap["Tolino Root"] = TolinoRootController()
         lightsMap["Tolino Ntx"] = TolinoNtxController()
         lightsMap["Tolino Ntx (no warmth)"] = TolinoNtxNoWarmthController()
+        lightsMap["Rockchip RK3566"] = Rockchip3566Controller()
 
         // Device ID
         binding.info.append("Manufacturer: ${DeviceInfo.MANUFACTURER}\n")

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -18,6 +18,7 @@ object DeviceInfo {
     private const val STR_NTX = "ntx_6sl"
     private const val STR_ROCKCHIP = "rockchip"
     private const val STR_TOLINO = "tolino"
+    const val DEVICE_RK3566_EINK = "rk3566_eink"
 
     val MANUFACTURER: String
     val BRAND: String
@@ -296,7 +297,7 @@ object DeviceInfo {
             -> Id.INKBOOKFOCUS
 
             // InkBook Focus Plus
-            DEVICE == "rk3566_eink" && MODEL == "focus plus"
+            DEVICE == DEVICE_RK3566_EINK && MODEL == "focus plus"
             -> Id.INKBOOKFOCUS_PLUS
 
             // InkPalm Plus
@@ -632,7 +633,7 @@ object DeviceInfo {
             -> Id.TOLINO
 
             // Xiaomi
-            MANUFACTURER == "xiaomi" && BRAND == "xiaomi" && MODEL == "xiaomi_reader" && DEVICE == "rk3566_eink" && HARDWARE == "rk30board"
+            MANUFACTURER == "xiaomi" && BRAND == "xiaomi" && MODEL == "xiaomi_reader" && DEVICE == DEVICE_RK3566_EINK && HARDWARE == "rk30board"
             -> Id.XIAOMI_READER
 
             // ???

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -1,6 +1,7 @@
 package org.koreader.launcher.device
 
 import android.util.Log
+import org.koreader.launcher.BuildConfig
 import org.koreader.launcher.device.lights.*
 import java.util.*
 
@@ -107,7 +108,9 @@ object LightsFactory {
                     TolinoRootController()
                 }
                 DeviceInfo.Id.INKBOOKFOCUS_PLUS -> {
-                    logController("Rockchip3566Controller")
+                    logController("Rockchip3566Controller") {
+                        Rockchip3566Controller.reportApiAvailability()
+                    }
                     Rockchip3566Controller()
                 }
                 else -> {
@@ -117,8 +120,13 @@ object LightsFactory {
             }
         }
 
-    private fun logController(name: String?) {
+    private fun logController(name: String, extendedLog: (() -> String)? = null) {
         Log.i(TAG, String.format(Locale.US,
             "Using %s driver", name))
+        if (BuildConfig.DEBUG) {
+            extendedLog?.invoke()?.let {
+                Log.i(TAG, it)
+            }
+        }
     }
 }

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -106,6 +106,10 @@ object LightsFactory {
                     logController("TolinoRoot")
                     TolinoRootController()
                 }
+                DeviceInfo.Id.INKBOOKFOCUS_PLUS -> {
+                    logController("Rockchip3566Controller")
+                    Rockchip3566Controller()
+                }
                 else -> {
                     logController("Generic")
                     GenericController()

--- a/app/src/main/java/org/koreader/launcher/device/lights/OnyxC67Controller.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/OnyxC67Controller.kt
@@ -3,7 +3,7 @@ package org.koreader.launcher.device.lights
 import android.app.Activity
 import android.util.Log
 import org.koreader.launcher.device.LightsInterface
-import org.koreader.launcher.extensions.read
+import org.koreader.launcher.extensions.readOrElse
 import org.koreader.launcher.extensions.write
 import java.io.File
 
@@ -36,7 +36,7 @@ class OnyxC67Controller : LightsInterface {
     }
 
     override fun getBrightness(activity: Activity): Int {
-        return File(BRIGHTNESS_FILE).read()
+        return File(BRIGHTNESS_FILE).readOrElse()
     }
 
     override fun getWarmth(activity: Activity): Int {

--- a/app/src/main/java/org/koreader/launcher/device/lights/OnyxColorController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/OnyxColorController.kt
@@ -3,7 +3,7 @@ package org.koreader.launcher.device.lights
 import android.app.Activity
 import android.util.Log
 import org.koreader.launcher.device.LightsInterface
-import org.koreader.launcher.extensions.read
+import org.koreader.launcher.extensions.readOrElse
 import org.koreader.launcher.extensions.write
 import java.io.File
 
@@ -43,7 +43,7 @@ class OnyxColorController : LightsInterface {
     }
 
     override fun getBrightness(activity: Activity): Int {
-        return File(ACTUAL_BRIGHTNESS_FILE).read()
+        return File(ACTUAL_BRIGHTNESS_FILE).readOrElse()
     }
 
     override fun getWarmth(activity: Activity): Int {

--- a/app/src/main/java/org/koreader/launcher/device/lights/OnyxWarmthController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/OnyxWarmthController.kt
@@ -3,7 +3,7 @@ package org.koreader.launcher.device.lights
 import android.app.Activity
 import android.util.Log
 import org.koreader.launcher.device.LightsInterface
-import org.koreader.launcher.extensions.read
+import org.koreader.launcher.extensions.readOrElse
 import org.koreader.launcher.extensions.write
 import java.io.File
 
@@ -34,11 +34,11 @@ class OnyxWarmthController : LightsInterface {
     }
 
     override fun getBrightness(activity: Activity): Int {
-        return File(WHITE_FILE).read()
+        return File(WHITE_FILE).readOrElse()
     }
 
     override fun getWarmth(activity: Activity): Int {
-        return File(WARMTH_FILE).read()
+        return File(WARMTH_FILE).readOrElse()
     }
 
     override fun setBrightness(activity: Activity, brightness: Int) {

--- a/app/src/main/java/org/koreader/launcher/device/lights/Rockchip3566Controller.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/Rockchip3566Controller.kt
@@ -1,0 +1,296 @@
+package org.koreader.launcher.device.lights
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import org.koreader.launcher.device.LightsInterface
+import org.koreader.launcher.device.lights.Rockchip3566Controller.Companion.LED_A_FILE
+import org.koreader.launcher.device.lights.Rockchip3566Controller.Companion.LED_B_FILE
+import org.koreader.launcher.device.lights.Rockchip3566Controller.Companion.SYS_PROP_BRIGHTNESS
+import org.koreader.launcher.device.lights.Rockchip3566Controller.Companion.SYS_PROP_TEMPERATURE
+import org.koreader.launcher.device.lights.Rockchip3566Controller.Companion.SYS_UTIL_RK3566_CLASS_NAME
+import org.koreader.launcher.extensions.forNameOrNull
+import org.koreader.launcher.extensions.getMethodOrNull
+import org.koreader.launcher.extensions.read
+import org.koreader.launcher.extensions.write
+import org.koreader.launcher.util.getSystemProperty
+import org.koreader.launcher.util.setSystemProperty
+import java.io.File
+
+/**
+ * The light controller for the device [org.koreader.launcher.device.DeviceInfo.DEVICE_RK3566_EINK]
+ * which is based on reverse engineering the main launcher "inkBOOKSettings.apk" for the model
+ * [org.koreader.launcher.device.DeviceInfo.Id.INKBOOKFOCUS_PLUS].
+ *
+ * This controller tries to write to the LED files [LED_A_FILE] and [LED_B_FILE], as a fallback
+ * reflection via [SYS_UTIL_RK3566_CLASS_NAME] is used if a write should be not possible.
+ *
+ * Whenever the brightness or warmth changes, the [computeLedValues] function needs to be called
+ * which computes the correct values for LED a and b. Note that these values do not correspond
+ * to the input which is set by [setBrightness] and [setWarmth].
+ *
+ * Additionally, to mimic the behavior of the system app as good as possible, the brightness
+ * and warmth values are stored in the system properties [SYS_PROP_BRIGHTNESS] and [SYS_PROP_TEMPERATURE].
+ *
+ * However, the system app caches the brightness and temperature in RAM, therefore any changes
+ * won't be automatically reflected in the system UI.
+ */
+class Rockchip3566Controller : LightsInterface {
+
+    companion object Companion {
+        private const val TAG = "Rockchip3566Controller"
+        private const val BRIGHTNESS_MAX = 180
+        private const val WARMTH_MAX = 200
+        private const val MIN = 0
+
+        private const val SYS_UTIL_RK3566_CLASS_NAME = "android.yitoa.rk3566.SysUtil"
+
+        private const val SYS_UTIL_METHOD_SET_LED_A_BRIGHTNESS = "setBackLightLedaBrightness"
+        private const val SYS_UTIL_METHOD_GET_MAX_LED_A_BRIGHTNESS = "getBackLightLedaMaxBrightness"
+        private const val SYS_UTIL_METHOD_SET_LED_B_BRIGHTNESS = "setBackLightLedbBrightness"
+        private const val SYS_UTIL_METHOD_GET_MAX_LED_B_BRIGHTNESS = "getBackLightLedbMaxBrightness"
+
+        private const val SYS_PROP_BRIGHTNESS = "persist.inkbook.frontlight.brightness"
+        private const val SYS_PROP_TEMPERATURE = "persist.inkbook.frontlight.temperature"
+
+        // typo exists in system property
+        private const val SYS_PROP_COLD_EFFICIENCY = "persist.inkbook.light.coldefficancy"
+        private const val SYS_PROP_COLD_EFF_DEFAULT = 1
+
+        // typo exists in system property
+        private const val SYS_PROP_WARM_EFFICIENCY = "persist.inkbook.light.warmefficancy"
+        private const val SYS_PROP_WARM_EFF_DEFAULT = 1
+
+        // system properties for led a and b
+        private const val SYS_PROP_LED_A = "persist.yitoa.backlight.leda.brightness"
+        private const val SYS_PROP_LED_B = "persist.yitoa.backlight.ledb.brightness"
+
+        // system files for backlight brightness led a and b
+        private const val LED_A_FILE = "/sys/class/backlight/lm3630a_leda/brightness"
+        private const val LED_B_FILE = "/sys/class/backlight/lm3630a_ledb/brightness"
+
+        // system files for the max backlight brightness for led a and b
+        private const val MAX_LED_A_FILE = "/sys/class/backlight/lm3630a_leda/max_brightness"
+        private const val MAX_LED_B_FILE = "/sys/class/backlight/lm3630a_ledb/max_brightness"
+        private const val DEFAULT_MAX = 200
+    }
+
+    private var sysUtilWrapper: ClassWrapper? = null
+
+    private fun getSysUtilClass(context: Context): ClassWrapper? {
+        if (sysUtilWrapper != null) {
+            return sysUtilWrapper
+        }
+        val sysUtil = forNameOrNull(SYS_UTIL_RK3566_CLASS_NAME) ?: return null
+        val instance = sysUtil
+            .getConstructor(Context::class.java)
+            .newInstance(context)
+        val wrapper = ClassWrapper(sysUtil, instance)
+        sysUtilWrapper = wrapper
+        return wrapper
+    }
+
+    override fun getPlatform(): String {
+        return "rockchip"
+    }
+
+    override fun hasFallback(): Boolean {
+        return false
+    }
+
+    override fun hasWarmth(): Boolean {
+        return true
+    }
+
+    override fun needsPermission(): Boolean {
+        // no, as settings can be only manipulated via reflection
+        return false
+    }
+
+    override fun getBrightness(activity: Activity): Int {
+        return getSystemProperty(SYS_PROP_BRIGHTNESS, MIN.toString())
+            ?.toIntOrNull() ?: MIN
+    }
+
+    override fun getWarmth(activity: Activity): Int {
+        return getSystemProperty(SYS_PROP_TEMPERATURE, MIN.toString())
+            ?.toIntOrNull() ?: MIN
+    }
+
+    override fun setBrightness(activity: Activity, brightness: Int) {
+        setBrightnessInternal(activity, brightness)
+    }
+
+    override fun setWarmth(activity: Activity, warmth: Int) {
+        setTemperatureInternal(activity, warmth)
+    }
+
+    override fun getMinWarmth(): Int {
+        return MIN
+    }
+
+    override fun getMaxWarmth(): Int {
+        return WARMTH_MAX
+    }
+
+    override fun getMinBrightness(): Int {
+        return MIN
+    }
+
+    override fun getMaxBrightness(): Int {
+        return BRIGHTNESS_MAX
+    }
+
+    override fun enableFrontlightSwitch(activity: Activity): Int {
+        return 1
+    }
+
+    override fun hasStandaloneWarmth(): Boolean {
+        return false
+    }
+
+    private fun setBrightnessInternal(context: Context, brightness: Int) {
+        val defaultTemp = 0
+        val temperature =
+            getSystemProperty(SYS_PROP_TEMPERATURE, 0.toString())
+                ?.toIntOrNull() ?: defaultTemp
+        setLight(context, brightness, temperature)
+    }
+
+    private fun setTemperatureInternal(context: Context, temperature: Int) {
+        val defaultTemp = 0
+        val brightness =
+            getSystemProperty(SYS_PROP_BRIGHTNESS, 0.toString())
+                ?.toIntOrNull() ?: defaultTemp
+        setLight(context, brightness, temperature)
+    }
+
+    private fun setLight(context: Context, brightness: Int, temperature: Int) {
+        // a 0 value is never persisted for the configurable properties, which is done
+        // in order to keep the last known value when the light is turned off
+        if (brightness > 0) {
+            setSystemProperty(SYS_PROP_BRIGHTNESS, brightness.toString())
+        }
+        if (temperature > 0) {
+            setSystemProperty(SYS_PROP_TEMPERATURE, temperature.toString())
+        }
+
+        // retrieves the efficiency factors
+        val coldEff =
+            getSystemProperty(SYS_PROP_COLD_EFFICIENCY, SYS_PROP_COLD_EFF_DEFAULT.toString())
+                ?.toIntOrNull() ?: SYS_PROP_COLD_EFF_DEFAULT
+        val warmEff =
+            getSystemProperty(SYS_PROP_WARM_EFFICIENCY, SYS_PROP_WARM_EFF_DEFAULT.toString())
+                ?.toIntOrNull() ?: SYS_PROP_WARM_EFF_DEFAULT
+
+        val sysUtil: ClassWrapper? by lazy { getSysUtilClass(context) }
+
+        // retrieves the max leda and ledb
+        val maxLedA = File(MAX_LED_A_FILE).readOrElse {
+            (sysUtil?.clazz?.getMethodOrNull(
+                methodName = SYS_UTIL_METHOD_GET_MAX_LED_A_BRIGHTNESS
+            )?.invoke(sysUtil!!.instance) as? Int) ?: DEFAULT_MAX
+        }
+        val maxLedB = File(MAX_LED_B_FILE).readOrElse {
+            (sysUtil?.clazz?.getMethodOrNull(
+                methodName = SYS_UTIL_METHOD_GET_MAX_LED_B_BRIGHTNESS
+            )?.invoke(sysUtil!!.instance) as? Int) ?: DEFAULT_MAX
+        }
+        val (ledA, ledB) = computeLedValues(
+            brightness,
+            temperature,
+            coldEff,
+            warmEff,
+            maxLedA,
+            maxLedB
+        )
+
+        // set the leda and ledb based on writing to the file directly
+        // as a fallback, call the reflection function
+        if (File(LED_A_FILE).write(ledA)) {
+            setSystemProperty(SYS_PROP_LED_A, ledA.toString())
+        } else {
+            sysUtil
+                ?.clazz?.getMethodOrNull(
+                    methodName = SYS_UTIL_METHOD_SET_LED_A_BRIGHTNESS,
+                    Int::class.java
+                )
+                ?.invoke(sysUtil!!.instance, ledA)
+        }
+        if (File(LED_B_FILE).write(ledB)) {
+            setSystemProperty(SYS_PROP_LED_B, ledB.toString())
+        } else {
+            sysUtil
+                ?.clazz?.getMethodOrNull(
+                    methodName = SYS_UTIL_METHOD_SET_LED_B_BRIGHTNESS,
+                    Int::class.java
+                )
+                ?.invoke(sysUtil!!.instance, ledB)
+        }
+        Log.i(
+            TAG, "setLight=(brightness: ${brightness}, temperature: $temperature), " +
+                "setLeds=(leda: ${ledA}, ledb: $ledB)"
+        )
+
+        // com.android.systemui has registered a broadcast receiver to this intent action
+        context.sendBroadcast(Intent("com.android.systemui.statusbar.action.light_change").apply {
+            // the system ui will adapt the light icon based on the boolean state
+            putExtra("state", brightness > 1)
+        })
+    }
+
+    /**
+     * This computation function is taken from the inkBOOKSettings.apk, it is called right before
+     * the setters of android.yitoa.rk3566.SysUtil are called.
+     *
+     * @return a pair where [Pair.first] represents leda and [Pair.second] ledb.
+     */
+    private fun computeLedValues(
+        brightness: Int,
+        temperature: Int,
+        coldEff: Int,
+        warmEff: Int,
+        ledAMax: Int,
+        ledBMax: Int,
+    ): Pair<Int, Int> {
+        return when {
+            temperature <= 95 -> {
+                val ledB = brightness.coerceAtMost(ledBMax)
+                val ledA = ((brightness * temperature / 100.0) * coldEff / warmEff)
+                    .toInt()
+                    .coerceAtMost(ledAMax)
+                ledA to ledB
+            }
+
+            temperature <= 105 -> {
+                val ledB = brightness.coerceAtMost(ledBMax)
+                val ledA = (coldEff * brightness / warmEff)
+                    .coerceAtMost(ledAMax)
+                ledA to ledB
+            }
+
+            else -> {
+                val ledA = brightness.coerceAtMost(ledAMax)
+                val ledB = (((ledBMax - temperature) * brightness / 100.0) * coldEff / warmEff)
+                    .toInt()
+                    .coerceAtMost(ledBMax)
+                ledA to ledB
+            }
+        }
+    }
+
+    private data class ClassWrapper(
+        val clazz: Class<*>,
+        val instance: Any,
+    )
+}
+
+private fun File.readOrElse(block: () -> Int): Int {
+    val value = read()
+    return if (value == 0) {
+        block()
+    } else {
+        value
+    }
+}

--- a/app/src/main/java/org/koreader/launcher/device/lights/Rockchip3566Controller.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/Rockchip3566Controller.kt
@@ -12,8 +12,10 @@ import org.koreader.launcher.device.lights.Rockchip3566Controller.Companion.SYS_
 import org.koreader.launcher.device.lights.Rockchip3566Controller.Companion.SYS_UTIL_RK3566_CLASS_NAME
 import org.koreader.launcher.extensions.forNameOrNull
 import org.koreader.launcher.extensions.getMethodOrNull
-import org.koreader.launcher.extensions.read
+import org.koreader.launcher.extensions.invokeOrNull
+import org.koreader.launcher.extensions.readOrElse
 import org.koreader.launcher.extensions.write
+import org.koreader.launcher.util.ANDROID_OS_SYS_PROP_CLASS_NAME
 import org.koreader.launcher.util.getSystemProperty
 import org.koreader.launcher.util.setSystemProperty
 import java.io.File
@@ -39,40 +41,40 @@ import java.io.File
 class Rockchip3566Controller : LightsInterface {
 
     companion object Companion {
-        private const val TAG = "Rockchip3566Controller"
+        const val TAG = "Rockchip3566Controller"
         private const val BRIGHTNESS_MAX = 180
         private const val WARMTH_MAX = 200
         private const val MIN = 0
 
-        private const val SYS_UTIL_RK3566_CLASS_NAME = "android.yitoa.rk3566.SysUtil"
+        const val SYS_UTIL_RK3566_CLASS_NAME = "android.yitoa.rk3566.SysUtil"
 
-        private const val SYS_UTIL_METHOD_SET_LED_A_BRIGHTNESS = "setBackLightLedaBrightness"
-        private const val SYS_UTIL_METHOD_GET_MAX_LED_A_BRIGHTNESS = "getBackLightLedaMaxBrightness"
-        private const val SYS_UTIL_METHOD_SET_LED_B_BRIGHTNESS = "setBackLightLedbBrightness"
-        private const val SYS_UTIL_METHOD_GET_MAX_LED_B_BRIGHTNESS = "getBackLightLedbMaxBrightness"
+        const val SYS_UTIL_METHOD_SET_LED_A_BRIGHTNESS = "setBackLightLedaBrightness"
+        const val SYS_UTIL_METHOD_GET_MAX_LED_A_BRIGHTNESS = "getBackLightLedaMaxBrightness"
+        const val SYS_UTIL_METHOD_SET_LED_B_BRIGHTNESS = "setBackLightLedbBrightness"
+        const val SYS_UTIL_METHOD_GET_MAX_LED_B_BRIGHTNESS = "getBackLightLedbMaxBrightness"
 
-        private const val SYS_PROP_BRIGHTNESS = "persist.inkbook.frontlight.brightness"
-        private const val SYS_PROP_TEMPERATURE = "persist.inkbook.frontlight.temperature"
-
-        // typo exists in system property
-        private const val SYS_PROP_COLD_EFFICIENCY = "persist.inkbook.light.coldefficancy"
-        private const val SYS_PROP_COLD_EFF_DEFAULT = 1
+        const val SYS_PROP_BRIGHTNESS = "persist.inkbook.frontlight.brightness"
+        const val SYS_PROP_TEMPERATURE = "persist.inkbook.frontlight.temperature"
 
         // typo exists in system property
-        private const val SYS_PROP_WARM_EFFICIENCY = "persist.inkbook.light.warmefficancy"
-        private const val SYS_PROP_WARM_EFF_DEFAULT = 1
+        const val SYS_PROP_COLD_EFFICIENCY = "persist.inkbook.light.coldefficancy"
+        const val SYS_PROP_COLD_EFF_DEFAULT = 1
+
+        // typo exists in system property
+        const val SYS_PROP_WARM_EFFICIENCY = "persist.inkbook.light.warmefficancy"
+        const val SYS_PROP_WARM_EFF_DEFAULT = 1
 
         // system properties for led a and b
-        private const val SYS_PROP_LED_A = "persist.yitoa.backlight.leda.brightness"
-        private const val SYS_PROP_LED_B = "persist.yitoa.backlight.ledb.brightness"
+        const val SYS_PROP_LED_A = "persist.yitoa.backlight.leda.brightness"
+        const val SYS_PROP_LED_B = "persist.yitoa.backlight.ledb.brightness"
 
         // system files for backlight brightness led a and b
-        private const val LED_A_FILE = "/sys/class/backlight/lm3630a_leda/brightness"
-        private const val LED_B_FILE = "/sys/class/backlight/lm3630a_ledb/brightness"
+        val LED_A_FILE = File("/sys/class/backlight/lm3630a_leda/brightness")
+        val LED_B_FILE = File("/sys/class/backlight/lm3630a_ledb/brightness")
 
         // system files for the max backlight brightness for led a and b
-        private const val MAX_LED_A_FILE = "/sys/class/backlight/lm3630a_leda/max_brightness"
-        private const val MAX_LED_B_FILE = "/sys/class/backlight/lm3630a_ledb/max_brightness"
+        val MAX_LED_A_FILE = File("/sys/class/backlight/lm3630a_leda/max_brightness")
+        val MAX_LED_B_FILE = File("/sys/class/backlight/lm3630a_ledb/max_brightness")
         private const val DEFAULT_MAX = 200
     }
 
@@ -187,12 +189,12 @@ class Rockchip3566Controller : LightsInterface {
         val sysUtil: ClassWrapper? by lazy { getSysUtilClass(context) }
 
         // retrieves the max leda and ledb
-        val maxLedA = File(MAX_LED_A_FILE).readOrElse {
+        val maxLedA = MAX_LED_A_FILE.readOrElse {
             (sysUtil?.clazz?.getMethodOrNull(
                 methodName = SYS_UTIL_METHOD_GET_MAX_LED_A_BRIGHTNESS
             )?.invoke(sysUtil!!.instance) as? Int) ?: DEFAULT_MAX
         }
-        val maxLedB = File(MAX_LED_B_FILE).readOrElse {
+        val maxLedB = MAX_LED_B_FILE.readOrElse {
             (sysUtil?.clazz?.getMethodOrNull(
                 methodName = SYS_UTIL_METHOD_GET_MAX_LED_B_BRIGHTNESS
             )?.invoke(sysUtil!!.instance) as? Int) ?: DEFAULT_MAX
@@ -208,7 +210,7 @@ class Rockchip3566Controller : LightsInterface {
 
         // set the leda and ledb based on writing to the file directly
         // as a fallback, call the reflection function
-        if (File(LED_A_FILE).write(ledA)) {
+        if (LED_A_FILE.write(ledA)) {
             setSystemProperty(SYS_PROP_LED_A, ledA.toString())
         } else {
             sysUtil
@@ -218,7 +220,7 @@ class Rockchip3566Controller : LightsInterface {
                 )
                 ?.invoke(sysUtil!!.instance, ledA)
         }
-        if (File(LED_B_FILE).write(ledB)) {
+        if (LED_B_FILE.write(ledB)) {
             setSystemProperty(SYS_PROP_LED_B, ledB.toString())
         } else {
             sysUtil
@@ -286,11 +288,68 @@ class Rockchip3566Controller : LightsInterface {
     )
 }
 
-private fun File.readOrElse(block: () -> Int): Int {
-    val value = read()
-    return if (value == 0) {
-        block()
-    } else {
-        value
+/**
+ * Reports the availability of the used APIs to control lights.
+ */
+fun Rockchip3566Controller.Companion.reportApiAvailability(): String {
+    val logMessage = StringBuilder()
+
+    logMessage.appendLine("Checking API availability for driver $TAG")
+
+    logMessage.appendLine("Check read/write permissions for hardware system files")
+    val ledFiles = listOf(LED_A_FILE, LED_B_FILE, MAX_LED_A_FILE, MAX_LED_B_FILE)
+    ledFiles.forEach { file ->
+        logMessage.appendLine("\t${file.absolutePath} - readable: ${file.canRead()}, writable: ${file.canWrite()}")
     }
+
+    logMessage.appendLine("Check system utility class via reflection")
+    val sysUtilClass = forNameOrNull(SYS_UTIL_RK3566_CLASS_NAME)
+    logMessage.appendLine("Class $SYS_UTIL_RK3566_CLASS_NAME - available: ${sysUtilClass != null}")
+
+    if (sysUtilClass != null) {
+        val brightnessMethods = listOf(
+            SYS_UTIL_METHOD_SET_LED_A_BRIGHTNESS,
+            SYS_UTIL_METHOD_SET_LED_B_BRIGHTNESS
+        )
+        brightnessMethods.forEach { methodName ->
+            val isAvailable = sysUtilClass.getMethodOrNull(methodName, Int::class.java) != null
+            logMessage.appendLine("\tMethod $methodName - available: $isAvailable")
+        }
+
+        val maxBrightnessMethods = listOf(
+            SYS_UTIL_METHOD_GET_MAX_LED_A_BRIGHTNESS,
+            SYS_UTIL_METHOD_GET_MAX_LED_B_BRIGHTNESS
+        )
+        maxBrightnessMethods.forEach { methodName ->
+            val isAvailable = sysUtilClass.getMethodOrNull(methodName) != null
+            logMessage.appendLine("\tMethod $methodName - available: $isAvailable")
+        }
+    }
+
+    logMessage.appendLine("Check system properties")
+    val sysPropClass = forNameOrNull(ANDROID_OS_SYS_PROP_CLASS_NAME)
+    logMessage.appendLine("Class $ANDROID_OS_SYS_PROP_CLASS_NAME - available: ${sysPropClass != null}")
+
+    if (sysPropClass != null) {
+        val getSysPropMethod = sysPropClass.getMethodOrNull("get", String::class.java)
+        if (getSysPropMethod != null) {
+            val systemProperties = listOf(
+                SYS_PROP_BRIGHTNESS,
+                SYS_PROP_TEMPERATURE,
+                SYS_PROP_COLD_EFFICIENCY,
+                SYS_PROP_WARM_EFFICIENCY,
+                SYS_PROP_LED_A,
+                SYS_PROP_LED_B
+            )
+
+            systemProperties.forEach { propertyName ->
+                val value = getSysPropMethod.invokeOrNull<String>(sysPropClass, propertyName)
+                val displayValue = value?.ifEmpty { "n/a" }
+                logMessage.appendLine("\tSystem property $propertyName - value: $displayValue")
+            }
+        }
+    }
+
+    return logMessage.toString()
 }
+

--- a/app/src/main/java/org/koreader/launcher/device/lights/Rockchip3566Controller.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/Rockchip3566Controller.kt
@@ -297,8 +297,15 @@ fun Rockchip3566Controller.Companion.reportApiAvailability(): String {
     logMessage.appendLine("Check read/write permissions for hardware system files")
     val ledFiles = listOf(LED_A_FILE, LED_B_FILE, MAX_LED_A_FILE, MAX_LED_B_FILE)
     ledFiles.forEach { file ->
-        logMessage.appendLine("\t${file.absolutePath} - readable: ${file.canRead()}, " +
-            "writable: ${file.canWrite()}${if (file.canRead()) " - current value: ${file.readOrElse()}" else ""}")
+        val msg = if (file.exists()) {
+            "readable: ${file.canRead()}, writable: ${file.canWrite()}${
+                if (file.canRead()) " " +
+                    "- current value: ${file.readOrElse()}" else ""
+            }"
+        } else {
+            "not available"
+        }
+        logMessage.appendLine("\t${file.absolutePath} - $msg")
     }
 
     logMessage.appendLine("Check system utility class via reflection")

--- a/app/src/main/java/org/koreader/launcher/device/lights/Rockchip3566Controller.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/Rockchip3566Controller.kt
@@ -297,7 +297,8 @@ fun Rockchip3566Controller.Companion.reportApiAvailability(): String {
     logMessage.appendLine("Check read/write permissions for hardware system files")
     val ledFiles = listOf(LED_A_FILE, LED_B_FILE, MAX_LED_A_FILE, MAX_LED_B_FILE)
     ledFiles.forEach { file ->
-        logMessage.appendLine("\t${file.absolutePath} - readable: ${file.canRead()}, writable: ${file.canWrite()}")
+        logMessage.appendLine("\t${file.absolutePath} - readable: ${file.canRead()}, " +
+            "writable: ${file.canWrite()}${if (file.canRead()) " - current value: ${file.readOrElse()}" else ""}")
     }
 
     logMessage.appendLine("Check system utility class via reflection")

--- a/app/src/main/java/org/koreader/launcher/device/lights/Rockchip3566Controller.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/Rockchip3566Controller.kt
@@ -229,8 +229,8 @@ class Rockchip3566Controller : LightsInterface {
                 ?.invoke(sysUtil!!.instance, ledB)
         }
         Log.i(
-            TAG, "setLight=(brightness: ${brightness}, temperature: $temperature), " +
-                "setLeds=(leda: ${ledA}, ledb: $ledB)"
+            TAG, "setLight=(brightness: $brightness, temperature: $temperature), " +
+                "setLeds=(leda: $ledA, ledb: $ledB)"
         )
 
         // com.android.systemui has registered a broadcast receiver to this intent action

--- a/app/src/main/java/org/koreader/launcher/device/lights/Rockchip3566Controller.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/Rockchip3566Controller.kt
@@ -153,18 +153,16 @@ class Rockchip3566Controller : LightsInterface {
     }
 
     private fun setBrightnessInternal(context: Context, brightness: Int) {
-        val defaultTemp = 0
         val temperature =
-            getSystemProperty(SYS_PROP_TEMPERATURE, 0.toString())
-                ?.toIntOrNull() ?: defaultTemp
+            getSystemProperty(SYS_PROP_TEMPERATURE, MIN.toString())
+                ?.toIntOrNull() ?: MIN
         setLight(context, brightness, temperature)
     }
 
     private fun setTemperatureInternal(context: Context, temperature: Int) {
-        val defaultTemp = 0
         val brightness =
-            getSystemProperty(SYS_PROP_BRIGHTNESS, 0.toString())
-                ?.toIntOrNull() ?: defaultTemp
+            getSystemProperty(SYS_PROP_BRIGHTNESS, MIN.toString())
+                ?.toIntOrNull() ?: MIN
         setLight(context, brightness, temperature)
     }
 

--- a/app/src/main/java/org/koreader/launcher/device/lights/TolinoNtxController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/TolinoNtxController.kt
@@ -5,7 +5,7 @@ import android.provider.Settings
 import android.util.Log
 import org.koreader.launcher.device.Ioctl
 import org.koreader.launcher.device.LightsInterface
-import org.koreader.launcher.extensions.read
+import org.koreader.launcher.extensions.readOrElse
 import java.io.File
 
 /* Special controller for Tolino Vision5
@@ -61,7 +61,7 @@ class TolinoNtxController : Ioctl(), LightsInterface {
 
     override fun getWarmth(activity: Activity): Int {
         if (currentWarmth == null) {
-            currentWarmth = WARMTH_MAX - File(COLOR_FILE).read()
+            currentWarmth = WARMTH_MAX - File(COLOR_FILE).readOrElse()
         }
         return currentWarmth ?: WARMTH_MAX
     }

--- a/app/src/main/java/org/koreader/launcher/device/lights/TolinoRootController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/TolinoRootController.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.provider.Settings
 import android.util.Log
 import org.koreader.launcher.device.LightsInterface
-import org.koreader.launcher.extensions.read
+import org.koreader.launcher.extensions.readOrElse
 import org.koreader.launcher.extensions.write
 import java.io.File
 
@@ -102,7 +102,7 @@ class TolinoRootController : LightsInterface {
     }
 
     override fun getWarmth(activity: Activity): Int {
-        return WARMTH_MAX - File(COLOR_FILE).read()
+        return WARMTH_MAX - File(COLOR_FILE).readOrElse()
     }
 
     override fun setBrightness(activity: Activity, brightness: Int) {

--- a/app/src/main/java/org/koreader/launcher/extensions/ClassExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ClassExtensions.kt
@@ -20,6 +20,22 @@ fun Class<*>.getMethodOrNull(
 }
 
 /**
+ * Safe function for [Method.invoke].
+ */
+inline fun <reified T> Method.invokeOrNull(
+    instance: Any,
+    methodName: String,
+    vararg parameterTypes: Class<*>,
+): T? {
+    try {
+        return this.invoke(instance, methodName, *parameterTypes) as T
+    } catch (e: Exception) {
+        Log.e("ClassExtensions", "Method.invokeOrNull failed", e)
+        return null
+    }
+}
+
+/**
  * Safe function for [Class.forName].
  */
 fun forNameOrNull(className: String): Class<*>? {

--- a/app/src/main/java/org/koreader/launcher/extensions/ClassExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ClassExtensions.kt
@@ -1,0 +1,32 @@
+package org.koreader.launcher.extensions
+
+import android.util.Log
+import java.lang.reflect.Method
+
+/**
+ * Safe function for [Class.getMethod].
+ */
+fun Class<*>.getMethodOrNull(
+    methodName: String,
+    vararg parameterTypes: Class<*>,
+): Method? {
+    try {
+        return this
+            .getMethod(methodName, *parameterTypes)
+    } catch (e: Exception) {
+        Log.e("ClassExtensions", "getMethod failed", e)
+        return null
+    }
+}
+
+/**
+ * Safe function for [Class.forName].
+ */
+fun forNameOrNull(className: String): Class<*>? {
+    return try {
+        Class.forName(className)
+    } catch (e: Exception) {
+        Log.e("ClassExtensions", "forNameOrNull failed", e)
+        null
+    }
+}

--- a/app/src/main/java/org/koreader/launcher/extensions/ClassExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ClassExtensions.kt
@@ -14,7 +14,7 @@ fun Class<*>.getMethodOrNull(
         return this
             .getMethod(methodName, *parameterTypes)
     } catch (e: Exception) {
-        Log.e("ClassExtensions", "getMethod failed", e)
+        Log.e("ClassExtensions", "Class.getMethod failed", e)
         return null
     }
 }
@@ -26,7 +26,7 @@ fun forNameOrNull(className: String): Class<*>? {
     return try {
         Class.forName(className)
     } catch (e: Exception) {
-        Log.e("ClassExtensions", "forNameOrNull failed", e)
+        Log.e("ClassExtensions", "Class.forName failed", e)
         null
     }
 }

--- a/app/src/main/java/org/koreader/launcher/extensions/FileExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/FileExtensions.kt
@@ -41,10 +41,12 @@ fun File.read(): Int {
     }
 }
 
-fun File.write(value: Int) {
+fun File.write(value: Int): Boolean {
     try {
         writeText(value.toString())
+        return true
     } catch (e: Exception) {
         e.printStackTrace()
+        return false
     }
 }

--- a/app/src/main/java/org/koreader/launcher/extensions/FileExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/FileExtensions.kt
@@ -32,15 +32,31 @@ fun File.symlink(link: String): Boolean {
     }
 }
 
-fun File.read(): Int {
+private const val FILE_READ_INT_DEFAULT = 0
+
+/**
+ * Reads from [this] and parses the result to [Int].
+ *
+ * In case of an error, [block] is invoked an returned.
+ */
+fun File.readOrElse(block: () -> Int = { FILE_READ_INT_DEFAULT }): Int {
+    return read() ?: return block()
+}
+
+private fun File.read(): Int? {
     return try {
         this.readText().replace("\n", "").toInt()
     } catch (e: Exception) {
         e.printStackTrace()
-        0
+        null
     }
 }
 
+/**
+ * Writes [value] to [this].
+ *
+ * @return true if the write op was successful, otherwise false.
+ */
 fun File.write(value: Int): Boolean {
     try {
         writeText(value.toString())

--- a/app/src/main/java/org/koreader/launcher/util/SystemPropertiesUtil.kt
+++ b/app/src/main/java/org/koreader/launcher/util/SystemPropertiesUtil.kt
@@ -4,8 +4,10 @@ import android.util.Log
 import org.koreader.launcher.extensions.forNameOrNull
 import java.lang.reflect.Method
 
+const val ANDROID_OS_SYS_PROP_CLASS_NAME = "android.os.SystemProperties"
+
 private val systemPropertiesClass: Class<*>? by lazy {
-    forNameOrNull("android.os.SystemProperties")
+    forNameOrNull(ANDROID_OS_SYS_PROP_CLASS_NAME)
 }
 
 private val systemPropertiesMethodSet: Method? by lazy {

--- a/app/src/main/java/org/koreader/launcher/util/SystemPropertiesUtil.kt
+++ b/app/src/main/java/org/koreader/launcher/util/SystemPropertiesUtil.kt
@@ -1,0 +1,42 @@
+package org.koreader.launcher.util
+
+import android.util.Log
+import org.koreader.launcher.extensions.forNameOrNull
+import java.lang.reflect.Method
+
+private val systemPropertiesClass: Class<*>? by lazy {
+    forNameOrNull("android.os.SystemProperties")
+}
+
+private val systemPropertiesMethodSet: Method? by lazy {
+    systemPropertiesClass
+        ?.getMethod("set", String::class.java, String::class.java)
+}
+
+private val systemPropertiesMethodGet: Method? by lazy {
+    systemPropertiesClass
+        ?.getMethod("get", String::class.java, String::class.java)
+}
+
+/**
+ * Sets the [value] for the [key] as a system property via reflection.
+ */
+fun setSystemProperty(key: String, value: String) {
+    try {
+        systemPropertiesMethodSet?.invoke(systemPropertiesClass, key, value)
+    } catch (e: Exception) {
+        Log.e("SystemPropertiesUtil", "setSystemProperty has failed!", e)
+    }
+}
+
+/**
+ * @return the system property value for the [key].
+ */
+fun getSystemProperty(key: String, default: String): String? {
+    try {
+        return systemPropertiesMethodGet?.invoke(systemPropertiesClass, key, default) as String
+    } catch (e: Exception) {
+        Log.e("SystemPropertiesUtil", "setSystemProperty has failed!", e)
+        return null
+    }
+}

--- a/app/src/main/java/org/koreader/launcher/util/SystemPropertiesUtil.kt
+++ b/app/src/main/java/org/koreader/launcher/util/SystemPropertiesUtil.kt
@@ -36,7 +36,7 @@ fun getSystemProperty(key: String, default: String): String? {
     try {
         return systemPropertiesMethodGet?.invoke(systemPropertiesClass, key, default) as String
     } catch (e: Exception) {
-        Log.e("SystemPropertiesUtil", "setSystemProperty has failed!", e)
+        Log.e("SystemPropertiesUtil", "getSystemProperty has failed!", e)
         return null
     }
 }


### PR DESCRIPTION
> [!NOTE]  
> Testing device:
> MANUFACTURER: inkbook
> BRAND       : rockchip
> MODEL       : focus plus
> DEVICE      : rk3566_eink
> PRODUCT     : r0782a
> HARDWARE    : rk30board

This PR adds a new light controller for the [`InkBOOK Focus Plus`](https://inkbook.eu/de/products/inkbook-focus-plus) e-reader, which is based on the `Rockchip3566` device. The generic (or any other existing) controller doesn't work for this model at all.

The light is controlled by two hardware LEDs called `leda` and `ledb`. The input for the led values needs to be computed based on the brightness and warmth. The computation function has been reverse engineered from the `inkBOOKSettings.apk`.

Controlling the light is done by writing to the "files" directly which works without root access. I also added a fallback by using reflection in case that the write/read should not be permitted on some other devices even though I think it's not that versatile as it relies on the existence of a specific class.

I tried to mimic the behavior of the system app as good as possible, i.e. as soon as a new value is set, the value is also persisted in the corresponding system property:
- `brightness`: `persist.inkbook.frontlight.brightness`
- `warmth`: `persist.inkbook.frontlight.temperature`
- `leda`: `persist.yitoa.backlight.leda.brightness`
- `ledb`: `persist.yitoa.backlight.ledb.brightness`

And finally, a broadcast action `com.android.systemui.statusbar.action.light_change` is sent out so that the systemUI app bar updates the light icon. However, the light handlers in the inkBOOK related .apks are not listening to that broadcast action, they only send it out in case something changes. 
Furthermore, they also cache their last known brightness in the RAM, so when the koreader manipulates some light settings, then the inkBOOK apps are unaware of that, resulting in an unsynced state.
___
This section just contains details about the device specific APKs and light handling.

I started my investigations by reverse engineering the following system apks to find out how the light is being controlled:
- `/system_ext/priv-app/SystemUI_inkBook/SystemUI_inkBook.apk` - the system UI which e.g. displays the status bar. 
- `/odm/bundled_persist-app/inkBook3566Setting/inkBook3566Setting.apk` an app that mainly is responsible for displaying context menus for the status bar. it listens to broadcast receiver actions from the status bar:
   - click on light icon --> listens to the action, but does nothing.
   - long click on light icon --> starts `LightActivity` of the `inkBOOKSettings.apk` where the user can set the brightness and temperature with UI sliders.
- `/odm/bundled_persist-app/inkBOOKSettings/inkBOOKSettings.apk` - the main settings app, which also listens to broadcast receiver actions from the status bar.
   - this apk uses `android.yitoa.rk3566.SysUtil` from the platform's `framework.jar` to control the light. That util class provides methods to write to the leda/ledb files.
- `lightProvider.apk` (a provider which seems to handle the light as well but it's not exposed, so I guess it's just dead code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/573)
<!-- Reviewable:end -->
