### PR TITLE
Add alias for rebranded Onyx C67 (Noblex ER6A02)

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -361,6 +361,12 @@ object DeviceInfo {
             && DEVICE.startsWith("c67")
             -> Id.ONYX_C67
 
+            // Noblex ER6A02 (Rebranded Onyx C67)
+            MANUFACTURER == "onyx"
+            && PRODUCT == "er6a02"
+            && DEVICE == "er6a02"
+            -> Id.ONYX_C67
+
             // ONYX DARWIN 7
             MANUFACTURER == "onyx"
             && (PRODUCT == "mc_darwin7" || PRODUCT == "darwin7")


### PR DESCRIPTION
Added a pattern match to point the OEM rebranded model number to the ONYX_C67 ID

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/574)
<!-- Reviewable:end -->
