### PR TITLE
Add Rockchip e-ink device support: RK357x EPD controller, RK3566 full-refresh fix, OBOOK R501, Flow Mini

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -63,6 +63,7 @@ object DeviceInfo {
         HYREAD_GAZE_NOTE,
         HYREAD_GAZE_NOTE_CC,
         HYREAD_MINI6,
+        IFLYTEK_CUBE2,
         IFLYTEK_R3,
         INKBOOK,
         INKBOOKFOCUS,
@@ -310,6 +311,10 @@ object DeviceInfo {
             // Hyread Mini 6
             MANUFACTURER == "hyread" && MODEL == "k06nu"
             -> Id.HYREAD_MINI6
+
+            // Iflytek ebook Cube 2
+            MANUFACTURER == "iflytek" && MODEL == "iflytek ebook cube2"
+            -> Id.IFLYTEK_CUBE2
 
             // Iflytek ebook r3
             MANUFACTURER == "iflytek" && MODEL == "iflytek ebook r3"

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -88,6 +88,7 @@ object DeviceInfo {
         NOOK_GLPLUS,
         OBOOK_P10D,
         OBOOK_P78D,
+        OBOOK_R501,
         ONYX_C67,
         ONYX_DARWIN5,
         ONYX_DARWIN7,
@@ -414,6 +415,10 @@ object DeviceInfo {
             // OBOOK P78D
             MANUFACTURER == STR_ROCKCHIP && PRODUCT == "rk3566_78d" && MODEL == "p78d"
             -> Id.OBOOK_P78D
+
+            // OBOOK R501
+            MANUFACTURER == STR_ROCKCHIP && MODEL == "obook" && DEVICE == "rk3566_r501"
+            -> Id.OBOOK_R501
 
             // Onyx C67
             MANUFACTURER == "onyx"

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -78,6 +78,7 @@ object DeviceInfo {
         MOBISCRIBE_WAVE,
         MOAAN_MIX7,
         MOAAN_W7,
+        MOAAN_FLOW_MINI,
         MOOINKPLUS2C,
         NABUK,
         NOOK,
@@ -369,6 +370,10 @@ object DeviceInfo {
             // Moaan W7
             BRAND == "allwinner" && MODEL == "epd103" && DEVICE == "virgo-perf1" && HARDWARE == "sun8iw15p1"
             -> Id.MOAAN_W7
+
+            // Moaan Flow Mini (迷你阅) — same sun8iw15p1 platform as W7
+            BRAND == "Allwinner" && MODEL == "FLOW.Mini" && DEVICE == "virgo-perf1" && HARDWARE == "sun8iw15p1"
+            -> Id.MOAAN_FLOW_MINI
 
             // Mooink Plus 2c
             BRAND == "allwinner" && MODEL == "mooink plus 2c"
@@ -753,6 +758,7 @@ object DeviceInfo {
         QUIRK_NO_LIGHTS = when (ID) {
             Id.LINFINY_ENOTE,
             Id.MOAAN_W7,
+            Id.MOAAN_FLOW_MINI,
             Id.ONYX_MAX,
             Id.ONYX_MAX2_PRO,
             Id.ONYX_NOTE,

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -372,7 +372,7 @@ object DeviceInfo {
             -> Id.MOAAN_W7
 
             // Moaan Flow Mini (迷你阅) — same sun8iw15p1 platform as W7
-            BRAND == "Allwinner" && MODEL == "FLOW.Mini" && DEVICE == "virgo-perf1" && HARDWARE == "sun8iw15p1"
+            BRAND == "allwinner" && MODEL == "flow.mini" && DEVICE == "virgo-perf1" && HARDWARE == "sun8iw15p1"
             -> Id.MOAAN_FLOW_MINI
 
             // Mooink Plus 2c

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -203,6 +203,7 @@ object EPDFactory {
                 }
                 
                 DeviceInfo.Id.MOAAN_W7,
+                DeviceInfo.Id.MOAAN_FLOW_MINI,
                 -> {
                     logController("Allwinner/Sunxi")
                     SunxiEPDController()

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -190,6 +190,7 @@ object EPDFactory {
                 DeviceInfo.Id.MOAAN_MIX7,
                 DeviceInfo.Id.OBOOK_P10D,
                 DeviceInfo.Id.OBOOK_P78D,
+                DeviceInfo.Id.OBOOK_R501,
                 DeviceInfo.Id.PUBU_PUBOOK,
                 DeviceInfo.Id.XIAOMI_READER,
                 -> {

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -15,6 +15,7 @@ import org.koreader.launcher.device.epd.OldTolinoEPDController
 import org.koreader.launcher.device.epd.NGL4EPDController
 import org.koreader.launcher.device.epd.NookEmperorEPDController
 import org.koreader.launcher.device.epd.RK3566EPDController
+import org.koreader.launcher.device.epd.RK357xEPDController
 import org.koreader.launcher.device.epd.SunxiEPDController
 
 import java.util.*
@@ -194,6 +195,12 @@ object EPDFactory {
                 -> {
                     logController("Rockchip RK3566")
                     RK3566EPDController()
+                }
+
+                DeviceInfo.Id.IFLYTEK_CUBE2,
+                -> {
+                    logController("Rockchip RK357x (EbookManager)")
+                    RK357xEPDController()
                 }
 
                 DeviceInfo.Id.LENOVO_SMARTPAPER,

--- a/app/src/main/java/org/koreader/launcher/device/epd/RK3566EPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/RK3566EPDController.kt
@@ -14,7 +14,10 @@ class RK3566EPDController : RK35xxEPDController(), EPDInterface {
     }
 
     override fun getWaveformFull(): Int {
-        return EPD_AUTO
+        // 1 = EPD_FULL in MainActivity.einkUpdate()'s mode mapping (1..4).
+        // EPD_AUTO(0) would be treated as "invalid" and dropped there,
+        // making every full-refresh request a no-op.
+        return 1
     }
 
     override fun getWaveformPartial(): Int {

--- a/app/src/main/java/org/koreader/launcher/device/epd/RK357xEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/RK357xEPDController.kt
@@ -1,0 +1,110 @@
+/* RK357x EPD Controller for Rockchip RK3572/RK3576 based devices
+ *
+ * Applies to devices sharing the RK3576 BSP (e.g. the iflytek ebook
+ * Cube 2 with its RK3572 SoC).
+ *
+ * Refresh channel (reversed from 讯飞阅读 cube2_release.1104.apk, 2026-08):
+ *   getSystemService("ebook") -> android.os.EbookManager -> sendOneFullFrame()
+ *
+ * The ROM's e-ink SDK (com.iflytek.eink.EinkManagerRK3576Impl) uses the
+ * "ebook" system service for EPD refresh (EbookManager.setRefreshMode(int) /
+ * sendOneFullFrame()), and the per-device config class
+ * DisplaySettingsCube2Delegate manages refresh quality via the
+ * persist.ebook.* property family.
+ *
+ * Full refresh only: partial refreshes are handled by the system's
+ * EinkCanvas (libeinkhwui.so, native Android 16 EPD composition),
+ * so this controller reports "full-only" mode, letting KOReader
+ * schedule full refreshes (FULL_REFRESH_COUNT / chapters / images)
+ * while the system keeps doing partial updates on its own.
+ *
+ * Package: org.koreader.launcher.device.epd
+ */
+
+package org.koreader.launcher.device.epd
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.Log
+import org.koreader.launcher.device.EPDInterface
+
+class RK357xEPDController : EPDInterface {
+
+    override fun getPlatform(): String {
+        return "rk357x"
+    }
+
+    override fun getMode(): String {
+        // Full refresh only: partial refreshes are handled by the
+        // system's EinkCanvas (native EPD composition).
+        return "full-only"
+    }
+
+    override fun getWaveformFull(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformPartial(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformFullUi(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformPartialUi(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformFast(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformDelay(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformDelayUi(): Int {
+        return EPD_AUTO
+    }
+
+    override fun getWaveformDelayFast(): Int {
+        return EPD_AUTO
+    }
+
+    override fun needsView(): Boolean {
+        return true
+    }
+
+    override fun setEpdMode(targetView: android.view.View,
+                            mode: Int, delay: Long,
+                            x: Int, y: Int, width: Int, height: Int, epdMode: String?) {
+        requestFullFrame(targetView.context)
+    }
+
+    override fun resume() {}
+    override fun pause() {}
+
+    companion object {
+        private const val TAG = "EPD"
+
+        const val EPD_AUTO = 0
+
+        @SuppressLint("WrongConstant")
+        fun requestFullFrame(context: Context): Boolean {
+            return try {
+                val ebookManagerClass = Class.forName("android.os.EbookManager")
+                val ebookManager: Any? = context.getSystemService("ebook")
+
+                val sendOneFullFrame = ebookManagerClass.getDeclaredMethod("sendOneFullFrame")
+                sendOneFullFrame.invoke(ebookManager)
+
+                true
+            } catch (e: Exception) {
+                Log.e(TAG, e.toString())
+                Log.e(TAG, e.stackTraceToString())
+                false
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for several Rockchip-based e-ink devices and fixes a full-refresh regression on the generic RK3566 controller.

## Commits
1. **device: add Moaan Flow Mini (sun8iw15p1) as Allwinner/Sunxi EPD device** — recognize the Moaan Flow Mini as an Allwinner/Sunxi EPD device.
2. **device: fix Flow Mini detection** — DeviceInfo lowercases all Build fields, so the detection must match `flow.mini` / `allwinner`.
3. **device: add RK357x EPD controller (iflytek ebook Cube 2, RK3572)** — new controller using the `EbookManager` system service (`sendOneFullFrame` via reflection), with DeviceInfo/EPDFactory wiring.
4. **fix(rk3566): getWaveformFull returns EPD_FULL(1)** — `getWaveformFull()` returned `EPD_AUTO` (0); `MainActivity.einkUpdate()` maps modes 1..4 and treats 0 as `invalid`, so full-refresh requests were silently dropped. Returning `EPD_FULL` (1) lets the refresh reach `setEpdMode()`. This affects **all RK3566 devices** (OBOK, InkPalm Plus, Moaan Mix 7, Xiaomi Reader, etc.). Note: #608 fixed the same root cause for `LenovoSmartPaperEPDController`; this fixes the generic `RK3566EPDController`.
5. **device: add OBOOK R501 (rk3566_r501) to OBOOK family** — previously fell through to `FakeEPDController`; now mapped to `RK3566EPDController` so e-ink full refresh works.

## Notes
- All changes are in `DeviceInfo.kt`, `EPDFactory.kt`, and the `device/epd/` controllers.
- Verified in a full Android (ARM/ARM64) build; OBOOK R501 full refresh tested on device.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/611)
<!-- Reviewable:end -->
