### PR TITLE
Add Lenovo Smart/Yoga Paper support (EPD + lights)

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -69,6 +69,7 @@ object DeviceInfo {
         INKBOOKFOCUS_PLUS,
         INKPALM_PLUS,
         JDREAD,
+        LENOVO_SMARTPAPER,
         LINFINY_ENOTE,
         MEEBOOK_M6,
         MEEBOOK_M6C,
@@ -330,6 +331,10 @@ object DeviceInfo {
             MANUFACTURER == "onyx" && MODEL == "jdread"
             -> Id.JDREAD
 
+            // Lenovo SmartPaper
+            "lenovo".equals(BRAND, ignoreCase = true) && "lenovo sp101fu".equals(MODEL, ignoreCase = true)
+                -> Id.LENOVO_SMARTPAPER
+
             // Linfiny A4 (13.3") eNote / Avalue ENT-13T1 / QuirkLogic Papyr
             MANUFACTURER == "linfiny" && MODEL == "ent-13t1"
             -> Id.LINFINY_ENOTE
@@ -525,7 +530,7 @@ object DeviceInfo {
             // Onyx Note Air 4C
             BRAND == "onyx" && MODEL == "noteair4c"
             -> Id.ONYX_NOTE_AIR_4C
-            
+
             // Onyx Note Air 5C
             BRAND == "onyx" && MODEL == "noteair5c"
             -> Id.ONYX_NOTE_AIR_5C

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -5,6 +5,7 @@ package org.koreader.launcher.device
 
 import android.util.Log
 import org.koreader.launcher.device.epd.CremaEPDController
+import org.koreader.launcher.device.epd.LenovoSmartPaperEPDController
 import org.koreader.launcher.device.epd.NookEPDController
 import org.koreader.launcher.device.epd.TolinoEPDController
 import org.koreader.launcher.device.epd.RK3026EPDController
@@ -183,6 +184,12 @@ object EPDFactory {
                 -> {
                     logController("Rockchip RK3566")
                     RK3566EPDController()
+                }
+
+                DeviceInfo.Id.LENOVO_SMARTPAPER,
+                -> {
+                    logController("Lenovo SmartPaper")
+                    LenovoSmartPaperEPDController()
                 }
 
                 else -> {

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -14,6 +14,11 @@ object LightsFactory {
                     logController("Boyue S62")
                     BoyueS62RootController()
                 }
+                DeviceInfo.Id.LENOVO_SMARTPAPER,
+                    -> {
+                    logController("LenovoSmartPaper")
+                    LenovoSmartPaperLightsController()
+                }
                 DeviceInfo.Id.ONYX_GALILEO2,
                 DeviceInfo.Id.ONYX_GO_COLOR7,
                 DeviceInfo.Id.ONYX_GO6,

--- a/app/src/main/java/org/koreader/launcher/device/epd/LenovoSmartPaperEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/LenovoSmartPaperEPDController.kt
@@ -1,0 +1,95 @@
+package org.koreader.launcher.device.epd
+
+import android.annotation.SuppressLint
+import android.util.Log
+import android.view.View
+import org.koreader.launcher.device.EPDInterface
+import org.koreader.launcher.device.epd.rockchip.RK35xxEPDController.Companion.EPD_AUTO
+
+/* EPD Controller for Lenovo SmartPaper (RK3566).
+ *
+ * Uses the hidden system service android.os.EinkManager via reflection.
+ * The service is obtained via Context.getSystemService("eink").
+ *
+ * Note: sendOneFullFrame() is blocked by SELinux on Lenovo devices,
+ * so we use screenRefresh(true, 1) instead, which correctly triggers
+ * a full-screen GC16 refresh (black/white flash to clear ghosting).
+ */
+
+class LenovoSmartPaperEPDController : EPDInterface {
+
+    companion object {
+        private const val TAG = "EPD"
+    }
+
+    override fun getPlatform(): String {
+        return "rockchip"
+    }
+
+    override fun getMode(): String {
+        return "full-only"
+    }
+
+    override fun getWaveformFull(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformPartial(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformFullUi(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformPartialUi(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformFast(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformDelay(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformDelayUi(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformDelayFast(): Int {
+        return EPD_AUTO
+    }
+
+    override fun needsView(): Boolean {
+        return true
+    }
+
+    @SuppressLint("WrongConstant")
+    override fun setEpdMode(targetView: View,
+                            mode: Int, delay: Long,
+                            x: Int, y: Int, width: Int, height: Int, epdMode: String?)
+    {
+        try {
+            val einkManagerClass = Class.forName("android.os.EinkManager")
+            val einkManager: Any? = targetView.context.getSystemService("eink")
+
+            if (einkManager != null) {
+                // Use screenRefresh(true, 1) — the only working full-refresh
+                // path on Lenovo devices. sendOneFullFrame() is blocked by SELinux.
+                val screenRefresh = einkManagerClass.getMethod(
+                    "screenRefresh", Boolean::class.javaPrimitiveType, Int::class.javaPrimitiveType)
+                screenRefresh.invoke(einkManager, true, 1)
+            } else {
+                Log.w(TAG, "EinkManager service not available")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "setEpdMode failed: ${e.message}")
+            Log.e(TAG, e.stackTraceToString())
+        }
+    }
+
+    override fun resume() {}
+    override fun pause() {}
+}

--- a/app/src/main/java/org/koreader/launcher/device/lights/LenovoSmartPaperLightsController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/LenovoSmartPaperLightsController.kt
@@ -69,7 +69,7 @@ class LenovoSmartPaperLightsController : LightsInterface {
         return try {
             val brightnessFloat = Settings.System.getFloat(
                 activity.contentResolver, "screen_brightness_float", 0f)
-            // Extract brightness raw value (0–99)
+            // Extract brightness raw value (0–99). The "rounding" logic purposefully follows original SystemUI.
             val raw = (brightnessFloat * 10000f).roundToInt() / 100
             raw.coerceIn(MIN, BRIGHTNESS_RAW_MAX)
         } catch (e: Exception) {

--- a/app/src/main/java/org/koreader/launcher/device/lights/LenovoSmartPaperLightsController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/LenovoSmartPaperLightsController.kt
@@ -1,0 +1,145 @@
+package org.koreader.launcher.device.lights
+
+import android.app.Activity
+import android.provider.Settings
+import android.util.Log
+import org.koreader.launcher.device.LightsInterface
+import kotlin.math.roundToInt
+
+/* Lights Controller for Lenovo SmartPaper.
+ *
+ * Brightness and color temperature are encoded into a single float
+ * and written to Settings.System "screen_brightness_float", using the
+ * same encoding as Lenovo's system QuickSettingManager:
+ *
+ *   float value = (brightness / 100.0f) + (colorTemp / 10000.0f)
+ *
+ * Brightness raw range: 0–99
+ * Color temperature raw range: 0–24 (via PowerManager.BRIGHTNESS_COLORTEMP_MAX)
+ *
+ * Requires WRITE_SETTINGS permission (special permission, must be granted
+ * manually via Settings.ACTION_MANAGE_WRITE_SETTINGS).
+ */
+
+class LenovoSmartPaperLightsController : LightsInterface {
+
+    companion object {
+        private const val TAG = "Lights"
+        private const val BRIGHTNESS_RAW_MAX = 99
+        private const val DEFAULT_COLORTEMP_MAX = 24
+        private const val MIN = 0
+
+        // The UI exposes 0–24 steps for both brightness and warmth.
+        // This matches the color temp range and provides fine-grained
+        // brightness control within the 0–99 raw range.
+        private const val UI_MAX = 24
+    }
+
+    private var colorTempMax: Int = DEFAULT_COLORTEMP_MAX
+
+    init {
+        colorTempMax = getMaxColorTemp()
+        Log.i(TAG, "LenovoSmartPaper lights: brightness=0..$BRIGHTNESS_RAW_MAX, " +
+            "warmth=0..$colorTempMax, UI steps=0..$UI_MAX")
+    }
+
+    override fun getPlatform(): String {
+        return "lenovo"
+    }
+
+    override fun hasFallback(): Boolean {
+        return false
+    }
+
+    override fun hasWarmth(): Boolean {
+        return true
+    }
+
+    override fun needsPermission(): Boolean {
+        return true
+    }
+
+    override fun hasStandaloneWarmth(): Boolean {
+        return false
+    }
+
+    // ── Read ──────────────────────────────────────────────────────────────────
+
+    override fun getBrightness(activity: Activity): Int {
+        return try {
+            val brightnessFloat = Settings.System.getFloat(
+                activity.contentResolver, "screen_brightness_float", 0f)
+            // Extract brightness raw value (0–99)
+            val raw = (brightnessFloat * 10000f).roundToInt() / 100
+            raw.coerceIn(MIN, BRIGHTNESS_RAW_MAX)
+        } catch (e: Exception) {
+            Log.w(TAG, "getBrightness failed: ${e.message}")
+            MIN
+        }
+    }
+
+    override fun getWarmth(activity: Activity): Int {
+        return try {
+            val brightnessFloat = Settings.System.getFloat(
+                activity.contentResolver, "screen_brightness_float", 0f)
+            // Extract color temperature raw value (0–24)
+            val raw = (brightnessFloat * 10000f).roundToInt() % 100
+            raw.coerceIn(MIN, colorTempMax)
+        } catch (e: Exception) {
+            Log.w(TAG, "getWarmth failed: ${e.message}")
+            MIN
+        }
+    }
+
+    // ── Write ─────────────────────────────────────────────────────────────────
+
+    override fun setBrightness(activity: Activity, brightness: Int) {
+        val clamped = brightness.coerceIn(MIN, BRIGHTNESS_RAW_MAX)
+        val warmth = getWarmth(activity)
+        writeCombinedFloat(activity, clamped, warmth)
+    }
+
+    override fun setWarmth(activity: Activity, warmth: Int) {
+        val clamped = warmth.coerceIn(MIN, colorTempMax)
+        val brightness = getBrightness(activity)
+        writeCombinedFloat(activity, brightness, clamped)
+    }
+
+    private fun writeCombinedFloat(activity: Activity, brightness: Int, warmth: Int) {
+        try {
+            val value = (brightness / 100.0f) + (warmth / 10000.0f)
+            val rounded = (value * 10000f).roundToInt() / 10000f
+            Settings.System.putFloat(
+                activity.contentResolver, "screen_brightness_float", rounded)
+            Log.d(TAG, "write brightness=$brightness warmth=$warmth → float=$rounded")
+        } catch (e: SecurityException) {
+            Log.e(TAG, "WRITE_SETTINGS permission not granted: ${e.message}")
+        } catch (e: Exception) {
+            Log.e(TAG, "setBrightness failed: ${e.message}")
+        }
+    }
+
+    // ── Range ─────────────────────────────────────────────────────────────────
+
+    override fun getMinBrightness(): Int = MIN
+    override fun getMinWarmth(): Int = MIN
+    override fun getMaxBrightness(): Int = BRIGHTNESS_RAW_MAX
+    override fun getMaxWarmth(): Int = colorTempMax
+
+    override fun enableFrontlightSwitch(activity: Activity): Int {
+        return 1
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun getMaxColorTemp(): Int {
+        return try {
+            android.os.PowerManager::class.java
+                .getField("BRIGHTNESS_COLORTEMP_MAX")
+                .get(null) as Int
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not read BRIGHTNESS_COLORTEMP_MAX, using default $DEFAULT_COLORTEMP_MAX", e)
+            DEFAULT_COLORTEMP_MAX
+        }
+    }
+}


### PR DESCRIPTION
 Add full EPD refresh and brightness/warmth control for Lenovo Smart(Global version)/Yoga(China version) Paper.

  - EPD: full refresh via EinkManager.screenRefresh() reflection
  - Lights: brightness (0–99) and color temperature (0–24) encoded
    into Settings.System screen_brightness_float
  - Device detected by Brand=lenovo, Model=lenovo sp101fu
  
  Based on reverse-engineering of Lenovo's system EinkManager service
  and QuickSettingManager encoding scheme.

  Note: This patch has not been tested by building and running it as
  part of KOReader itself. However, the underlying EPD and lights
  control logic was verified with a standalone [test app](https://github.com/4285f4/smartpaper-eink-test).

  The test was performed on a Chinese-version device flashed with
  global firmware. The key difference between the two firmware
  variants:

  - Chinese version: only allows installing apps from the built-in
    app store and has ADB access locked down.
  - Global version: enables ADB by default and allows installation
    of third-party applications.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/599)
<!-- Reviewable:end -->
