### PR TITLE
Add Mobiscribe Wave device support with broken touch report quirk

### DIFF
--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -44,6 +44,7 @@ interface LuaInterface {
     fun getStatusBarHeight(): Int
     fun getVersion(): String
     fun hasBrokenLifecycle(): Boolean
+    fun hasBrokenTouchReport(): Boolean
     fun hasClipboardText(): Boolean
     fun hasLights(): Boolean
     fun hasNativeRotation(): Boolean

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -520,6 +520,10 @@ class MainActivity : NativeActivity(), LuaInterface,
         return device.bugLifecycle
     }
 
+    override fun hasBrokenTouchReport(): Boolean {
+        return device.brokenTouchReport
+    }
+
     override fun hasClipboardText(): Boolean {
         val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         return clipboard.primaryClip?.let {

--- a/app/src/main/java/org/koreader/launcher/device/Device.kt
+++ b/app/src/main/java/org/koreader/launcher/device/Device.kt
@@ -9,6 +9,7 @@ class Device(activity: Activity) {
 
     @Suppress("unused")
     val product = DeviceInfo.PRODUCT
+    val brokenTouchReport = DeviceInfo.QUIRK_BROKEN_TOUCH_REPORT
     val needsWakelocks = DeviceInfo.QUIRK_NEEDS_WAKELOCKS
     val bugLifecycle = DeviceInfo.QUIRK_BROKEN_LIFECYCLE
     val hasColorScreen = DeviceInfo.HAS_COLOR_SCREEN

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -28,6 +28,7 @@ object DeviceInfo {
 
     // known quirks
     val QUIRK_BROKEN_LIFECYCLE: Boolean
+    val QUIRK_BROKEN_TOUCH_REPORT: Boolean
     val QUIRK_NEEDS_WAKELOCKS: Boolean
     val QUIRK_NO_LIGHTS: Boolean
 
@@ -73,6 +74,7 @@ object DeviceInfo {
         MEEBOOK_M6C,
         MEEBOOK_M7,
         MEEBOOK_P6,
+        MOBISCRIBE_WAVE,
         MOAAN_MIX7,
         MOOINKPLUS2C,
         NABUK,
@@ -345,6 +347,10 @@ object DeviceInfo {
             // Meebook P6
             MANUFACTURER == "haoqing" && MODEL == "p6"
             -> Id.MEEBOOK_P6
+
+            // Mobiscribe Wave
+            BRAND == "allwinner" && MODEL == "wave" && DEVICE == "e70p24_android"
+            -> Id.MOBISCRIBE_WAVE
 
             // Moaan Mix7
             MANUFACTURER == STR_ROCKCHIP && MODEL == "moaanmix7"
@@ -698,6 +704,12 @@ object DeviceInfo {
         // has broken lifecycle
         QUIRK_BROKEN_LIFECYCLE = when (ID) {
             Id.ONYX_POKE2,
+            -> true else -> false
+        }
+
+        // reports ACONFIGURATION_TOUCHSCREEN_NOTOUCH despite having a touchscreen
+        QUIRK_BROKEN_TOUCH_REPORT = when (ID) {
+            Id.MOBISCRIBE_WAVE,
             -> true else -> false
         }
 

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -1926,6 +1926,16 @@ local function run(android_app_state)
         end)
     end
 
+    android.hasBrokenTouchReport = function()
+        return JNI:context(android.app.activity.vm, function(jni)
+            return jni:callBooleanMethod(
+                android.app.activity.clazz,
+                "hasBrokenTouchReport",
+                "()Z"
+            )
+        end)
+    end
+
     android.setHapticOverride = function(enable)
         android.hapticOverride = enable or false
     end
@@ -1972,6 +1982,7 @@ local function run(android_app_state)
     -- device properties
     android.prop.version = android.getVersion()
     android.prop.brokenLifecycle = android.hasBrokenLifecycle()
+    android.prop.brokenTouchReport = android.hasBrokenTouchReport()
 
     -- update logger name
     android.log_name = android.prop.name


### PR DESCRIPTION
The Mobiscribe Wave's firmware reports `ACONFIGURATION_TOUCHSCREEN_NOTOUCH` despite having a functioning touchscreen. This causes KOReader to skip registering touch zones in the reader view, making documents completely unusable via touch input (the file manager still works because it uses ges_events instead of touch zones).

This adds the Mobiscribe Wave to DeviceInfo and exposes a new `QUIRK_BROKEN_TOUCH_REPORT` flag through the JNI pipeline so the KOReader Lua side can work around the incorrect reporting.

Closes #589
Related: koreader/koreader#12349

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/590)
<!-- Reviewable:end -->
