### PR TITLE
Android: add auto-rotation support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
             android:exported="true"
             android:theme="@style/SplashScreen"
             android:resizeableActivity="false"
-            android:screenOrientation="nosensor"
+            android:screenOrientation="fullSensor"
             android:launchMode="singleInstance"
             android:configChanges="colorMode|density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
             tools:ignore="NonResizeableActivity">

--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -78,6 +78,7 @@ interface LuaInterface {
     fun setScreenWarmth(warmth: Int)
     fun setScreenOffTimeout(ms: Int)
     fun setScreenAutoRotation(enabled: Boolean)
+    fun setScreenAutoRotationLocked(orientation: Int)
     fun setScreenOrientation(orientation: Int)
     fun startTestActivity()
     fun showFrontlightDialog(title: String, dim: String, warmth: String, okButton: String, cancelButton: String)

--- a/app/src/main/java/org/koreader/launcher/LuaInterface.kt
+++ b/app/src/main/java/org/koreader/launcher/LuaInterface.kt
@@ -77,6 +77,7 @@ interface LuaInterface {
     fun setScreenBrightness(brightness: Int)
     fun setScreenWarmth(warmth: Int)
     fun setScreenOffTimeout(ms: Int)
+    fun setScreenAutoRotation(enabled: Boolean)
     fun setScreenOrientation(orientation: Int)
     fun startTestActivity()
     fun showFrontlightDialog(title: String, dim: String, warmth: String, okButton: String, cancelButton: String)

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -134,10 +134,21 @@ class MainActivity : NativeActivity(), LuaInterface,
         Log.v(TAG_SURFACE, "Using $surfaceKind implementation")
 
         @Suppress("DEPRECATION")
-        screenIsLandscape = windowManager.defaultDisplay.width > windowManager.defaultDisplay.height
+        val dw = windowManager.defaultDisplay.width
+        val dh = windowManager.defaultDisplay.height
+        val drotation = windowManager.defaultDisplay.rotation
+        // Display.width/height are adjusted for current rotation.
+        // For ROTATION_90/270, width and height are swapped relative to natural,
+        // so invert the comparison to determine the true natural orientation.
+        screenIsLandscape = if (drotation == Surface.ROTATION_90 || drotation == Surface.ROTATION_270) {
+            dh > dw
+        } else {
+            dw > dh
+        }
 
         Log.v(tag, String.format(Locale.US,
-            "native orientation: %s", if (this.screenIsLandscape) "landscape" else "portrait"))
+            "native orientation: %s (rotation=%d w=%d h=%d)",
+            if (this.screenIsLandscape) "landscape" else "portrait", drotation, dw, dh))
 
         registerReceiver(event, event.filter)
 

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -734,6 +734,10 @@ class MainActivity : NativeActivity(), LuaInterface,
         }
     }
 
+    override fun setScreenAutoRotationLocked(orientation: Int) {
+        setLockedAutoOrientation(orientation)
+    }
+
     override fun setScreenWarmth(warmth: Int) {
         device.lights.setWarmth(this, warmth)
     }

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -725,6 +725,15 @@ class MainActivity : NativeActivity(), LuaInterface,
         setOrientationCompat(screenIsLandscape, orientation)
     }
 
