### PR TITLE
feat(tts): expose Android TextToSpeech bridge to Lua

### DIFF
--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -81,4 +81,15 @@ interface LuaInterface {
     fun startTestActivity()
     fun showFrontlightDialog(title: String, dim: String, warmth: String, okButton: String, cancelButton: String)
     fun showToast(message: String, longTimeout: Boolean)
+
+    // TTS Methods
+    fun ttsInit(): Boolean
+    fun ttsSpeak(text: String, queueMode: Int): Boolean
+    fun ttsStop(): Boolean
+    fun ttsIsSpeaking(): Boolean
+    fun ttsSetSpeechRate(ratePercent: Int): Boolean
+    fun ttsSetPitch(pitchPercent: Int): Boolean
+    fun ttsSetLanguage(localeTag: String): Int
+    fun ttsOpenSettings()
+    fun ttsInstallData()
 }

--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -89,7 +89,6 @@ interface LuaInterface {
     fun ttsIsSpeaking(): Boolean
     fun ttsSetSpeechRate(ratePercent: Int): Boolean
     fun ttsSetPitch(pitchPercent: Int): Boolean
-    fun ttsSetLanguage(localeTag: String): Int
     fun ttsOpenSettings()
     fun ttsInstallData()
 }

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -15,6 +15,7 @@ import android.graphics.PixelFormat
 import android.net.Uri
 import android.os.*
 import android.provider.Settings
+import android.speech.tts.TextToSpeech
 import android.util.Log
 import android.view.*
 import android.widget.Toast
@@ -756,12 +757,23 @@ class MainActivity : NativeActivity(), LuaInterface,
 
     override fun ttsInit(): Boolean = ttsEngine.ttsInit()
     override fun ttsSpeak(text: String, queueMode: Int): Boolean = ttsEngine.ttsSpeak(text, queueMode)
-    override fun ttsStop(): Boolean = ttsEngine.ttsStop()
+    override fun ttsStop(): Boolean = ttsEngine.withReadyTts { it.stop() }
     override fun ttsIsSpeaking(): Boolean = ttsEngine.ttsIsSpeaking()
-    override fun ttsSetSpeechRate(ratePercent: Int): Boolean = ttsEngine.ttsSetSpeechRate(ratePercent)
-    override fun ttsSetPitch(pitchPercent: Int): Boolean = ttsEngine.ttsSetPitch(pitchPercent)
-    override fun ttsOpenSettings() = ttsEngine.ttsOpenSettings()
-    override fun ttsInstallData() = ttsEngine.ttsInstallData()
+    override fun ttsSetSpeechRate(ratePercent: Int): Boolean {
+        val rate = (ratePercent / 100.0f).coerceIn(0.1f, 4.0f)
+        return ttsEngine.withReadyTts { it.setSpeechRate(rate) }
+    }
+    override fun ttsSetPitch(pitchPercent: Int): Boolean {
+        val pitch = (pitchPercent / 100.0f).coerceIn(0.1f, 4.0f)
+        return ttsEngine.withReadyTts { it.setPitch(pitch) }
+    }
+    override fun ttsOpenSettings() {
+        // There is no public Settings action constant for TTS settings across all API levels.
+        ttsEngine.startActivitySafe("com.android.settings.TTS_SETTINGS", "Failed to open TTS settings")
+    }
+    override fun ttsInstallData() {
+        ttsEngine.startActivitySafe(TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA, "Failed to install TTS data")
+    }
 
     /*---------------------------------------------------------------
      *                       private methods                        *

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -254,7 +254,7 @@ class MainActivity : NativeActivity(), LuaInterface,
     /* Called when the activity is going to be destroyed */
     public override fun onDestroy() {
         Log.v(tag, "onDestroy()")
-        ttsEngine.onDestroy()
+        ttsEngine.shutdown()
         unregisterReceiver(event)
         super.onDestroy()
     }

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -16,7 +16,6 @@ import android.net.Uri
 import android.os.*
 import android.provider.Settings
 import android.util.Log
-
 import android.view.*
 import android.widget.Toast
 import androidx.annotation.RequiresApi
@@ -57,7 +56,6 @@ class MainActivity : NativeActivity(), LuaInterface,
 
     // TTS (Text-to-Speech)
     private lateinit var ttsEngine: TTSEngine
