### PR TITLE
Add support for ONYX_GO7 device ID

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -100,6 +100,7 @@ object EPDFactory {
                 DeviceInfo.Id.ONYX_GALILEO2,
                 DeviceInfo.Id.ONYX_GO_103,
                 DeviceInfo.Id.ONYX_GO6,
+                DeviceInfo.Id.ONYX_GO7,
                 DeviceInfo.Id.ONYX_GO7GEN2,
                 DeviceInfo.Id.ONYX_KON_TIKI2,
                 DeviceInfo.Id.ONYX_LEAF,


### PR DESCRIPTION
After the fix here https://github.com/koreader/android-luajit-launcher/pull/579
we can safely re-add Onyx-go7 EPDFFactory again.

Device info
Manufacturer: onyx
Brand: onyx
Model: go7
Device: go7
Hardware: qcom
Platform: lito

### Tested : 
font size change → sleep → wake : no black screen
### Driver used
<img width="1264" height="1680" alt="image" src="https://github.com/user-attachments/assets/98f7760a-13c2-4f4b-bd22-737c4c80ec2f" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/584)
<!-- Reviewable:end -->
