### PR TITLE
Add Onyx Boox Faraday 2 support and switch Poke3 to ADB lights

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -91,6 +91,7 @@ object DeviceInfo {
         ONYX_DARWIN7,
         ONYX_DARWIN9,
         ONYX_EDISON,
+        ONYX_FARADAY2,
         ONYX_FAUST3,
         ONYX_GALILEO2,
         ONYX_GO_103,
@@ -435,6 +436,10 @@ object DeviceInfo {
             MANUFACTURER == "onyx" && PRODUCT == "mc_faust3" && DEVICE == "mc_faust3"
             -> Id.ONYX_FAUST3
 
+            // Onyx Boox Faraday 2
+            MANUFACTURER == "onyx" && MODEL == "faraday2"
+            -> Id.ONYX_FARADAY2
+
             // Onyx Boox Galileo 2
             BRAND == "onyx" && MODEL == "galileo2"
             -> Id.ONYX_GALILEO2
@@ -762,6 +767,7 @@ object DeviceInfo {
             Id.MEEBOOK_M6C,
             Id.MOOINKPLUS2C,
             Id.NONE,
+            Id.ONYX_FARADAY2,
             Id.ONYX_GO_COLOR7,
             Id.ONYX_GO7GEN2,
             Id.ONYX_NOVA3_COLOR,

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -112,6 +112,7 @@ object EPDFactory {
                 DeviceInfo.Id.ONYX_DARWIN5,
                 DeviceInfo.Id.ONYX_DARWIN9,
                 DeviceInfo.Id.ONYX_EDISON,
+                DeviceInfo.Id.ONYX_FARADAY2,
                 DeviceInfo.Id.ONYX_GALILEO2,
                 DeviceInfo.Id.ONYX_GO_103,
                 DeviceInfo.Id.ONYX_GO6,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -67,7 +67,6 @@ object LightsFactory {
                 DeviceInfo.Id.ONYX_NOVA3,
                 DeviceInfo.Id.ONYX_NOVA_PRO,
                 DeviceInfo.Id.ONYX_POKE2,
-                DeviceInfo.Id.ONYX_POKE3,
                 DeviceInfo.Id.ONYX_POKE_PRO,
                 -> {
                     logController("Onyx/Qualcomm")
@@ -75,6 +74,7 @@ object LightsFactory {
                 }
                 DeviceInfo.Id.ONYX_DARWIN5,
                 DeviceInfo.Id.ONYX_DARWIN9,
+                DeviceInfo.Id.ONYX_FARADAY2,
                 DeviceInfo.Id.ONYX_LEAF2,
                 DeviceInfo.Id.ONYX_LIVINGSTONE3,
                 DeviceInfo.Id.ONYX_NOTE4,
@@ -84,6 +84,7 @@ object LightsFactory {
                 DeviceInfo.Id.ONYX_NOVA2,
                 DeviceInfo.Id.ONYX_NOVA_AIR_2,
                 DeviceInfo.Id.ONYX_NOVA_AIR_C,
+                DeviceInfo.Id.ONYX_POKE3,
                 DeviceInfo.Id.ONYX_POKE4,
                 DeviceInfo.Id.ONYX_POKE4LITE,
                 DeviceInfo.Id.ONYX_TAB_ULTRA,


### PR DESCRIPTION
Reason: new
Commercial name of product: Onyx Boox Faraday 2
Android version: 11
Driver(s) that work: Onyx ADB (lights)

Device info:
Manufacturer: onyx
Brand: onyx
Model: faraday2
Device: boox
Product: boox
Hardware: qcom
Platform: bengal



Reason: update
Onyx Boox poke 3
android version: 10
driver(s) that work:
Onyx ADB (lights)
Onyx/Qualcomm

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/609)
<!-- Reviewable:end -->
