### PR TITLE
Fix EPD full refresh not working and add test entries for Lenovo Smart Paper

### DIFF
--- a/app/src/main/java/org/koreader/launcher/TestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/TestActivity.kt
@@ -18,9 +18,11 @@ import org.koreader.launcher.device.epd.NookEmperorEPDController
 import org.koreader.launcher.device.epd.OnyxEPDController
 import org.koreader.launcher.device.epd.RK3026EPDController
 import org.koreader.launcher.device.epd.RK3368EPDController
+import org.koreader.launcher.device.epd.LenovoSmartPaperEPDController
 import org.koreader.launcher.device.epd.RK3566EPDController
 import org.koreader.launcher.device.epd.SunxiEPDController
 import org.koreader.launcher.device.epd.TolinoEPDController
+import org.koreader.launcher.device.lights.LenovoSmartPaperLightsController
 import org.koreader.launcher.device.lights.OnyxAdbLightsController
 import org.koreader.launcher.device.lights.OnyxC67Controller
 import org.koreader.launcher.device.lights.OnyxColorController
@@ -69,6 +71,7 @@ class TestActivity: AppCompatActivity() {
 
         // EPD drivers
         epdMap["Freescale/NTX"] = TolinoEPDController()
+        epdMap["Lenovo Smart Paper"] = LenovoSmartPaperEPDController()
         epdMap["Nook GL4"] = NGL4EPDController()
         epdMap["Nook GL4 Plus"] = NookEmperorEPDController()
         epdMap["Onyx/Qualcomm"] = OnyxEPDController()
@@ -79,6 +82,7 @@ class TestActivity: AppCompatActivity() {
 
         // Lights drivers
         lightsMap["Boyue S62 Root"] = BoyueS62RootController()
+        lightsMap["Lenovo Smart Paper"] = LenovoSmartPaperLightsController()
         lightsMap["Onyx ADB (lights)"] = OnyxAdbLightsController()
         lightsMap["Onyx C67"] = OnyxC67Controller()
         lightsMap["Onyx Color"] = OnyxColorController()
@@ -165,6 +169,13 @@ class TestActivity: AppCompatActivity() {
         lightsMap[id]?.let { driver ->
             Log.i(tag, String.format("running lights test: %s", id))
 
+            if (id == "Lenovo Smart Paper") {
+                val tooltipText = "For $id, please grant the \"Modify system settings\" permission\n" +
+                    "in Android Settings before testing."
+                ToolTip.showTooltip(binding.root, tooltipText, this)
+                Log.i(tag, tooltipText)
+            }
+
             if (id == "Onyx ADB (lights)") {
                 val tooltipText = "For $id, please see the wiki to enable additional permissions:\n" +
                     "https://github.com/koreader/koreader/wiki/Android-tips-and-tricks#adb-stuff"
@@ -204,6 +215,7 @@ class TestActivity: AppCompatActivity() {
                         }
                     }
 
+                    "Lenovo Smart Paper",
                     "Rockchip RK3026",
                     "Rockchip RK3368",
                     "Rockchip RK3566" -> {

--- a/app/src/main/java/org/koreader/launcher/device/epd/LenovoSmartPaperEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/LenovoSmartPaperEPDController.kt
@@ -4,6 +4,12 @@ import android.annotation.SuppressLint
 import android.util.Log
 import android.view.View
 import org.koreader.launcher.device.EPDInterface
+import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController.Companion.EINK_MODE_FAST
+import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController.Companion.EINK_MODE_FULL
+import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController.Companion.EINK_MODE_FULL_UI
+import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController.Companion.EINK_MODE_PARTIAL
+import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController.Companion.EINK_MODE_PARTIAL_UI
+import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController.Companion.EINK_WAVEFORM_DELAY
 
 /* EPD Controller for Lenovo SmartPaper (RK3566).
  *
@@ -19,12 +25,6 @@ class LenovoSmartPaperEPDController : EPDInterface {
 
     companion object {
         private const val TAG = "EPD"
-
-        // Waveform value for full-screen refresh. Must match the EPD_FULL constant
-        // in MainActivity.einkUpdate() (value 1) so the refresh request is not
-        // discarded as "invalid". The actual waveform used by EinkManager is
-        // determined inside setEpdMode(), not by this constant.
-        private const val WAVEFORM_FULL = 1
     }
 
     override fun getPlatform(): String {
@@ -36,35 +36,35 @@ class LenovoSmartPaperEPDController : EPDInterface {
     }
 
     override fun getWaveformFull(): Int {
-        return WAVEFORM_FULL
+        return EINK_MODE_FULL
     }
 
     override fun getWaveformPartial(): Int {
-        return WAVEFORM_FULL
+        return EINK_MODE_PARTIAL
     }
 
     override fun getWaveformFullUi(): Int {
-        return WAVEFORM_FULL
+        return EINK_MODE_FULL_UI
     }
 
     override fun getWaveformPartialUi(): Int {
-        return WAVEFORM_FULL
+        return EINK_MODE_PARTIAL_UI
     }
 
     override fun getWaveformFast(): Int {
-        return WAVEFORM_FULL
+        return EINK_MODE_FAST
     }
 
     override fun getWaveformDelay(): Int {
-        return WAVEFORM_FULL
+        return EINK_WAVEFORM_DELAY
     }
 
     override fun getWaveformDelayUi(): Int {
-        return WAVEFORM_FULL
+        return EINK_WAVEFORM_DELAY
     }
 
     override fun getWaveformDelayFast(): Int {
-        return WAVEFORM_FULL
+        return EINK_WAVEFORM_DELAY
     }
 
     override fun needsView(): Boolean {
@@ -72,10 +72,11 @@ class LenovoSmartPaperEPDController : EPDInterface {
     }
 
     @SuppressLint("WrongConstant")
-    override fun setEpdMode(targetView: View,
-                            mode: Int, delay: Long,
-                            x: Int, y: Int, width: Int, height: Int, epdMode: String?)
-    {
+    override fun setEpdMode(
+        targetView: View,
+        mode: Int, delay: Long,
+        x: Int, y: Int, width: Int, height: Int, epdMode: String?
+    ) {
         try {
             val einkManagerClass = Class.forName("android.os.EinkManager")
             val einkManager: Any? = targetView.context.getSystemService("eink")
@@ -84,7 +85,8 @@ class LenovoSmartPaperEPDController : EPDInterface {
                 // Use screenRefresh(true, 1) — the only working full-refresh
                 // path on Lenovo devices. sendOneFullFrame() is blocked by SELinux.
                 val screenRefresh = einkManagerClass.getMethod(
-                    "screenRefresh", Boolean::class.javaPrimitiveType, Int::class.javaPrimitiveType)
+                    "screenRefresh", Boolean::class.javaPrimitiveType, Int::class.javaPrimitiveType
+                )
                 screenRefresh.invoke(einkManager, true, 1)
             } else {
                 Log.w(TAG, "EinkManager service not available")

--- a/app/src/main/java/org/koreader/launcher/device/epd/LenovoSmartPaperEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/LenovoSmartPaperEPDController.kt
@@ -1,30 +1,26 @@
+/* EPD Controller for Lenovo Smart Paper (RK3566).
+ * Tested on Lenovo Smart Paper. sendOneFullFrame() does not work on this device,
+ * so setEpdMode() uses screenRefresh(true, 1) for full refresh instead.
+ */
+
 package org.koreader.launcher.device.epd
 
-import android.annotation.SuppressLint
 import android.util.Log
 import android.view.View
 import org.koreader.launcher.device.EPDInterface
-import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController.Companion.EINK_MODE_FAST
-import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController.Companion.EINK_MODE_FULL
-import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController.Companion.EINK_MODE_FULL_UI
-import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController.Companion.EINK_MODE_PARTIAL
-import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController.Companion.EINK_MODE_PARTIAL_UI
-import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController.Companion.EINK_WAVEFORM_DELAY
+import org.koreader.launcher.device.epd.rockchip.RK35xxEPDController
 
-/* EPD Controller for Lenovo SmartPaper (RK3566).
- *
- * Uses the hidden system service android.os.EinkManager via reflection.
- * The service is obtained via Context.getSystemService("eink").
- *
- * Note: sendOneFullFrame() is blocked by SELinux on Lenovo devices,
- * so we use screenRefresh(true, 1) instead, which correctly triggers
- * a full-screen GC16 refresh (black/white flash to clear ghosting).
- */
-
-class LenovoSmartPaperEPDController : EPDInterface {
+class LenovoSmartPaperEPDController : RK35xxEPDController(), EPDInterface {
 
     companion object {
         private const val TAG = "EPD"
+
+        // RK3566 EPD waveform modes (see RK35xxEPDController)
+        private const val EPD_FULL = 2      // EPD_FULL_GC16
+        private const val EPD_FULL_GL16 = 3 // EPD_FULL_GL16 (Balanced)
+        private const val EPD_PART = 7      // EPD_PART_GC16
+        private const val EPD_A2 = 12       // EPD_A2 (fast refresh)
+        private const val EPD_DELAY = 0
     }
 
     override fun getPlatform(): String {
@@ -36,42 +32,41 @@ class LenovoSmartPaperEPDController : EPDInterface {
     }
 
     override fun getWaveformFull(): Int {
-        return EINK_MODE_FULL
+        return EPD_FULL
     }
 
     override fun getWaveformPartial(): Int {
-        return EINK_MODE_PARTIAL
+        return EPD_PART
     }
 
     override fun getWaveformFullUi(): Int {
-        return EINK_MODE_FULL_UI
+        return EPD_FULL_GL16
     }
 
     override fun getWaveformPartialUi(): Int {
-        return EINK_MODE_PARTIAL_UI
+        return EPD_PART
     }
 
     override fun getWaveformFast(): Int {
-        return EINK_MODE_FAST
+        return EPD_A2
     }
 
     override fun getWaveformDelay(): Int {
-        return EINK_WAVEFORM_DELAY
+        return EPD_DELAY
     }
 
     override fun getWaveformDelayUi(): Int {
-        return EINK_WAVEFORM_DELAY
+        return EPD_DELAY
     }
 
     override fun getWaveformDelayFast(): Int {
-        return EINK_WAVEFORM_DELAY
+        return EPD_DELAY
     }
 
     override fun needsView(): Boolean {
         return true
     }
 
-    @SuppressLint("WrongConstant")
     override fun setEpdMode(
         targetView: View,
         mode: Int, delay: Long,
@@ -82,8 +77,6 @@ class LenovoSmartPaperEPDController : EPDInterface {
             val einkManager: Any? = targetView.context.getSystemService("eink")
 
             if (einkManager != null) {
-                // Use screenRefresh(true, 1) — the only working full-refresh
-                // path on Lenovo devices. sendOneFullFrame() is blocked by SELinux.
                 val screenRefresh = einkManagerClass.getMethod(
                     "screenRefresh", Boolean::class.javaPrimitiveType, Int::class.javaPrimitiveType
                 )

--- a/app/src/main/java/org/koreader/launcher/device/epd/LenovoSmartPaperEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/LenovoSmartPaperEPDController.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.util.Log
 import android.view.View
 import org.koreader.launcher.device.EPDInterface
-import org.koreader.launcher.device.epd.rockchip.RK35xxEPDController.Companion.EPD_AUTO
 
 /* EPD Controller for Lenovo SmartPaper (RK3566).
  *
@@ -20,6 +19,12 @@ class LenovoSmartPaperEPDController : EPDInterface {
 
     companion object {
         private const val TAG = "EPD"
+
+        // Waveform value for full-screen refresh. Must match the EPD_FULL constant
+        // in MainActivity.einkUpdate() (value 1) so the refresh request is not
+        // discarded as "invalid". The actual waveform used by EinkManager is
+        // determined inside setEpdMode(), not by this constant.
+        private const val WAVEFORM_FULL = 1
     }
 
     override fun getPlatform(): String {
@@ -31,35 +36,35 @@ class LenovoSmartPaperEPDController : EPDInterface {
     }
 
     override fun getWaveformFull(): Int {
-        return EPD_AUTO
+        return WAVEFORM_FULL
     }
 
     override fun getWaveformPartial(): Int {
-        return EPD_AUTO
+        return WAVEFORM_FULL
     }
 
     override fun getWaveformFullUi(): Int {
-        return EPD_AUTO
+        return WAVEFORM_FULL
     }
 
     override fun getWaveformPartialUi(): Int {
-        return EPD_AUTO
+        return WAVEFORM_FULL
     }
 
     override fun getWaveformFast(): Int {
-        return EPD_AUTO
+        return WAVEFORM_FULL
     }
 
     override fun getWaveformDelay(): Int {
-        return EPD_AUTO
+        return WAVEFORM_FULL
     }
 
     override fun getWaveformDelayUi(): Int {
-        return EPD_AUTO
+        return WAVEFORM_FULL
     }
 
     override fun getWaveformDelayFast(): Int {
-        return EPD_AUTO
+        return WAVEFORM_FULL
     }
 
     override fun needsView(): Boolean {

--- a/app/src/main/java/org/koreader/launcher/device/epd/LenovoSmartPaperEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/LenovoSmartPaperEPDController.kt
@@ -8,19 +8,12 @@ package org.koreader.launcher.device.epd
 import android.util.Log
 import android.view.View
 import org.koreader.launcher.device.EPDInterface
-import org.koreader.launcher.device.epd.rockchip.RK35xxEPDController
+import org.koreader.launcher.device.epd.rockchip.RK33xxEPDController
 
-class LenovoSmartPaperEPDController : RK35xxEPDController(), EPDInterface {
+class LenovoSmartPaperEPDController : RK33xxEPDController(), EPDInterface {
 
     companion object {
         private const val TAG = "EPD"
-
-        // RK3566 EPD waveform modes (see RK35xxEPDController)
-        private const val EPD_FULL = 2      // EPD_FULL_GC16
-        private const val EPD_FULL_GL16 = 3 // EPD_FULL_GL16 (Balanced)
-        private const val EPD_PART = 7      // EPD_PART_GC16
-        private const val EPD_A2 = 12       // EPD_A2 (fast refresh)
-        private const val EPD_DELAY = 0
     }
 
     override fun getPlatform(): String {
@@ -32,35 +25,35 @@ class LenovoSmartPaperEPDController : RK35xxEPDController(), EPDInterface {
     }
 
     override fun getWaveformFull(): Int {
-        return EPD_FULL
+        return EINK_MODE_FULL
     }
 
     override fun getWaveformPartial(): Int {
-        return EPD_PART
+        return EINK_MODE_PARTIAL
     }
 
     override fun getWaveformFullUi(): Int {
-        return EPD_FULL_GL16
+        return EINK_MODE_FULL_UI
     }
 
     override fun getWaveformPartialUi(): Int {
-        return EPD_PART
+        return EINK_MODE_PARTIAL_UI
     }
 
     override fun getWaveformFast(): Int {
-        return EPD_A2
+        return EINK_MODE_FAST
     }
 
     override fun getWaveformDelay(): Int {
-        return EPD_DELAY
+        return EINK_WAVEFORM_DELAY
     }
 
     override fun getWaveformDelayUi(): Int {
-        return EPD_DELAY
+        return EINK_WAVEFORM_DELAY
     }
 
     override fun getWaveformDelayFast(): Int {
-        return EPD_DELAY
+        return EINK_WAVEFORM_DELAY
     }
 
     override fun needsView(): Boolean {


### PR DESCRIPTION
Fix EPD full refresh not working and add test entries for Lenovo Smart Paper

- EPD: fix waveform constants returning EPD_AUTO (0) which caused einkUpdate(0) to be discarded as 'invalid' in MainActivity.einkUpdate(). Changed all getWaveform* methods to return WAVEFORM_FULL (1) so the refresh request reaches setEpdMode().
- TestActivity: add EPD and lights test entries for Lenovo Smart Paper, with a tooltip for lights reminding users to grant WRITE_SETTINGS permission.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/608)
<!-- Reviewable:end -->
