### PR TITLE
Fix Crema Soundup menu flickering due to unsupported GLR16 waveform

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -4,6 +4,7 @@
 package org.koreader.launcher.device
 
 import android.util.Log
+import org.koreader.launcher.device.epd.CremaEPDController
 import org.koreader.launcher.device.epd.NookEPDController
 import org.koreader.launcher.device.epd.TolinoEPDController
 import org.koreader.launcher.device.epd.RK3026EPDController
@@ -77,7 +78,6 @@ object EPDFactory {
                 }
 
                 DeviceInfo.Id.CREMA,
-                DeviceInfo.Id.CREMA_0660L,
                 DeviceInfo.Id.CREMA_CARTA_G,
                 DeviceInfo.Id.HANVON_960,
                 DeviceInfo.Id.ONYX_JDREAD,
@@ -92,6 +92,12 @@ object EPDFactory {
                 -> {
                     logController("Tolino/NTX")
                     TolinoEPDController()
+                }
+
+                DeviceInfo.Id.CREMA_0660L,
+                -> {
+                    logController("Crema/NTX")
+                    CremaEPDController()
                 }
 
                 DeviceInfo.Id.ONYX_DARWIN5,

--- a/app/src/main/java/org/koreader/launcher/device/epd/CremaEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/CremaEPDController.kt
@@ -1,0 +1,63 @@
+/* Crema e-ink devices (NTX-based, GC16 for UI instead of GLR16) */
+
+package org.koreader.launcher.device.epd
+
+import org.koreader.launcher.device.EPDInterface
+import org.koreader.launcher.device.epd.freescale.NTXEPDController
+
+class CremaEPDController : NTXEPDController(), EPDInterface {
+
+    override fun getPlatform(): String {
+        return "freescale"
+    }
+
+    override fun getMode(): String {
+        return "all"
+    }
+
+    override fun getWaveformFull(): Int {
+       return EINK_WAVEFORM_UPDATE_FULL + EINK_WAVEFORM_MODE_GC16
+    }
+
+    override fun getWaveformPartial(): Int {
+        return EINK_WAVEFORM_UPDATE_PARTIAL + EINK_WAVEFORM_MODE_GC16
+    }
+
+    override fun getWaveformFullUi(): Int {
+        return EINK_WAVEFORM_UPDATE_FULL + EINK_WAVEFORM_MODE_GC16
+    }
+
+    override fun getWaveformPartialUi(): Int {
+        return EINK_WAVEFORM_UPDATE_PARTIAL + EINK_WAVEFORM_MODE_GC16
+    }
+
+    override fun getWaveformFast(): Int {
+        return EINK_WAVEFORM_UPDATE_PARTIAL + EINK_WAVEFORM_MODE_DU
+    }
+
+    override fun getWaveformDelay(): Int {
+        return EINK_WAVEFORM_DELAY
+    }
+
+    override fun getWaveformDelayUi(): Int {
+        return EINK_WAVEFORM_DELAY
+    }
+
+    override fun getWaveformDelayFast(): Int {
+        return EINK_WAVEFORM_DELAY
+    }
+
+    override fun needsView(): Boolean {
+        return true
+    }
+
+    override fun setEpdMode(targetView: android.view.View,
+                            mode: Int, delay: Long,
+                            x: Int, y: Int, width: Int, height: Int, epdMode: String?)
+    {
+        requestEpdMode(targetView, mode, delay, x, y, width, height)
+    }
+
+    override fun resume() {}
+    override fun pause() {}
+}


### PR DESCRIPTION
The Crema Soundup was grouped with Tolino devices and used `TolinoEPDController`, which uses the GLR16 waveform for UI refreshes. The Crema Soundup firmware does not properly support GLR16, causing menu popups to flicker and turn white.

`CremaEPDController` in this PR is identical to `TolinoEPDController` except it uses GC16 for UI waveforms (`getWaveformFullUi` and `getWaveformPartialUi`). All other settings remain the same.

This change is needed for koreader/koreader#15008.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/582)
<!-- Reviewable:end -->