-
 
     // surface used on devices that need a view
     private var view: NativeSurfaceView? = null
@@ -115,7 +113,6 @@ class MainActivity : NativeActivity(), LuaInterface,
         updater = ApkUpdater()
         lightDialog = LightDialog()
         ttsEngine = TTSEngine(this)
-
 
         setTheme(R.style.Fullscreen)
 
@@ -260,7 +257,6 @@ class MainActivity : NativeActivity(), LuaInterface,
         unregisterReceiver(event)
         super.onDestroy()
     }
-
 
     /*---------------------------------------------------------------
      *                         native callbacks                     *

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -763,7 +763,6 @@ class MainActivity : NativeActivity(), LuaInterface,
     override fun ttsOpenSettings() = ttsEngine.ttsOpenSettings()
     override fun ttsInstallData() = ttsEngine.ttsInstallData()
 
-
     /*---------------------------------------------------------------
      *                       private methods                        *
      *--------------------------------------------------------------*/

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -1000,7 +1000,9 @@ class MainActivity : NativeActivity(), LuaInterface,
         runOnUiThread {
             try {
                 val intent = Intent()
-                intent.action = TextToSpeech.Engine.ACTION_TTS_SETTINGS
+                // There is no public Settings action constant for TTS settings across all API levels.
+                // This is the widely used Settings action string, with a safe fallback.
+                intent.action = "com.android.settings.TTS_SETTINGS"
                 if (intent.resolveActivity(packageManager) == null) {
                     intent.action = android.provider.Settings.ACTION_SETTINGS
                 }

--- a/app/src/main/java/org/koreader/launcher/TTSEngine.kt
+++ b/app/src/main/java/org/koreader/launcher/TTSEngine.kt
@@ -18,11 +18,11 @@ class TTSEngine(private val activity: Activity) {
         }
 
         activity.runOnUiThread {
-            ttsShutdownInternal()
+            shutdown()
             tts = TextToSpeech(activity) { status ->
                 ttsInitialized = status == TextToSpeech.SUCCESS
                 if (!ttsInitialized) {
-                    ttsShutdownInternal()
+                    shutdown()
                 }
             }
         }
@@ -45,11 +45,7 @@ class TTSEngine(private val activity: Activity) {
 
     fun ttsIsSpeaking(): Boolean = tts?.isSpeaking == true
 
-    fun onDestroy() {
-        ttsShutdownInternal()
-    }
-
-    private fun ttsShutdownInternal() {
+    fun shutdown() {
         try {
             tts?.stop()
             tts?.shutdown()
@@ -68,11 +64,7 @@ class TTSEngine(private val activity: Activity) {
         }
 
         activity.runOnUiThread {
-            try {
-                action(ttsInstance)
-            } catch (e: Exception) {
-                Log.e(tag, "TTS operation failed", e)
-            }
+            action(ttsInstance)
         }
 
         return true

--- a/app/src/main/java/org/koreader/launcher/TTSEngine.kt
+++ b/app/src/main/java/org/koreader/launcher/TTSEngine.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.speech.tts.TextToSpeech
 import android.util.Log
 import java.util.HashMap
-import java.util.Locale
 
 class TTSEngine(private val activity: Activity) {
     private val tag = this::class.java.simpleName

--- a/app/src/main/java/org/koreader/launcher/TTSEngine.kt
+++ b/app/src/main/java/org/koreader/launcher/TTSEngine.kt
@@ -43,34 +43,7 @@ class TTSEngine(private val activity: Activity) {
         }
     }
 
-    fun ttsStop(): Boolean = withReadyTts {
-            it.stop()
-    }
-
     fun ttsIsSpeaking(): Boolean = tts?.isSpeaking == true
-
-    fun ttsSetSpeechRate(ratePercent: Int): Boolean {
-        val rate = (ratePercent / 100.0f).coerceIn(0.1f, 4.0f)
-        return withReadyTts {
-            it.setSpeechRate(rate)
-        }
-    }
-
-    fun ttsSetPitch(pitchPercent: Int): Boolean {
-        val pitch = (pitchPercent / 100.0f).coerceIn(0.1f, 4.0f)
-        return withReadyTts {
-            it.setPitch(pitch)
-        }
-    }
-
-    fun ttsOpenSettings() {
-        // There is no public Settings action constant for TTS settings across all API levels.
-        startActivitySafe("com.android.settings.TTS_SETTINGS", "Failed to open TTS settings")
-    }
-
-    fun ttsInstallData() {
-        startActivitySafe(TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA, "Failed to install TTS data")
-    }
 
     fun onDestroy() {
         ttsShutdownInternal()
@@ -88,7 +61,7 @@ class TTSEngine(private val activity: Activity) {
         }
     }
 
-    private inline fun withReadyTts(crossinline action: (TextToSpeech) -> Unit): Boolean {
+    fun withReadyTts(action: (TextToSpeech) -> Unit): Boolean {
         val ttsInstance = tts
         if (!ttsInitialized || ttsInstance == null) {
             return false
@@ -105,7 +78,7 @@ class TTSEngine(private val activity: Activity) {
         return true
     }
 
-    private fun startActivitySafe(action: String, errorMessage: String) {
+    fun startActivitySafe(action: String, errorMessage: String) {
         activity.runOnUiThread {
             try {
                 activity.startActivity(Intent(action))

--- a/app/src/main/java/org/koreader/launcher/TTSEngine.kt
+++ b/app/src/main/java/org/koreader/launcher/TTSEngine.kt
@@ -1,0 +1,153 @@
+package org.koreader.launcher
+
+import android.app.Activity
+import android.content.Intent
+import android.speech.tts.TextToSpeech
+import android.util.Log
+import java.util.HashMap
+import java.util.Locale
+
+class TTSEngine(private val activity: Activity) {
+    private val tag = this::class.java.simpleName
+
+    @Volatile
+    private var tts: TextToSpeech? = null
+    @Volatile
+    private var ttsInitialized = false
+    private val ttsLock = Object()
+
+    fun ttsInit(): Boolean {
+        synchronized(ttsLock) {
+            if (tts != null) {
+                return true
+            }
+        }
+
+        runOnUiThreadSafe("TTS init") {
+            ttsShutdownInternal()
+            tts = TextToSpeech(activity) { status ->
+                val success = status == TextToSpeech.SUCCESS
+                synchronized(ttsLock) {
+                    ttsInitialized = success
+                }
+                if (!success) {
+                    ttsShutdownInternal()
+                }
+            }
+        }
+
+        return true
+    }
+
+    fun ttsSpeak(text: String, queueMode: Int): Boolean {
+        if (!ttsInitialized || tts == null) {
+            ttsInit()
+            return false
+        }
+
+        runOnUiThreadSafe("TTS speak") {
+            ttsSpeakInternal(tts!!, text, queueMode)
+        }
+        return true
+    }
+
+    fun ttsStop(): Boolean {
+        return withReadyTtsOnUiThread("TTS stop") {
+            it.stop()
+        }
+    }
+
+    fun ttsIsSpeaking(): Boolean {
+        return tts?.isSpeaking == true
+    }
+
+    fun ttsSetSpeechRate(ratePercent: Int): Boolean {
+        val rate = (ratePercent / 100.0f).coerceIn(0.1f, 4.0f)
+        return withReadyTtsOnUiThread("TTS setSpeechRate") {
+            it.setSpeechRate(rate)
+        }
+    }
+
+    fun ttsSetPitch(pitchPercent: Int): Boolean {
+        val pitch = (pitchPercent / 100.0f).coerceIn(0.1f, 4.0f)
+        return withReadyTtsOnUiThread("TTS setPitch") {
+            it.setPitch(pitch)
+        }
+    }
+
+    fun ttsOpenSettings() {
+        runOnUiThreadSafe("TTS openSettings") {
+            val intent = Intent()
+            // There is no public Settings action constant for TTS settings across all API levels.
+            // This is the widely used Settings action string.
+            intent.action = "com.android.settings.TTS_SETTINGS"
+            try {
+                activity.startActivity(intent)
+            } catch (e: Exception) {
+                Log.e(tag, "Failed to open TTS settings", e)
+            }
+        }
+    }
+
+    fun ttsInstallData() {
+        runOnUiThreadSafe("TTS installData") {
+            val intent = Intent()
+            intent.action = TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA
+            try {
+                activity.startActivity(intent)
+            } catch (e: Exception) {
+                Log.e(tag, "Failed to install TTS data", e)
+            }
+        }
+    }
+
+    fun onStop() {
+         // Optionally handle lifecycle here if needed, but MainActivity calls ttsShutdownInternal in onDestroy
+    }
+
+    fun onDestroy() {
+        ttsShutdownInternal()
+    }
+
+    private fun ttsShutdownInternal() {
+        synchronized(ttsLock) {
+            try {
+                tts?.stop()
+                tts?.shutdown()
+            } catch (e: Exception) {
+                Log.e(tag, "TTS shutdown failed", e)
+            } finally {
+                tts = null
+                ttsInitialized = false
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun ttsSpeakInternal(ttsInstance: TextToSpeech, text: String, queueMode: Int): Int {
+        val params = HashMap<String, String>()
+        params[TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID] = "utteranceId"
+        return ttsInstance.speak(text, queueMode, params)
+    }
+
+    private fun runOnUiThreadSafe(what: String, action: () -> Unit) {
+        activity.runOnUiThread {
+            try {
+                action()
+            } catch (e: Exception) {
+                Log.e(tag, "$what failed", e)
+            }
+        }
+    }
+
+    private inline fun withReadyTtsOnUiThread(what: String, crossinline action: (TextToSpeech) -> Unit): Boolean {
+        val ttsInstance = tts
+        if (!ttsInitialized || ttsInstance == null) {
+            return false
+        }
+        runOnUiThreadSafe(what) {
+            action(ttsInstance)
+        }
+        return true
+    }
+}

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2596,6 +2596,196 @@ local function run(android_app_state)
         end)
     end
 
+    --[[--
+    TTS (Text-to-Speech) namespace
+    Exposes Android TextToSpeech framework to Lua
+    --]]
+    android.tts = {}
+
+    -- TextToSpeech queue modes
+    android.tts.QUEUE_FLUSH = 0  -- Interrupts current speech, flushes queue
+    android.tts.QUEUE_ADD = 1    -- Adds to end of queue
+
+    -- TextToSpeech LANG_* return codes
+    android.tts.LANG_MISSING_DATA = -1
+    android.tts.LANG_NOT_SUPPORTED = -2
+    android.tts.LANG_AVAILABLE = 0
+    android.tts.LANG_COUNTRY_AVAILABLE = 1
+    android.tts.LANG_COUNTRY_VAR_AVAILABLE = 2
+
+    --[[
+        Initialize the TTS engine.
+        Must be called before other TTS operations.
+        Idempotent - safe to call multiple times.
+        Returns: boolean - true if initialized successfully
+    --]]
+    android.tts.init = function()
+        return JNI:context(android.app.activity.vm, function(jni)
+            return jni:callBooleanMethod(
+                android.app.activity.clazz,
+                "ttsInit",
+                "()Z"
+            )
+        end)
+    end
+
+    --[[
+        Speak text.
+        Parameters:
+            text - string to speak
+            queueMode - android.tts.QUEUE_FLUSH or android.tts.QUEUE_ADD
+        Returns: boolean - true if queued successfully
+    --]]
+    android.tts.speak = function(text, queueMode)
+        queueMode = queueMode or android.tts.QUEUE_FLUSH
+        return JNI:context(android.app.activity.vm, function(jni)
+            local jtext = jni.env[0].NewStringUTF(jni.env, text)
+            local ok = jni:callBooleanMethod(
+                android.app.activity.clazz,
+                "ttsSpeak",
+                "(Ljava/lang/String;I)Z",
+                jtext,
+                ffi.new("int32_t", queueMode)
+            )
+            jni.env[0].DeleteLocalRef(jni.env, jtext)
+            return ok
+        end)
+    end
+
+    --[[
+        Stop speaking.
+        Clears the speech queue and stops current utterance.
+        Returns: boolean - true if stopped successfully
+    --]]
+    android.tts.stop = function()
+        return JNI:context(android.app.activity.vm, function(jni)
+            return jni:callBooleanMethod(
+                android.app.activity.clazz,
+                "ttsStop",
+                "()Z"
+            )
+        end)
+    end
+
+    --[[
+        Check if TTS is currently speaking.
+        Returns: boolean - true if speaking
+    --]]
+    android.tts.isSpeaking = function()
+        return JNI:context(android.app.activity.vm, function(jni)
+            return jni:callBooleanMethod(
+                android.app.activity.clazz,
+                "ttsIsSpeaking",
+                "()Z"
+            )
+        end)
+    end
+
+    --[[
+        Set speech rate.
+        Parameters:
+            ratePercent - integer 50..200 (maps to 0.5x..2.0x speed)
+                          100 = normal speed
+        Returns: boolean - true if set successfully
+    --]]
+    android.tts.setSpeechRate = function(ratePercent)
+        return JNI:context(android.app.activity.vm, function(jni)
+            return jni:callBooleanMethod(
+                android.app.activity.clazz,
+                "ttsSetSpeechRate",
+                "(I)Z",
+                ffi.new("int32_t", ratePercent)
+            )
+        end)
+    end
+
+    --[[
+        Set pitch.
+        Parameters:
+            pitchPercent - integer 50..200 (maps to 0.5x..2.0x pitch)
+                           100 = normal pitch
+        Returns: boolean - true if set successfully
+    --]]
+    android.tts.setPitch = function(pitchPercent)
+        return JNI:context(android.app.activity.vm, function(jni)
+            return jni:callBooleanMethod(
+                android.app.activity.clazz,
+                "ttsSetPitch",
+                "(I)Z",
+                ffi.new("int32_t", pitchPercent)
+            )
+        end)
+    end
+
+    --[[
+        Set language/locale.
+        Parameters:
+            localeTag - string locale tag (e.g., "en-US", "ja-JP", "vi-VN")
+        Returns: integer - one of:
+            android.tts.LANG_MISSING_DATA (-1) - Language data missing
+            android.tts.LANG_NOT_SUPPORTED (-2) - Language not supported
+            android.tts.LANG_AVAILABLE (0) - Language available
+            android.tts.LANG_COUNTRY_AVAILABLE (1) - Language + country available
+            android.tts.LANG_COUNTRY_VAR_AVAILABLE (2) - Language + country + variant available
+            -1 on error
+    --]]
+    android.tts.setLanguage = function(localeTag)
+        return JNI:context(android.app.activity.vm, function(jni)
+            local jtag = jni.env[0].NewStringUTF(jni.env, localeTag)
+            local result = jni:callIntMethod(
+                android.app.activity.clazz,
+                "ttsSetLanguage",
+                "(Ljava/lang/String;)I",
+                jtag
+            )
+            jni.env[0].DeleteLocalRef(jni.env, jtag)
+            return result
+        end)
+    end
+
+    --[[
+        Open TTS system settings.
+        Launches the Android TTS settings activity.
+    --]]
+    android.tts.openSettings = function()
+        JNI:context(android.app.activity.vm, function(jni)
+            jni:callVoidMethod(
+                android.app.activity.clazz,
+                "ttsOpenSettings",
+                "()V"
+            )
+        end)
+    end
+
+    --[[
+        Install TTS data.
+        Launches the system activity to download/install TTS voice data.
+    --]]
+    android.tts.installData = function()
+        JNI:context(android.app.activity.vm, function(jni)
+            jni:callVoidMethod(
+                android.app.activity.clazz,
+                "ttsInstallData",
+                "()V"
+            )
+        end)
+    end
+
+    --[[
+        Convenience function: Speak text with automatic initialization.
+        Initializes TTS if not already done, then speaks.
+        Parameters:
+            text - string to speak
+            queueMode - optional, defaults to QUEUE_FLUSH
+        Returns: boolean - true if successful
+    --]]
+    android.tts.say = function(text, queueMode)
+        if not android.tts.init() then
+            return false
+        end
+        return android.tts.speak(text, queueMode)
+    end
+
     android.getStatusBarHeight = function()
         return JNI:context(android.app.activity.vm, function(jni)
             return jni:callIntMethod(

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2606,13 +2606,6 @@ local function run(android_app_state)
     android.tts.QUEUE_FLUSH = 0  -- Interrupts current speech, flushes queue
     android.tts.QUEUE_ADD = 1    -- Adds to end of queue
 
-    -- TextToSpeech LANG_* return codes
-    android.tts.LANG_MISSING_DATA = -1
-    android.tts.LANG_NOT_SUPPORTED = -2
-    android.tts.LANG_AVAILABLE = 0
-    android.tts.LANG_COUNTRY_AVAILABLE = 1
-    android.tts.LANG_COUNTRY_VAR_AVAILABLE = 2
-
     --[[
         Initialize the TTS engine.
         Must be called before other TTS operations.
@@ -2714,32 +2707,6 @@ local function run(android_app_state)
                 "(I)Z",
                 ffi.new("int32_t", pitchPercent)
             )
-        end)
-    end
-
-    --[[
-        Set language/locale.
-        Parameters:
-            localeTag - string locale tag (e.g., "en-US", "ja-JP", "vi-VN")
-        Returns: integer - one of:
-            android.tts.LANG_MISSING_DATA (-1) - Language data missing
-            android.tts.LANG_NOT_SUPPORTED (-2) - Language not supported
-            android.tts.LANG_AVAILABLE (0) - Language available
-            android.tts.LANG_COUNTRY_AVAILABLE (1) - Language + country available
-            android.tts.LANG_COUNTRY_VAR_AVAILABLE (2) - Language + country + variant available
-            -1 on error
-    --]]
-    android.tts.setLanguage = function(localeTag)
-        return JNI:context(android.app.activity.vm, function(jni)
-            local jtag = jni.env[0].NewStringUTF(jni.env, localeTag)
-            local result = jni:callIntMethod(
-                android.app.activity.clazz,
-                "ttsSetLanguage",
-                "(Ljava/lang/String;)I",
-                jtag
-            )
-            jni.env[0].DeleteLocalRef(jni.env, jtag)
-            return result
         end)
     end
 


### PR DESCRIPTION
## Summary
This PR adds an Android TextToSpeech (TTS) bridge to the launcher, exposing the system TTS framework to Lua via a new `android.tts` namespace. This enables KOReader-side plugins to implement “Read Aloud” using the user’s configured system TTS engine (Google/Samsung/…).

## API exposed to Lua
`assets/android.lua` now provides:
- `android.tts.init()` -> `boolean` (requests initialization; initialization completes asynchronously)
- `android.tts.speak(text, queueMode)` -> `boolean` (returns `false` if the engine is not ready yet)
- `android.tts.stop()` -> `boolean`
- `android.tts.isSpeaking()` -> `boolean`
- `android.tts.setSpeechRate(ratePercent)` -> `boolean` (e.g. 50..200)
- `android.tts.setPitch(pitchPercent)` -> `boolean` (e.g. 50..200)
- `android.tts.openSettings()` -> `void`
- `android.tts.installData()` -> `void`
- `android.tts.say(text, queueMode)` convenience wrapper

Constants:
- `android.tts.QUEUE_FLUSH = 0`
- `android.tts.QUEUE_ADD = 1`

## Implementation Details
- `app/src/main/java/org/koreader/launcher/LuaInterface.kt`
  - Adds `tts*` methods to the Lua/JNI interface.
- `app/src/main/java/org/koreader/launcher/MainActivity.kt`
  - Implements the `tts*` methods.
  - Stores a `TextToSpeech` instance and a readiness flag (`ttsInitialized`).
  - Executes TTS calls on the UI thread via `runOnUiThread` (except for `isSpeaking`, which is best-effort).
  - Cleans up on `onDestroy()` via `ttsShutdownInternal()`.
- `assets/android.lua`
  - Adds the `android.tts` namespace and ensures JNI varargs type-safety by casting ints with `ffi.new("int32_t", ...)`.

## Testing
- Codacy: PASS.
- Note: GitHub Actions build workflow for this PR is **awaiting maintainer approval** because it comes from a fork.
- Manual verification steps:
  1. Build and install KOReader for Android.
  2. From Lua (or a plugin), call `android.tts.init()` and retry `android.tts.say("hello")` until it returns `true`.
  3. Verify `android.tts.stop()` and `android.tts.isSpeaking()`.
  4. Verify `android.tts.openSettings()` and `android.tts.installData()`.

## Limitations
- No ForegroundService/notification controls (kept out of scope for this MVP bridge).
- Requires an installed system TTS engine and voice data for the desired language.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/578)
<!-- Reviewable:end -->
