### PR TITLE
Set FONTDIR so MuPDF can find its fallback fonts

### DIFF
--- a/assets/android.lua
+++ b/assets/android.lua
@@ -2731,15 +2731,12 @@ local function run(android_app_state)
         error(err)
     end
 
-    -- MuPDF resolves its built-in fallback fonts (eg. noto/NotoSans-Regular.ttf, used to
-    -- render the HTML dictionary popup) via a path relative to $FONTDIR, defaulting to
-    -- "./fonts" (see base/thirdparty/mupdf/external_fonts.patch) when unset. That default
-    -- is relative to the process' cwd, which we just changed to the app's private data
-    -- directory above -- not to the koreader home directory on external storage where the
-    -- actual "fonts" directory lives. Point FONTDIR there explicitly so MuPDF can always
-    -- find its fonts regardless of the process' cwd.
-    local koreader_home = os.getenv("KO_HOME") or (android.getExternalStoragePath() .. "/koreader")
-    C.setenv("FONTDIR", koreader_home .. "/fonts", 1)
+    -- MuPDF looks up its fallback fonts (eg. noto/NotoSans-Regular.ttf, used to render the
+    -- HTML dictionary popup) relative to $FONTDIR, defaulting to "./fonts" when unset (see
+    -- base/thirdparty/mupdf/external_fonts.patch). Point it at android.dir/fonts, where
+    -- Assets.kt's bootstrap() extracts the app's bundled "fonts" dir -- guaranteed present,
+    -- no external-storage access required.
+    C.setenv("FONTDIR", android.dir .. "/fonts", 1)
 
     dofile(android.dir.."/llapp_main.lua")
 end

--- a/assets/android.lua
+++ b/assets/android.lua
@@ -31,6 +31,7 @@ local ffi = require("ffi")
 ffi.cdef[[
 // posix:
 int chdir(const char *path);
+int setenv(const char *name, const char *value, int overwrite);
 // logging:
 int __android_log_print(int prio, const char *tag,  const char *fmt, ...);
 typedef enum android_LogPriority {
@@ -2729,6 +2730,16 @@ local function run(android_app_state)
         android.LOGE(err)
         error(err)
     end
+
+    -- MuPDF resolves its built-in fallback fonts (eg. noto/NotoSans-Regular.ttf, used to
+    -- render the HTML dictionary popup) via a path relative to $FONTDIR, defaulting to
+    -- "./fonts" (see base/thirdparty/mupdf/external_fonts.patch) when unset. That default
+    -- is relative to the process' cwd, which we just changed to the app's private data
+    -- directory above -- not to the koreader home directory on external storage where the
+    -- actual "fonts" directory lives. Point FONTDIR there explicitly so MuPDF can always
+    -- find its fonts regardless of the process' cwd.
+    local koreader_home = os.getenv("KO_HOME") or (android.getExternalStoragePath() .. "/koreader")
+    C.setenv("FONTDIR", koreader_home .. "/fonts", 1)
 
     dofile(android.dir.."/llapp_main.lua")
 end


### PR DESCRIPTION
Companion fix to koreader/koreader#15737 (which fixes koreader/koreader#15736).

# PR (koreader/android-luajit-launcher) — Set FONTDIR so MuPDF can find its fallback fonts

**Branch:** `fix/fontdir-relative-path-crash` (base: `master`)
**Commit:** `0eccce26c79d81f0eb32c33997bb2dc4ab232743`

## Title

Set FONTDIR so MuPDF can find its fallback fonts

## Summary

- MuPDF resolves its built-in fallback fonts (e.g. `noto/NotoSans-Regular.ttf`,
  used whenever it renders HTML content — notably KOReader's HTML dictionary
  popup) via a path relative to the `$FONTDIR` environment variable,
  defaulting to `./fonts` when unset (see
  `base/thirdparty/mupdf/external_fonts.patch`, `get_font_file()`, in the
  koreader/koreader repo).
- That default is relative to the process' **current working directory**,
  which `assets/android.lua` `chdir()`s to the app's private data directory
  (`getFilesDir()`) very early at startup — not to the koreader home
  directory on external storage (`/sdcard/koreader` by default) where the
  actual `fonts` directory is extracted/lives.
- On devices without legacy full external-storage access (i.e. most modern
  Android installs, including this one — `MANAGE_EXTERNAL_STORAGE` was not
  granted), this makes **every** MuPDF HTML-fallback-font lookup fail with
  `cannot open ./fonts/noto/NotoSans-Regular.ttf: No such file or directory`,
  which in turn crashes koreader (see companion PR in koreader/koreader:
  `DictQuickLookup:update()` propagates this as an unhandled error on
  Android).
- Fix: explicitly `setenv("FONTDIR", ...)` right after the existing `chdir()`
  call, pointing at `$KO_HOME/fonts` (respecting `KO_HOME` if set, exactly
  like `datastorage.lua`'s `getDataDir()` does), before `llapp_main.lua` — and
  therefore any MuPDF usage — ever runs.

## Test plan

- [x] Built `arm64Rocks` debug APK against this branch + the koreader.git
      companion fix, installed on-device (Android 14, bigme hibreak).
- [x] Confirmed a previously-crashing HTML dictionary entry (Wiktionary FR-FR)
      now renders with correct formatting (bold/italic/lists), proving MuPDF
      resolves the fallback font correctly.
- [x] No regression to the existing `chdir()` behavior (app still starts,
      reads/writes `/sdcard/koreader` as before).

## Notes for reviewers

`FONTDIR` is only consulted by the `NOBUILTINFONT` build of MuPDF (see
`koreader/koreader`'s `base/thirdparty/mupdf/CMakeLists.txt`, which does
define `-DNOBUILTINFONT`), which is what koreader's Android build actually
uses — so this isn't dead configuration on this platform.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/601)
<!-- Reviewable:end -->
