### PR TITLE
Add support for the Onyx Boox Tab X C

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -143,6 +143,7 @@ object DeviceInfo {
         ONYX_TAB_ULTRA,
         ONYX_TAB_ULTRA_C,
         ONYX_TAB_ULTRA_C_PRO,
+        ONYX_TAB_X_C,
         PUBU_PUBOOK,
         RIDI_PAPER_3,
         SONY_CP1,
@@ -638,6 +639,10 @@ object DeviceInfo {
             BRAND == "onyx" && PRODUCT == "tabultracpro"
             -> Id.ONYX_TAB_ULTRA_C_PRO
 
+            // Onyx Tab X C
+            BRAND == "onyx" && PRODUCT == "tabxc" && DEVICE == "tabxc"
+            -> Id.ONYX_TAB_X_C
+
             // Pubu Pubook
             MANUFACTURER == STR_ROCKCHIP && BRAND == STR_ROCKCHIP && MODEL == "pubook" && DEVICE == "pubook" && HARDWARE == "rk30board"
             -> Id.PUBU_PUBOOK
@@ -757,6 +762,7 @@ object DeviceInfo {
             Id.ONYX_PALMA2_PRO,
             Id.ONYX_TAB_ULTRA_C,
             Id.ONYX_TAB_ULTRA_C_PRO,
+            Id.ONYX_TAB_X_C,
             -> true else -> false
         }
     }

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -152,6 +152,7 @@ object EPDFactory {
                 DeviceInfo.Id.ONYX_TAB_ULTRA,
                 DeviceInfo.Id.ONYX_TAB_ULTRA_C,
                 DeviceInfo.Id.ONYX_TAB_ULTRA_C_PRO,
+                DeviceInfo.Id.ONYX_TAB_X_C,
                 DeviceInfo.Id.STORYTEL_READER2,
                 -> {
                     logController("Onyx/Qualcomm")

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -30,6 +30,7 @@ object LightsFactory {
                 DeviceInfo.Id.ONYX_POKE6,
                 DeviceInfo.Id.ONYX_TAB_ULTRA_C,
                 DeviceInfo.Id.ONYX_TAB_ULTRA_C_PRO,
+                DeviceInfo.Id.ONYX_TAB_X_C,
                 -> {
                     logController("Onyx Adb")
                     OnyxAdbLightsController()


### PR DESCRIPTION
I tested both the frontlight control and the e-ink refresh successfully with the compatibility tester. 
I also built my own koreader apk based on current master branch, signed it and tested it on my Boox Tab X C. All working fine.

Content of test.log:

```
Device info:
Manufacturer: onyx
Brand: onyx
Model: tabxc
Device: tabxc
Product: tabxc
Hardware: qcom
Platform: msmnile


Test logs:
07-16 09:26:04.988 I/DeviceInfo(24898): MANUFACTURER: onyx
07-16 09:26:04.988 I/DeviceInfo(24898): BRAND       : onyx
07-16 09:26:04.988 I/DeviceInfo(24898): MODEL       : tabxc
07-16 09:26:04.988 I/DeviceInfo(24898): DEVICE      : tabxc
07-16 09:26:04.988 I/DeviceInfo(24898): PRODUCT     : tabxc
07-16 09:26:04.988 I/DeviceInfo(24898): HARDWARE    : qcom
07-16 09:26:04.989 I/Lights  (24898): Using Generic driver
07-16 09:26:04.994 E/EPD     (24898): java.lang.ClassNotFoundException: android.view.View$EINK_MODE
07-16 09:26:04.995 I/TolinoNtxController(24898): loading libioctl
07-16 09:26:04.996 I/TolinoNtxNoWarmthController(24898): loading libioctl
07-16 09:26:04.996 I/TolinoB300Controller(24898): loading libioctl
07-16 09:26:05.003 D/CompatibilityChangeReporter(24898): Compat change id reported: 237531167; UID 10151; state: DISABLED
07-16 09:26:05.006 W/Parcel  (24898): Expecting binder but got null!
07-16 09:26:05.010 V/ActivityThread(24898): reportTopResumedActivityChanged - > onActivityTopResumed
07-16 09:26:05.086 I/AdrenoGLES-0(24898): QUALCOMM build                   : 3d405fc93a, I090495d0da
07-16 09:26:05.086 I/AdrenoGLES-0(24898): Build Date                       : 06/14/23
07-16 09:26:05.086 I/AdrenoGLES-0(24898): OpenGL ES Shader Compiler Version: EV031.32.02.17
07-16 09:26:05.086 I/AdrenoGLES-0(24898): Local Branch                     :
07-16 09:26:05.086 I/AdrenoGLES-0(24898): Remote Branch                    : quic/gfx-adreno.lnx.1.0.r99-rel
07-16 09:26:05.086 I/AdrenoGLES-0(24898): Remote Branch                    : NONE
07-16 09:26:05.086 I/AdrenoGLES-0(24898): Reconstruct Branch               : NOTHING
07-16 09:26:05.086 I/AdrenoGLES-0(24898): Build Config                     : S P 10.0.7 AArch64
07-16 09:26:05.086 I/AdrenoGLES-0(24898): Driver Path                      : /vendor/lib64/egl/libGLESv2_adreno.so
07-16 09:26:05.090 I/AdrenoGLES-0(24898): PFP: 0x016ee203, ME: 0x00000000
07-16 09:26:05.101 E/OpenGLRenderer(24898): Unable to match the desired swap behavior.
07-16 09:26:08.069 I/TestActivity(24898): running epd test: Onyx/Qualcomm
07-16 09:26:08.070 E/EPD     (24898): java.lang.NoSuchMethodException: android.view.View.setWaveformAndScheme [int, int, int]
07-16 09:26:08.123 I/EPD     (24898): requested eink refresh, type: 98 x:0 y:0 w:2400 h:3200
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/600)
<!-- Reviewable:end -->
