### PR TITLE
Android network info

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
     <!-- common android permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"

--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -65,7 +65,9 @@ interface LuaInterface {
     fun isWarmthDevice(): Boolean
     fun needsWakelocks(): Boolean
     fun openLink(url: String): Boolean
+    fun isWifiEnabled(): Boolean
     fun openWifiSettings()
+    fun setWifiEnabled(enable: Boolean): Boolean
     fun performHapticFeedback(constant: Int, force: Int)
     fun requestIgnoreBatteryOptimizations(rationale: String, okButton: String, cancelButton: String)
     fun requestWriteSystemSettings(rationale: String, okButton: String, cancelButton: String)

--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -29,6 +29,7 @@ interface LuaInterface {
     fun getLightDialogState(): Int
     fun getName(): String
     fun getNetworkInfo(): String
+    fun getWifiNetworkDetails(): String
     fun getPlatformName(): String
     fun getScreenAvailableHeight(): Int
     fun getScreenAvailableWidth(): Int

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -438,6 +438,10 @@ class MainActivity : NativeActivity(), LuaInterface,
         return networkInfo()
     }
 
+    override fun getWifiNetworkDetails(): String {
+        return wifiNetworkDetails()
+    }
+
     override fun getPlatformName(): String {
         return platform
     }

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -640,8 +640,16 @@ class MainActivity : NativeActivity(), LuaInterface,
         }
     }
 
+    override fun isWifiEnabled(): Boolean {
+        return wifiEnabled()
+    }
+
     override fun openWifiSettings() {
         openWifi()
+    }
+
+    override fun setWifiEnabled(enable: Boolean): Boolean {
+        return setWifiRadio(enable)
     }
 
     override fun performHapticFeedback(constant: Int, force: Int) {

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -19,6 +19,7 @@ import android.view.Surface
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
+import java.net.NetworkInterface
 import java.util.*
 
 val Activity.platform: String
@@ -209,6 +210,40 @@ fun Activity.setWifiRadio(enable: Boolean): Boolean {
     } catch (e: Exception) {
         false
     }
+}
+
+@Suppress("DEPRECATION")
+fun Activity.wifiNetworkDetails(): String {
+    if (!wifiEnabled()) return ""
+    val wifi = applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager ?: return ""
+    val info = wifi.connectionInfo
+
+    val ipInt = info?.ipAddress ?: 0
+    val ip = if (ipInt == 0) "" else "%d.%d.%d.%d".format(
+        ipInt and 0xFF, (ipInt shr 8) and 0xFF,
+        (ipInt shr 16) and 0xFF, (ipInt shr 24) and 0xFF
+    )
+
+    val mac = try {
+        NetworkInterface.getByName("wlan0")?.hardwareAddress
+            ?.joinToString(":") { "%02X".format(it) } ?: ""
+    } catch (e: Exception) { "" }
+
+    var ssid = info?.ssid?.removeSurrounding("\"") ?: ""
+    if (ssid.isEmpty() || ssid == "<unknown ssid>" || ssid.startsWith("0x")) {
+        ssid = try {
+            val proc = Runtime.getRuntime().exec(arrayOf("su", "-c",
+                "dumpsys wifi 2>/dev/null | grep -m1 'extra:'"))
+            val line = proc.inputStream.bufferedReader().readLine() ?: ""
+            Regex("""extra: "([^"]*)"""").find(line)?.groupValues?.get(1) ?: ""
+        } catch (e: Exception) { "" }
+    }
+
+    return listOfNotNull(
+        if (ssid.isNotEmpty()) "SSID: $ssid" else null,
+        if (ip.isNotEmpty()) "IP: $ip" else null,
+        if (mac.isNotEmpty()) "MAC: $mac" else null
+    ).joinToString("\n")
 }
 
 fun Activity.pruneCacheDir() {

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager
 import android.graphics.Point
 import android.graphics.Rect
 import android.net.ConnectivityManager
+import android.net.wifi.WifiManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.os.Environment
@@ -189,6 +190,25 @@ fun Activity.openWifi() {
         action = Settings.ACTION_WIFI_SETTINGS
     }
     startActivityCompat(this, openWifiIntent)
+}
+
+fun Activity.wifiEnabled(): Boolean {
+    val wifi = applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager ?: return false
+    return wifi.isWifiEnabled
+}
+
+@Suppress("DEPRECATION")
+fun Activity.setWifiRadio(enable: Boolean): Boolean {
+    val wifi = applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager ?: return false
+    if (wifi.setWifiEnabled(enable)) return true
+    // WifiManager.setWifiEnabled() is blocked on many devices (restricted by OEM or Android 10+).
+    // Fall back to root shell command.
+    val cmd = if (enable) "svc wifi enable" else "svc wifi disable"
+    return try {
+        Runtime.getRuntime().exec(arrayOf("su", "-c", cmd)).waitFor() == 0
+    } catch (e: Exception) {
+        false
+    }
 }
 
 fun Activity.pruneCacheDir() {

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2499,6 +2499,17 @@ local function run(android_app_state)
         end)
     end
 
+    android.getWifiNetworkDetails = function()
+        return JNI:context(android.app.activity.vm, function(jni)
+            local details = jni:callObjectMethod(
+                android.app.activity.clazz,
+                "getWifiNetworkDetails",
+                "()Ljava/lang/String;"
+            )
+            return jni:to_string(details)
+        end)
+    end
+
     android.download = function(url, name)
         return JNI:context(android.app.activity.vm, function(jni)
             local uri_string = jni.env[0].NewStringUTF(jni.env, url)

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2478,6 +2478,27 @@ local function run(android_app_state)
         end)
     end
 
+    android.isWifiEnabled = function()
+        return JNI:context(android.app.activity.vm, function(jni)
+            return jni:callBooleanMethod(
+                android.app.activity.clazz,
+                "isWifiEnabled",
+                "()Z"
+            )
+        end)
+    end
+
+    android.setWifiEnabled = function(enable)
+        return JNI:context(android.app.activity.vm, function(jni)
+            return jni:callBooleanMethod(
+                android.app.activity.clazz,
+                "setWifiEnabled",
+                "(Z)Z",
+                ffi.new("bool", enable)
+            )
+        end)
+    end
+
     android.download = function(url, name)
         return JNI:context(android.app.activity.vm, function(jni)
             local uri_string = jni.env[0].NewStringUTF(jni.env, url)


### PR DESCRIPTION
I apologize if this is not good, I don't know how to program. 
I have a Nook Glowlight 4 plus that runs android 8.1.0. The device it lacks a navigation bar or a back button so when I wanted to turn on wifi, it would navigate to the wifi settings page but it was a struggle to get back into koreader. I asked Claude if there was a way to fix this since for android 9 and below it is possible to just toggle wifi. 

the Settings->Network->Network info menu didn't display anything but "Connected to Wi-Fi" so I had Claude do some magic so that it would show the SSID, Ip, and Mac. On my device it requires root to get the mac by running a dumpsys command, but Claude assured me that no issues would be caused if someone didn't have root.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/593)
<!-- Reviewable:end -->
