### PR TITLE
EventReceiver: use Unix domain sockets with socketpair() instead of mkfifo()

### DIFF
--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -91,6 +91,8 @@ class MainActivity : NativeActivity(), LuaInterface,
     }
 
     init {
+        Log.i(tag, "loading libluajit-launcher")
+        System.loadLibrary("luajit-launcher")
         Log.i(tag, "loading libluajit")
         System.loadLibrary("luajit")
     }


### PR DESCRIPTION
This is extremely similar to the approach described in <https://github.com/koreader/koreader/discussions/14358#discussioncomment-14500895>.

Without this change events like android.intent.action.ACTION_POWER_CONNECTED don't reach the frontend, but I'm primarily interested in TEXT_INPUT from the IME/onscreen-keyboard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/580)
<!-- Reviewable:end -->