+    override fun setScreenAutoRotation(enabled: Boolean) {
+        if (enabled) {
+            setAutoOrientation()
+        } else {
+            // Lock to current orientation when disabling auto mode
+            setScreenOrientation(getScreenOrientation())
+        }
+    }
+
     override fun setScreenWarmth(warmth: Int) {
         device.lights.setWarmth(this, warmth)
     }

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -303,11 +303,11 @@ fun Activity.getOrientationCompat(isLandscape: Boolean): Int {
 }
 
 fun Activity.setOrientationCompat(isLandscape: Boolean, orientation: Int) {
-	    // Pass through sensor modes without remapping
-	    if (isPassthroughOrientation(orientation)) {
-	        requestedOrientation = orientation
-	        return
-	    }
+    // Pass through sensor modes without remapping
+    if (isPassthroughOrientation(orientation)) {
+        requestedOrientation = orientation
+        return
+    }
     val newOrientation = if (isLandscape) {
         when (orientation) {
             ANDROID_LANDSCAPE -> ANDROID_PORTRAIT

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -330,6 +330,17 @@ fun Activity.setAutoOrientation() {
     requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
 }
 
+fun Activity.setLockedAutoOrientation(orientation: Int) {
+    // LinuxFB rotation constants: 0=UR, 2=UD (portrait axis, even);
+    // 1=CW, 3=CCW (landscape axis, odd).
+    // Restrict native sensor rotation to the same axis as the current orientation.
+    requestedOrientation = if (orientation.and(1) == 0) {
+        ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+    } else {
+        ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+    }
+}
+
 private fun isPassthroughOrientation(orientation: Int): Boolean {
     return orientation == ANDROID_FULL_SENSOR ||
         orientation == ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED ||

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -1,4 +1,5 @@
 package org.koreader.launcher.extensions
+import android.content.pm.ActivityInfo
 
 import android.annotation.SuppressLint
 import android.app.Activity
@@ -302,6 +303,17 @@ fun Activity.getOrientationCompat(isLandscape: Boolean): Int {
 }
 
 fun Activity.setOrientationCompat(isLandscape: Boolean, orientation: Int) {
+	    // Pass through sensor modes without remapping
+	    if (orientation == ANDROID_FULL_SENSOR ||
+	        orientation == ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED ||
+	        orientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR ||
+	        orientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE ||
+	        orientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT ||
+	        orientation == ActivityInfo.SCREEN_ORIENTATION_NOSENSOR ||
+	        orientation == ActivityInfo.SCREEN_ORIENTATION_USER) {
+	        requestedOrientation = orientation
+	        return
+	    }
     val newOrientation = if (isLandscape) {
         when (orientation) {
             ANDROID_LANDSCAPE -> ANDROID_PORTRAIT
@@ -320,6 +332,10 @@ fun Activity.setOrientationCompat(isLandscape: Boolean, orientation: Int) {
     requestedOrientation = newOrientation
 }
 
+fun Activity.setAutoOrientation() {
+    requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
+}
+
 // constants from https://github.com/koreader/android-luajit-launcher/blob/master/assets/android.lua
 private const val ACTIVE_NETWORK_NONE = 0
 private const val ACTIVE_NETWORK_WIFI = 1
@@ -331,6 +347,7 @@ private const val ANDROID_LANDSCAPE = 0
 private const val ANDROID_PORTRAIT = 1
 private const val ANDROID_REVERSE_LANDSCAPE = 8
 private const val ANDROID_REVERSE_PORTRAIT = 9
+	private const val ANDROID_FULL_SENSOR = 10
 
 // constants from https://github.com/koreader/koreader-base/blob/master/ffi/framebuffer.lua
 private const val LINUX_PORTRAIT = 0

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -297,9 +297,9 @@ private fun startActivityCompat(context: Context, intent: Intent) {
 fun Activity.getOrientationCompat(isLandscape: Boolean): Int {
     val rotation = windowManager.defaultDisplay.rotation
     val result = when (rotation) {
-        Surface.ROTATION_90 -> if (isLandscape) LINUX_PORTRAIT else LINUX_REVERSE_LANDSCAPE
+        Surface.ROTATION_90 -> if (isLandscape) LINUX_REVERSE_PORTRAIT else LINUX_LANDSCAPE
         Surface.ROTATION_180 -> if (isLandscape) LINUX_REVERSE_LANDSCAPE else LINUX_REVERSE_PORTRAIT
-        Surface.ROTATION_270 -> if (isLandscape) LINUX_REVERSE_PORTRAIT else LINUX_LANDSCAPE
+        Surface.ROTATION_270 -> if (isLandscape) LINUX_PORTRAIT else LINUX_REVERSE_LANDSCAPE
         else -> if (isLandscape) LINUX_LANDSCAPE else LINUX_PORTRAIT
     }
     Log.i("AROT_DIAG", String.format(Locale.US,

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -302,7 +302,7 @@ fun Activity.getOrientationCompat(isLandscape: Boolean): Int {
         Surface.ROTATION_270 -> if (isLandscape) LINUX_PORTRAIT else LINUX_REVERSE_LANDSCAPE
         else -> if (isLandscape) LINUX_LANDSCAPE else LINUX_PORTRAIT
     }
-    Log.i("AROT_DIAG", String.format(Locale.US,
+    Log.d("AROT_DIAG", String.format(Locale.US,
         "getOrientationCompat: rotation=%d isLandscape=%b -> result=%d (%s)",
         rotation, isLandscape, result,
         when (result) {
@@ -318,7 +318,7 @@ fun Activity.getOrientationCompat(isLandscape: Boolean): Int {
 fun Activity.setOrientationCompat(isLandscape: Boolean, orientation: Int) {
     // Pass through sensor modes without remapping
     if (isPassthroughOrientation(orientation)) {
-        Log.i("AROT_DIAG", String.format(Locale.US,
+        Log.d("AROT_DIAG", String.format(Locale.US,
             "setOrientationCompat: orientation=%d isPassthrough=true", orientation))
         requestedOrientation = orientation
         return
@@ -338,7 +338,7 @@ fun Activity.setOrientationCompat(isLandscape: Boolean, orientation: Int) {
         // the CW/CCW direction (observed on this device).
         orientation
     }
-    Log.i("AROT_DIAG", String.format(Locale.US,
+    Log.d("AROT_DIAG", String.format(Locale.US,
         "setOrientationCompat: orientation=%d isLandscape=%b -> requestedOrientation=%d",
         orientation, isLandscape, newOrientation))
     requestedOrientation = newOrientation

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -362,7 +362,7 @@ private const val ANDROID_LANDSCAPE = 0
 private const val ANDROID_PORTRAIT = 1
 private const val ANDROID_REVERSE_LANDSCAPE = 8
 private const val ANDROID_REVERSE_PORTRAIT = 9
-	private const val ANDROID_FULL_SENSOR = 10
+private const val ANDROID_FULL_SENSOR = 10
 
 // constants from https://github.com/koreader/koreader-base/blob/master/ffi/framebuffer.lua
 private const val LINUX_PORTRAIT = 0

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -332,11 +332,11 @@ fun Activity.setOrientationCompat(isLandscape: Boolean, orientation: Int) {
             else -> orientation
         }
     } else {
-        when (orientation) {
-            ANDROID_LANDSCAPE -> ANDROID_REVERSE_LANDSCAPE
-            ANDROID_REVERSE_LANDSCAPE -> ANDROID_LANDSCAPE
-            else -> orientation
-        }
+        // Native portrait: Lua already maps DEVICE_ROTATED_* to the
+        // correct ASCREEN_ORIENTATION_* constants. No further remapping
+        // needed — swapping LANDSCAPE↔REVERSE_LANDSCAPE would invert
+        // the CW/CCW direction (observed on this device).
+        orientation
     }
     Log.i("AROT_DIAG", String.format(Locale.US,
         "setOrientationCompat: orientation=%d isLandscape=%b -> requestedOrientation=%d",

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -15,6 +15,7 @@ import android.os.Build
 import android.os.Environment
 import android.provider.Settings
 import android.util.DisplayMetrics
+import android.util.Log
 import android.view.Surface
 import android.view.View
 import androidx.appcompat.app.AlertDialog
@@ -294,17 +295,31 @@ private fun startActivityCompat(context: Context, intent: Intent) {
 /* Orientation */
 @Suppress("DEPRECATION")
 fun Activity.getOrientationCompat(isLandscape: Boolean): Int {
-    return when (windowManager.defaultDisplay.rotation) {
+    val rotation = windowManager.defaultDisplay.rotation
+    val result = when (rotation) {
         Surface.ROTATION_90 -> if (isLandscape) LINUX_PORTRAIT else LINUX_REVERSE_LANDSCAPE
         Surface.ROTATION_180 -> if (isLandscape) LINUX_REVERSE_LANDSCAPE else LINUX_REVERSE_PORTRAIT
         Surface.ROTATION_270 -> if (isLandscape) LINUX_REVERSE_PORTRAIT else LINUX_LANDSCAPE
         else -> if (isLandscape) LINUX_LANDSCAPE else LINUX_PORTRAIT
     }
+    Log.i("AROT_DIAG", String.format(Locale.US,
+        "getOrientationCompat: rotation=%d isLandscape=%b -> result=%d (%s)",
+        rotation, isLandscape, result,
+        when (result) {
+            0 -> "UR"
+            1 -> "CW"
+            2 -> "UD"
+            3 -> "CCW"
+            else -> "?"
+        }))
+    return result
 }
 
 fun Activity.setOrientationCompat(isLandscape: Boolean, orientation: Int) {
     // Pass through sensor modes without remapping
     if (isPassthroughOrientation(orientation)) {
+        Log.i("AROT_DIAG", String.format(Locale.US,
+            "setOrientationCompat: orientation=%d isPassthrough=true", orientation))
         requestedOrientation = orientation
         return
     }
@@ -323,6 +338,9 @@ fun Activity.setOrientationCompat(isLandscape: Boolean, orientation: Int) {
             else -> orientation
         }
     }
+    Log.i("AROT_DIAG", String.format(Locale.US,
+        "setOrientationCompat: orientation=%d isLandscape=%b -> requestedOrientation=%d",
+        orientation, isLandscape, newOrientation))
     requestedOrientation = newOrientation
 }
 

--- a/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
+++ b/app/src/main/java/org/koreader/launcher/extensions/ActivityExtensions.kt
@@ -304,13 +304,7 @@ fun Activity.getOrientationCompat(isLandscape: Boolean): Int {
 
 fun Activity.setOrientationCompat(isLandscape: Boolean, orientation: Int) {
 	    // Pass through sensor modes without remapping
-	    if (orientation == ANDROID_FULL_SENSOR ||
-	        orientation == ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED ||
-	        orientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR ||
-	        orientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE ||
-	        orientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT ||
-	        orientation == ActivityInfo.SCREEN_ORIENTATION_NOSENSOR ||
-	        orientation == ActivityInfo.SCREEN_ORIENTATION_USER) {
+	    if (isPassthroughOrientation(orientation)) {
 	        requestedOrientation = orientation
 	        return
 	    }
@@ -334,6 +328,16 @@ fun Activity.setOrientationCompat(isLandscape: Boolean, orientation: Int) {
 
 fun Activity.setAutoOrientation() {
     requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
+}
+
+private fun isPassthroughOrientation(orientation: Int): Boolean {
+    return orientation == ANDROID_FULL_SENSOR ||
+        orientation == ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED ||
+        orientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR ||
+        orientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE ||
+        orientation == ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT ||
+        orientation == ActivityInfo.SCREEN_ORIENTATION_NOSENSOR ||
+        orientation == ActivityInfo.SCREEN_ORIENTATION_USER
 }
 
 // constants from https://github.com/koreader/android-luajit-launcher/blob/master/assets/android.lua

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2079,6 +2079,16 @@ local function run(android_app_state)
                 android.LOGW("ignoring invalid orientation", new_orientation)
             end
         end,
+	        setAuto = function(enabled)
+	            JNI:context(android.app.activity.vm, function(jni)
+	                jni:callVoidMethod(
+	                    android.app.activity.clazz,
+	                    "setScreenAutoRotation",
+	                    "(Z)V",
+	                    ffi.new("bool", enabled)
+	                )
+	            end)
+	        end,
     }
 
     android.enableFrontlightSwitch = function()

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2079,26 +2079,26 @@ local function run(android_app_state)
                 android.LOGW("ignoring invalid orientation", new_orientation)
             end
         end,
-	        setAuto = function(enabled)
-	            JNI:context(android.app.activity.vm, function(jni)
-	                jni:callVoidMethod(
-	                    android.app.activity.clazz,
-	                    "setScreenAutoRotation",
-	                    "(Z)V",
-	                    ffi.new("bool", enabled)
-	                )
-	            end)
-	        end,
-	setAutoLocked = function(orientation)
-	    JNI:context(android.app.activity.vm, function(jni)
-	        jni:callVoidMethod(
-	            android.app.activity.clazz,
-	            "setScreenAutoRotationLocked",
-	            "(I)V",
-	            ffi.new("int32_t", orientation)
-	        )
-	    end)
-	end,
+        setAuto = function(enabled)
+            JNI:context(android.app.activity.vm, function(jni)
+                jni:callVoidMethod(
+                    android.app.activity.clazz,
+                    "setScreenAutoRotation",
+                    "(Z)V",
+                    ffi.new("bool", enabled)
+                )
+            end)
+        end,
+        setAutoLocked = function(orientation)
+            JNI:context(android.app.activity.vm, function(jni)
+                jni:callVoidMethod(
+                    android.app.activity.clazz,
+                    "setScreenAutoRotationLocked",
+                    "(I)V",
+                    ffi.new("int32_t", orientation)
+                )
+            end)
+        end,
     }
 
     android.enableFrontlightSwitch = function()

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2089,6 +2089,16 @@ local function run(android_app_state)
 	                )
 	            end)
 	        end,
+	setAutoLocked = function(orientation)
+	    JNI:context(android.app.activity.vm, function(jni)
+	        jni:callVoidMethod(
+	            android.app.activity.clazz,
+	            "setScreenAutoRotationLocked",
+	            "(I)V",
+	            ffi.new("int32_t", orientation)
+	        )
+	    end)
+	end,
     }
 
     android.enableFrontlightSwitch = function()


### PR DESCRIPTION
This PR adds the Android-side changes needed for auto-rotation support in KOReader (see companion PR in the main repository).

## Changes

- **AndroidManifest.xml**: Change `screenOrientation` from `nosensor` to `fullSensor`, allowing Android to manage screen rotation via the accelerometer.
- **ActivityExtensions.kt**: Add `setAutoOrientation()` extension and a sensor mode guard in `setOrientationCompat` that passes `FULL_SENSOR` and related constants through without remapping.
- **MainActivity.kt**: Add `setScreenAutoRotation(enabled)` method to enable/disable auto mode via `requestedOrientation`.
- **LuaInterface.kt**: Declare the new JNI method.
- **assets/android.lua**: Add `android.orientation.setAuto(enabled)` binding.

## Dependencies

This PR must be merged **before** the companion PR in `koreader/koreader`, which updates the luajit-launcher submodule pointer and implements the Lua-side auto-rotation UI and logic.

Companion PR: https://github.com/koreader/koreader/pull/15507

## Testing

- Built and tested on an Android ARM64 device (Onyx Boox Leaf5)
- Auto-rotation follows device orientation correctly
- Manual rotation selection exits auto mode and locks to the selected orientation
- Physical page-turn buttons follow rotation correctly in both modes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/594)
<!-- Reviewable:end -->
