### PR TITLE
Add lights support for Nook Glowlight 4 Plus (bnrv1300)

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -78,6 +78,7 @@ object DeviceInfo {
         NABUK,
         NOOK,
         NOOK_GL4,
+        NOOK_GL4PLUS,
         NOOK_GLPLUS,
         OBOOK_P10D,
         OBOOK_P78D,
@@ -358,10 +359,14 @@ object DeviceInfo {
             MANUFACTURER == "onyx" && MODEL == "nabukreg_hd"
             -> Id.NABUK
 
-            // Nook Glowlight 4 (4/4e/4plus)
-            (MANUFACTURER == "barnesandnoble")
-            && (MODEL == "bnrv1000" || MODEL == "bnrv1100" || MODEL == "bnrv1300")
+            // Nook Glowlight 4 / 4e
+            MANUFACTURER == "barnesandnoble"
+            && (MODEL == "bnrv1000" || MODEL == "bnrv1100")
             -> Id.NOOK_GL4
+
+            // Nook Glowlight 4 Plus
+            MANUFACTURER == "barnesandnoble" && MODEL == "bnrv1300"
+            -> Id.NOOK_GL4PLUS
 
             // Nook Glowlight plus 7.8" (2019)
             MANUFACTURER == "barnesandnoble" && MODEL == "bnrv700" && PRODUCT == "ntx_6sl"

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -69,6 +69,7 @@ object EPDFactory {
 
                 DeviceInfo.Id.MOOINKPLUS2C,
                 DeviceInfo.Id.NOOK_GL4,
+                DeviceInfo.Id.NOOK_GL4PLUS,
                 DeviceInfo.Id.TOLINO_EPOS3,
                 DeviceInfo.Id.TOLINO_VISION6,
                 DeviceInfo.Id.TOLINO_SHINE4,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -106,6 +106,11 @@ object LightsFactory {
                     logController("TolinoNTXNoWarmth")
                     TolinoNtxNoWarmthController()
                 }
+                DeviceInfo.Id.NOOK_GL4PLUS,
+                -> {
+                    logController("NookGL4plus")
+                    NookGL4plusController()
+                }
                 DeviceInfo.Id.NOOK_GL4,
                 DeviceInfo.Id.TOLINO_EPOS2,
                 -> {

--- a/app/src/main/java/org/koreader/launcher/device/lights/NookGL4plusController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/NookGL4plusController.kt
@@ -1,0 +1,108 @@
+package org.koreader.launcher.device.lights
+
+import android.app.Activity
+import android.content.ComponentName
+import android.content.Intent
+import android.provider.Settings
+import android.util.Log
+import org.koreader.launcher.device.LightsInterface
+
+/* Controller for Nook Glowlight 4 Plus (bnrv1300) on Android 8.1.
+ * Brightness via Settings.System. Requires "Modify system settings" special app permission;
+ *   grant with: adb shell appops set org.koreader.launcher WRITE_SETTINGS allow
+ * Warmth via com.nook.partner GlowLightService (exported, no permission required, no root).
+ *   Sends action_set_color_temperature (0-100 scale); the service rescales to 0-10 for
+ *   the lm3630a_led hardware and calls PowerManager.setFrontlightBrightnessColor() using
+ *   its own DEVICE_POWER privilege.
+ * see https://github.com/koreader/koreader/issues/14574
+ */
+class NookGL4plusController : LightsInterface {
+
+    companion object {
+        private const val TAG = "Lights"
+        private const val BRIGHTNESS_MAX = 100
+        private const val WARMTH_MAX = 10
+        private const val MIN = 0
+        private const val GLOWLIGHT_PACKAGE = "com.nook.partner"
+        private const val GLOWLIGHT_SERVICE = "com.nook.partner.service.GlowLightService"
+        private const val ACTION_SET_COLOR_TEMPERATURE = "action_set_color_temperature"
+        private const val EXTRA_COLOR_TEMPERATURE = "extra_color_temperature"
+    }
+
+    @Volatile private var currentWarmth: Int = MIN
+
+    override fun getPlatform(): String = "nook"
+    override fun hasFallback(): Boolean = false
+    override fun hasWarmth(): Boolean = true
+    override fun needsPermission(): Boolean = false
+    override fun hasStandaloneWarmth(): Boolean = false
+    override fun enableFrontlightSwitch(activity: Activity): Int = 1
+
+    override fun getBrightness(activity: Activity): Int {
+        return try {
+            Settings.System.getInt(activity.applicationContext.contentResolver,
+                Settings.System.SCREEN_BRIGHTNESS)
+        } catch (e: Exception) {
+            Log.w(TAG, e.toString())
+            MIN
+        }
+    }
+
+    override fun getWarmth(activity: Activity): Int {
+        return try {
+            Settings.System.getInt(activity.applicationContext.contentResolver,
+                "screen_brightness_color")
+        } catch (e: Exception) {
+            currentWarmth
+        }
+    }
+
+    override fun setBrightness(activity: Activity, brightness: Int) {
+        if (brightness < MIN || brightness > BRIGHTNESS_MAX) {
+            Log.w(TAG, "brightness value out of range: $brightness")
+            return
+        }
+        Log.v(TAG, "Setting brightness to $brightness")
+        try {
+            Settings.System.putInt(activity.applicationContext.contentResolver,
+                Settings.System.SCREEN_BRIGHTNESS, brightness)
+        } catch (e: Exception) {
+            Log.w(TAG, "$e")
+        }
+    }
+
+    override fun setWarmth(activity: Activity, warmth: Int) {
+        if (warmth < MIN || warmth > WARMTH_MAX) {
+            Log.w(TAG, "warmth value out of range: $warmth")
+            return
+        }
+        if (warmth == getWarmth(activity)) return
+        Log.v(TAG, "Setting warmth to $warmth of $WARMTH_MAX")
+        setWarmthViaService(activity, warmth)
+    }
+
+    private fun setWarmthViaService(activity: Activity, warmth: Int): Boolean {
+        return try {
+            val intent = Intent(ACTION_SET_COLOR_TEMPERATURE).apply {
+                component = ComponentName(GLOWLIGHT_PACKAGE, GLOWLIGHT_SERVICE)
+                putExtra(EXTRA_COLOR_TEMPERATURE, warmth * 10)
+            }
+            val result = activity.startService(intent)
+            if (result != null) {
+                currentWarmth = warmth
+                true
+            } else {
+                Log.w(TAG, "GlowLightService unavailable (com.nook.partner disabled?)")
+                false
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "setWarmth via service failed: $e")
+            false
+        }
+    }
+
+    override fun getMinBrightness(): Int = MIN
+    override fun getMaxBrightness(): Int = BRIGHTNESS_MAX
+    override fun getMinWarmth(): Int = MIN
+    override fun getMaxWarmth(): Int = WARMTH_MAX
+}


### PR DESCRIPTION
Split bnrv1300 out of the NOOK_GL4 device ID into a new NOOK_GL4PLUS ID with a dedicated `NookGL4plusController`.

**Brightness** is set via `Settings.System.SCREEN_BRIGHTNESS` — consistent with other Android e-reader controllers (e.g. TolinoNtxController, which uses the same lm3630a hardware). On e-ink devices the frontlight is driven by dedicated hardware that only responds to the system brightness setting, not `window.attributes.screenBrightness`. This permission is reset on fresh install.

**Warmth** is set via the Nook's own `com.nook.partner.service.GlowLightService` — **no root required**. The controller sends a `startService` intent with action `action_set_color_temperature` and extra `extra_color_temperature` (0–100 scale). The service (a priv-app holding `DEVICE_POWER`) internally rescales by ÷10 for the bnrv1300 hardware and calls `PowerManager.setFrontlightBrightnessColor()` under its own privilege, bypassing both the SELinux restriction on sysfs writes and the `DEVICE_POWER` requirement for direct binder calls. Hardware range is 0–10. Note: the Nook's native display settings show 0=warm and 10=cool — KOReader's warmth slider uses the opposite convention (0=cool, 10=warm), so the controller passes the value through without inversion and lets KOReader's UI labeling handle user-facing direction.

**EPD waveform control** (GC16 rootless, no Magisk module required) is in companion PR #597.

---

## Setup

### Brightness — "Modify system settings" permission

Required after each fresh install. No root needed.

**Via ADB:**
```sh
adb shell appops set org.koreader.launcher WRITE_SETTINGS allow
```

**Via the system UI:** long-press the KOReader icon → **App Info** → **Advanced** → **Modify system settings** → **Allow**.

### Warmth — `com.nook.partner` must be enabled

Warmth depends on `GlowLightService` inside `com.nook.partner`. The package must not be disabled wholesale. If warmth is unresponsive:

```sh
adb shell pm enable com.nook.partner
```

**If you previously disabled `com.nook.partner`** to remove the B&N launcher or block OTA updates, re-enable the package and then selectively re-disable the components you don't want — `GlowLightService` is independent of those components and is unaffected:

```sh
# Re-enable the package (no root required)
adb shell pm enable com.nook.partner

# Re-disable B&N launcher and OTA components (root required)
adb shell su -c 'pm disable com.nook.partner/.FacadeLauncherActivity'
adb shell su -c 'pm disable com.nook.partner/.OobeLauncherActivity'
adb shell su -c 'pm disable com.nook.partner/.otamanager.OtaIntentService'
adb shell su -c 'pm disable com.nook.partner/.otamanager.SideloadInstaller'
adb shell su -c 'pm disable com.nook.partner/.oobe.OobeOtaActivity'
```

Do not disable `com.nook.partner.service.GlowLightService` itself.

---

## Test plan

- [x] Brightness slider changes screen brightness on Nook Glowlight 4 Plus
- [x] Warmth slider changes color temperature (0–10 hardware range)
- [x] Warmth works without root (via GlowLightService)
- [x] Rapid slider movement does not cause freezes

Fixes https://github.com/koreader/koreader/issues/14574
Lua-side changes: koreader/koreader#15561

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/592)
<!-- Reviewable:end -->
