### PR TITLE
Sunxi: added binary A2 for fast refresh and other constants

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/epd/SunxiEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/SunxiEPDController.kt
@@ -25,22 +25,8 @@ class SunxiEPDController : EPDInterface {
         const val SUNXI_EINK_GLR16_MODE = 0x40
         const val SUNXI_EINK_GLD16_MODE = 0x80
         const val SUNXI_EINK_GU16_MODE = 0x84
-        const val SUNXI_EINK_GCK16_MODE = 0x90
-        const val SUNXI_EINK_GLK16_MODE = 0x94
-        const val SUNXI_EINK_CLEAR_MODE = 0x88
         const val SUNXI_EINK_RUBBER_MODE = 0x88
-        const val SUNXI_EINK_GC4L_MODE = 0x8C
-        const val SUNXI_EINK_GCC16_MODE = 0xA0
-        const val SUNXI_EINK_PARTIAL_MODE = 0x400
         const val SUNXI_EINK_AUTO_MODE = 0x8000
-        const val SUNXI_EINK_NEGATIVE_MODE = 0x10000
-        const val SUNXI_EINK_REGAL_MODE = 0x80000
-        const val SUNXI_EINK_GAMMA_CORRECT = 0x200000
-        const val SUNXI_EINK_MONOCHROME = 0x400000
-        const val SUNXI_EINK_DITHERING_Y1 = 0x01800000
-        const val SUNXI_EINK_DITHERING_Y4 = 0x02800000
-        const val SUNXI_EINK_DITHERING_SIMPLE = 0x04800000
-        const val SUNXI_EINK_DITHERING_NTX_Y1 = 0x08800000
         const val SUNXI_EINK_NO_MERGE = Integer.MIN_VALUE // 0x80000000
 
         const val SUNXI_EINK_DEFAULT_MODE = SUNXI_EINK_GU16_MODE

--- a/app/src/main/java/org/koreader/launcher/device/epd/SunxiEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/SunxiEPDController.kt
@@ -16,10 +16,35 @@ class SunxiEPDController : EPDInterface {
     companion object {
         private const val TAG = "EPD"
 
+        const val SUNXI_EINK_INIT_MODE = 0x01
+        const val SUNXI_EINK_DU_MODE = 0x02
         const val SUNXI_EINK_GC16_MODE = 0x04
+        const val SUNXI_EINK_GC4_MODE = 0x08
+        const val SUNXI_EINK_A2_MODE = 0x10
+        const val SUNXI_EINK_GL16_MODE = 0x20
         const val SUNXI_EINK_GLR16_MODE = 0x40
+        const val SUNXI_EINK_GLD16_MODE = 0x80
         const val SUNXI_EINK_GU16_MODE = 0x84
+        const val SUNXI_EINK_GCK16_MODE = 0x90
+        const val SUNXI_EINK_GLK16_MODE = 0x94
+        const val SUNXI_EINK_CLEAR_MODE = 0x88
+        const val SUNXI_EINK_RUBBER_MODE = 0x88
+        const val SUNXI_EINK_GC4L_MODE = 0x8C
+        const val SUNXI_EINK_GCC16_MODE = 0xA0
+        const val SUNXI_EINK_PARTIAL_MODE = 0x400
+        const val SUNXI_EINK_AUTO_MODE = 0x8000
+        const val SUNXI_EINK_NEGATIVE_MODE = 0x10000
+        const val SUNXI_EINK_REGAL_MODE = 0x80000
+        const val SUNXI_EINK_GAMMA_CORRECT = 0x200000
+        const val SUNXI_EINK_MONOCHROME = 0x400000
+        const val SUNXI_EINK_DITHERING_Y1 = 0x01800000
+        const val SUNXI_EINK_DITHERING_Y4 = 0x02800000
+        const val SUNXI_EINK_DITHERING_SIMPLE = 0x04800000
+        const val SUNXI_EINK_DITHERING_NTX_Y1 = 0x08800000
         const val SUNXI_EINK_NO_MERGE = Integer.MIN_VALUE // 0x80000000
+
+        const val SUNXI_EINK_DEFAULT_MODE = SUNXI_EINK_GU16_MODE
+
         private const val REVERT_DELAY_MS = 150L
 
         @Volatile private var reflectionReady = false
@@ -64,7 +89,7 @@ class SunxiEPDController : EPDInterface {
     override fun getWaveformPartial(): Int = SUNXI_EINK_GU16_MODE
     override fun getWaveformFullUi(): Int = SUNXI_EINK_NO_MERGE + SUNXI_EINK_GLR16_MODE
     override fun getWaveformPartialUi(): Int = SUNXI_EINK_GU16_MODE
-    override fun getWaveformFast(): Int = SUNXI_EINK_GU16_MODE
+    override fun getWaveformFast(): Int = SUNXI_EINK_A2_MODE
 
     override fun getWaveformDelay(): Int = 0
     override fun getWaveformDelayUi(): Int = 0
@@ -80,11 +105,12 @@ class SunxiEPDController : EPDInterface {
         val rawMode = when {
             epdMode == "EPD_FULL" || mode == getWaveformFull() -> SUNXI_EINK_GC16_MODE
             mode == getWaveformFullUi() -> SUNXI_EINK_GLR16_MODE
-            else -> SUNXI_EINK_GU16_MODE
+            mode == getWaveformFast() -> SUNXI_EINK_A2_MODE
+            else -> SUNXI_EINK_DEFAULT_MODE
         }
 
         setRefreshMode(targetView, rawMode)
-        if (rawMode != SUNXI_EINK_GU16_MODE) {
+        if (rawMode != SUNXI_EINK_DEFAULT_MODE) {
             // setRefreshMode is persistent, so revert to partial mode shortly after the
             // refresh to avoid leaving the display in a flashing mode.
             revertRunnable?.let { runnable ->
@@ -92,7 +118,7 @@ class SunxiEPDController : EPDInterface {
             }
             revertView = targetView
             val runnable = Runnable {
-                setRefreshMode(targetView, SUNXI_EINK_GU16_MODE)
+                setRefreshMode(targetView, SUNXI_EINK_DEFAULT_MODE)
             }
             revertRunnable = runnable
             targetView.postDelayed(runnable, REVERT_DELAY_MS)


### PR DESCRIPTION
Sorry for the fuss x) I've run some adb logging and found the actual constants used on the device and also found that faster binary refresh exists. So I replaced partial-grey GU16 with this binary A2. This A2 is apparently used for a drawing app from the vendor so it might be useful to have actually fast refresh in KOReader as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/603)
<!-- Reviewable:end -->
