### PR TITLE
Moaan W7 Support

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -76,6 +76,7 @@ object DeviceInfo {
         MEEBOOK_P6,
         MOBISCRIBE_WAVE,
         MOAAN_MIX7,
+        MOAAN_W7,
         MOOINKPLUS2C,
         NABUK,
         NOOK,
@@ -355,6 +356,9 @@ object DeviceInfo {
             // Moaan Mix7
             MANUFACTURER == STR_ROCKCHIP && MODEL == "moaanmix7"
             -> Id.MOAAN_MIX7
+
+            BRAND == "allwinner" && MODEL == "epd103" && DEVICE == "virgo-perf1" && HARDWARE == "sun8iw15p1"
+            -> Id.MOAAN_W7
 
             // Mooink Plus 2c
             BRAND == "allwinner" && MODEL == "mooink plus 2c"
@@ -727,6 +731,7 @@ object DeviceInfo {
             Id.ONYX_NOTE,
             Id.SONY_CP1,
             Id.SONY_RP1,
+            Id.MOAAN_W7,
             -> true else -> false
         }
 

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -727,12 +727,12 @@ object DeviceInfo {
         // Android devices without lights
         QUIRK_NO_LIGHTS = when (ID) {
             Id.LINFINY_ENOTE,
+            Id.MOAAN_W7,
             Id.ONYX_MAX,
             Id.ONYX_MAX2_PRO,
             Id.ONYX_NOTE,
             Id.SONY_CP1,
             Id.SONY_RP1,
-            Id.MOAAN_W7,
             -> true else -> false
         }
 

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -357,6 +357,7 @@ object DeviceInfo {
             MANUFACTURER == STR_ROCKCHIP && MODEL == "moaanmix7"
             -> Id.MOAAN_MIX7
 
+            // Moaan W7
             BRAND == "allwinner" && MODEL == "epd103" && DEVICE == "virgo-perf1" && HARDWARE == "sun8iw15p1"
             -> Id.MOAAN_W7
 


### PR DESCRIPTION
[Apparently](https://github.com/koreader/koreader/pull/15542), KOReader treats Moaan W7 as if it had a color screen.
I've also added it to the no-light list since it has no lights.
Everything else (except probably Wi-fi) has been working fine with the default `Id.NONE` so I don't need to add the new Id anywhere else, do I?..

The specs were taken from logs:
```
MANUFACTURER: allwinner
BRAND       : allwinner
MODEL       : epd103
DEVICE      : virgo-perf1
PRODUCT     : virgo_perf1
HARDWARE    : sun8iw15p1
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/595)
<!-- Reviewable:end -->
