### PR TITLE
MainActivity: fix einkUpdate/hapticFeedback crash when called from NativeThread

### DIFF
--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -56,6 +56,9 @@ class MainActivity : NativeActivity(), LuaInterface,
 
     // surface used on devices that need a view
     private var view: NativeSurfaceView? = null
+
+    // cached root view for EPD mode calls from NativeThread (avoids window.decorView on non-UI thread)
+    private var epdRootView: android.view.View? = null
     private class NativeSurfaceView(context: Context): SurfaceView(context),
         SurfaceHolder.Callback {
         init { holder.addCallback(this) }
@@ -132,6 +135,10 @@ class MainActivity : NativeActivity(), LuaInterface,
             "Native Content"
         }
         Log.v(TAG_SURFACE, "Using $surfaceKind implementation")
+
+        // Cache root view for EPD calls from NativeThread (window.decorView must not be
+        // accessed from a non-UI thread; pre-cache it here on the main thread instead).
+        epdRootView = view ?: window.decorView.findViewById(android.R.id.content)
 
         @Suppress("DEPRECATION")
         screenIsLandscape = windowManager.defaultDisplay.width > windowManager.defaultDisplay.height
@@ -314,7 +321,7 @@ class MainActivity : NativeActivity(), LuaInterface,
     }
 
     override fun einkUpdate(mode: Int) {
-        val rootView = view ?: window.decorView.findViewById<View>(android.R.id.content)
+        val rootView = epdRootView ?: return
         val modeName = when (mode) {
             1 -> "EPD_FULL"
             2 -> "EPD_PART"
@@ -332,7 +339,7 @@ class MainActivity : NativeActivity(), LuaInterface,
     }
 
     override fun einkUpdate(mode: Int, delay: Long, x: Int, y: Int, width: Int, height: Int) {
-        val rootView = view ?: window.decorView.findViewById<View>(android.R.id.content)
+        val rootView = epdRootView ?: return
         Log.v(tag, String.format(Locale.US,
             "requesting epd update, mode:%d, delay:%d, [x:%d, y:%d, w:%d, h:%d]",
             mode, delay, x, y, width, height))
@@ -645,7 +652,7 @@ class MainActivity : NativeActivity(), LuaInterface,
     }
 
     override fun performHapticFeedback(constant: Int, force: Int) {
-        val rootView = view ?: window.decorView.findViewById<View>(android.R.id.content)
+        val rootView = epdRootView ?: return
         hapticFeedback(constant, force > 0, rootView)
     }
 

--- a/app/src/main/java/org/koreader/launcher/MainActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/MainActivity.kt
@@ -172,6 +172,7 @@ class MainActivity : NativeActivity(), LuaInterface,
 
     override fun surfaceCreated(holder: SurfaceHolder) {
         super.surfaceCreated(holder)
+        epdRootView = view ?: window.decorView.rootView
         drawSplashScreen(holder)
     }
 


### PR DESCRIPTION
## Summary

`einkUpdate` and `performHapticFeedback` are called from the NativeThread (Lua/C side). Both previously resolved the root view inline via `window.decorView.findViewById(android.R.id.content)`, which is a UI-thread-only call and triggers a `CalledFromWrongThreadException` on affected devices.

**Fix:** cache the root view as `epdRootView` in `onCreate` (UI thread), and refresh it in `surfaceCreated` so it stays current if the surface is ever recreated. The call sites are updated to use `epdRootView ?: return` — a no-op if somehow called before the surface is ready.

## Changes

- `MainActivity.kt`: add `epdRootView` field, set in `onCreate` and refreshed in `surfaceCreated`; replace the three inline `window.decorView.findViewByid(...)` calls in `einkUpdate` (×2) and `performHapticFeedback` with the cached value

## Notes

This is a general Android fix, not device-specific. Split out of #592 (Nook GL4+ lights support) at reviewer request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/596)
<!-- Reviewable:end -->
