### PR TITLE
Fix Onyx Boox black screen on wake by not using SurfaceView

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/epd/OnyxEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/OnyxEPDController.kt
@@ -48,7 +48,7 @@ class OnyxEPDController : QualcommEPDController(), EPDInterface {
     }
 
     override fun needsView(): Boolean {
-        return true
+        return false
     }
 
     override fun setEpdMode(targetView: android.view.View,


### PR DESCRIPTION
On some Onyx Boox devices (confirmed on Palma 2), the SurfaceView surface is not recreated after the rapid RESUME/PAUSE/STOP activity cycling that the Boox system performs on wake. This leaves `android.app.window` permanently nil, causing a black screen. The app is still running and responding to touch; it just can't render because `ANativeWindow_lock` has no window to lock.

The SurfaceView with `setZOrderOnTop(true)` and `PixelFormat.TRANSPARENT` was introduced for NGL4/Tolino devices. The Onyx Qualcomm EPD API (`View.refreshScreen`) does not require a SurfaceView; when `needsView` is false, `einkUpdate()` already falls back to the DecorView content view. Setting `needsView()=false` makes Onyx devices use NativeActivity's default DecorView surface, which follows the standard activity lifecycle and correctly survives the Boox wake sequence.

This fixes koreader/koreader#12445.

## Diagnostics that led to this fix

Lifecycle event logging on the Boox Palma 2 revealed that after sleep/wake, `INIT_WINDOW` never fires when using a SurfaceView:

1. PAUSE → TERM_WINDOW(nil) → STOP → LOST_FOCUS
2. START → RESUME → PAUSE → RESUME → PAUSE → STOP → START → RESUME → GAINED_FOCUS(nil)

With `needsView()=false` (DecorView surface), `INIT_WINDOW` fires correctly:

1. PAUSE → TERM_WINDOW(nil) → STOP → LOST_FOCUS
2. START → RESUME → PAUSE → RESUME → INIT_WINDOW(valid) → PAUSE → TERM_WINDOW(nil) → STOP → START → RESUME → INIT_WINDOW(valid) → GAINED_FOCUS(valid)

## Test on Boox Palma 2

See https://github.com/koreader/koreader/issues/12445#issuecomment-3591874526 for the reproduction steps.

* Before this fix: font size change → sleep → wake causes black screen
* After this fix:  font size change → sleep → wake no longer causes black screen

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/579)
<!-- Reviewable:end -->
