### PR TITLE
Sunxi: full refresh on every page after launch

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/epd/SunxiEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/SunxiEPDController.kt
@@ -30,6 +30,7 @@ class SunxiEPDController : EPDInterface {
         const val SUNXI_EINK_NO_MERGE = Integer.MIN_VALUE // 0x80000000
 
         const val SUNXI_EINK_DEFAULT_MODE = SUNXI_EINK_GU16_MODE
+        const val SUNXI_EINK_RESET_MODE = 0
 
         private const val REVERT_DELAY_MS = 150L
 
@@ -104,6 +105,7 @@ class SunxiEPDController : EPDInterface {
             }
             revertView = targetView
             val runnable = Runnable {
+                setRefreshMode(targetView, SUNXI_EINK_RESET_MODE)
                 setRefreshMode(targetView, SUNXI_EINK_DEFAULT_MODE)
             }
             revertRunnable = runnable

--- a/app/src/main/java/org/koreader/launcher/device/epd/SunxiEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/SunxiEPDController.kt
@@ -10,8 +10,8 @@ import org.koreader.launcher.device.EPDInterface
 
 class SunxiEPDController : EPDInterface {
 
-    private var revertRunnable: Runnable? = null
-    private var revertView: View? = null
+    private var resetRunnable: Runnable? = null
+    private var resetView: View? = null
 
     companion object {
         private const val TAG = "EPD"
@@ -29,10 +29,8 @@ class SunxiEPDController : EPDInterface {
         const val SUNXI_EINK_AUTO_MODE = 0x8000
         const val SUNXI_EINK_NO_MERGE = Integer.MIN_VALUE // 0x80000000
 
-        const val SUNXI_EINK_DEFAULT_MODE = SUNXI_EINK_GU16_MODE
         const val SUNXI_EINK_RESET_MODE = 0
-
-        private const val REVERT_DELAY_MS = 150L
+        private const val RESET_DELAY_MS = 150L
 
         @Volatile private var reflectionReady = false
         private var getViewRootImplFn: Method? = null
@@ -69,7 +67,6 @@ class SunxiEPDController : EPDInterface {
     }
 
     override fun getPlatform(): String = "sunxi"
-
     override fun getMode(): String = "all"
 
     override fun getWaveformFull(): Int = SUNXI_EINK_NO_MERGE + SUNXI_EINK_GC16_MODE
@@ -93,27 +90,25 @@ class SunxiEPDController : EPDInterface {
             epdMode == "EPD_FULL" || mode == getWaveformFull() -> SUNXI_EINK_GC16_MODE
             mode == getWaveformFullUi() -> SUNXI_EINK_GLR16_MODE
             mode == getWaveformFast() -> SUNXI_EINK_A2_MODE
-            else -> SUNXI_EINK_DEFAULT_MODE
+            else -> SUNXI_EINK_RESET_MODE
         }
 
         setRefreshMode(targetView, rawMode)
-        if (rawMode != SUNXI_EINK_DEFAULT_MODE) {
-            // setRefreshMode is persistent, so revert to partial mode shortly after the
+        if (rawMode != SUNXI_EINK_RESET_MODE) {
+            // setRefreshMode is persistent, so reset to 0-mode shortly after the
             // refresh to avoid leaving the display in a flashing mode.
-            revertRunnable?.let { runnable ->
-                revertView?.removeCallbacks(runnable)
+            resetRunnable?.let { runnable ->
+                resetView?.removeCallbacks(runnable)
             }
-            revertView = targetView
+            resetView = targetView
             val runnable = Runnable {
                 setRefreshMode(targetView, SUNXI_EINK_RESET_MODE)
-                setRefreshMode(targetView, SUNXI_EINK_DEFAULT_MODE)
             }
-            revertRunnable = runnable
-            targetView.postDelayed(runnable, REVERT_DELAY_MS)
+            resetRunnable = runnable
+            targetView.postDelayed(runnable, RESET_DELAY_MS)
         }
     }
 
     override fun resume() {}
-
     override fun pause() {}
 }


### PR DESCRIPTION
When I launch KOReader, I see full refresh on every page until the page it should perform full refresh on anyway (I have refresh rate set to 6 pages, and up to the 6th page every one of them has full refresh, but starting with 7th refresh works correctly, that is full refresh happens only once per 6 pages, other pages have partial refresh). Opening filebrowser/library also heals this, so I guess the mode self-heals on first full refresh _after_ boot regardless of what triggers it.

I tried to figure out what the hell, but apparently the device hates the GU16 mode as default (maybe because GU16 (0x84) overlaps bits with full refresh GC16 (0x04), I don't know). So after testing I found that reset to 0 is probably the best fix since I have seen three bugs with various resets and 0-mode seems to fix all three:
1. Full refresh on time update in Compatibility Test window
2. Full refresh on every page turn even though refresh rate is not 1
3. Double full refresh after wake

I also tried immediate reset without the timer, but that would effectively disable full refresh of GC16, so the timer survives the changes...

P.S.: The new NookEmperor Controller doesn't work on this device although it looks like it should x)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/604)
<!-- Reviewable:end -->
