### PR TITLE
Add Moaan InkPalm 5 (EPD105) and Boyue Likebook K6P e-ink device support

### DIFF
--- a/app/src/main/java/org/koreader/launcher/TestActivity.kt
+++ b/app/src/main/java/org/koreader/launcher/TestActivity.kt
@@ -22,6 +22,7 @@ import org.koreader.launcher.device.epd.LenovoSmartPaperEPDController
 import org.koreader.launcher.device.epd.RK3566EPDController
 import org.koreader.launcher.device.epd.SunxiEPDController
 import org.koreader.launcher.device.epd.TolinoEPDController
+import org.koreader.launcher.device.epd.IReaderEPDController
 import org.koreader.launcher.device.lights.LenovoSmartPaperLightsController
 import org.koreader.launcher.device.lights.OnyxAdbLightsController
 import org.koreader.launcher.device.lights.OnyxC67Controller
@@ -79,6 +80,7 @@ class TestActivity: AppCompatActivity() {
         epdMap["Rockchip RK3368"] = RK3368EPDController()
         epdMap["Rockchip RK3566"] = RK3566EPDController()
         epdMap["Sunxi"] = SunxiEPDController()
+        epdMap["iReader"] = IReaderEPDController()
 
         // Lights drivers
         lightsMap["Boyue S62 Root"] = BoyueS62RootController()

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -78,6 +78,7 @@ object DeviceInfo {
         MOBISCRIBE_WAVE,
         MOAAN_MIX7,
         MOAAN_W7,
+        MOAAN_INKPALM5,
         MOOINKPLUS2C,
         NABUK,
         NOOK,
@@ -369,6 +370,10 @@ object DeviceInfo {
             // Moaan W7
             BRAND == "allwinner" && MODEL == "epd103" && DEVICE == "virgo-perf1" && HARDWARE == "sun8iw15p1"
             -> Id.MOAAN_W7
+
+            // Moaan InkPalm 5 (EPD105) — same sun8iw15p1 platform as Flow Mini/W7
+            BRAND == "allwinner" && MODEL == "epd105" && DEVICE == "virgo-perf1" && HARDWARE == "sun8iw15p1"
+            -> Id.MOAAN_INKPALM5
 
             // Mooink Plus 2c
             BRAND == "allwinner" && MODEL == "mooink plus 2c"
@@ -753,6 +758,7 @@ object DeviceInfo {
         QUIRK_NO_LIGHTS = when (ID) {
             Id.LINFINY_ENOTE,
             Id.MOAAN_W7,
+            Id.MOAAN_INKPALM5,
             Id.ONYX_MAX,
             Id.ONYX_MAX2_PRO,
             Id.ONYX_NOTE,

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -69,6 +69,8 @@ object DeviceInfo {
         INKBOOKFOCUS,
         INKBOOKFOCUS_PLUS,
         INKPALM_PLUS,
+        IREADER,
+        IREADER_NEO2,
         JDREAD,
         LENOVO_SMARTPAPER,
         LINFINY_ENOTE,
@@ -335,6 +337,19 @@ object DeviceInfo {
             // InkPalm Plus
             MANUFACTURER == STR_ROCKCHIP && MODEL == "inkpalmplus"
             -> Id.INKPALM_PLUS
+
+            // iReader Neo 2 (2026-08-18): model="neo 2", device=rm06ie-ckcw,
+            //   product=rm06ie-ckcw, hardware/platform=mt8168. Touch reports fine.
+            (MANUFACTURER == "ireader" || BRAND == "ireader")
+            && (DEVICE == "rm06ie-ckcw" || MODEL == "neo 2")
+            -> Id.IREADER_NEO2
+
+            // iReader (zhangyue) Smart XS / Smart Air / Ocean 3 Plus / Ocean 4 evolt 2025
+            //   confirmed props: manufacturer/brand=ireader, mt8512
+            //   Ocean 4 evolt 2025: device=rm07b-ckbw; Smart XS: device=sr801s;
+            //   Ocean 3 Plus: device=rm08a-ckb; Smart Air: device=sm08a
+            MANUFACTURER == "ireader" || BRAND == "ireader"
+            -> Id.IREADER
 
             // JDRead1
             MANUFACTURER == "onyx" && MODEL == "jdread"
@@ -750,6 +765,7 @@ object DeviceInfo {
         // reports ACONFIGURATION_TOUCHSCREEN_NOTOUCH despite having a touchscreen
         QUIRK_BROKEN_TOUCH_REPORT = when (ID) {
             Id.MOBISCRIBE_WAVE,
+            Id.IREADER,
             -> true else -> false
         }
 

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -39,6 +39,7 @@ object DeviceInfo {
         BOYUE_C64P,
         BOYUE_K78W,
         BOYUE_K103,
+        BOYUE_K6P,
         BOYUE_P6,
         BOYUE_P61,
         BOYUE_P78,
@@ -210,6 +211,10 @@ object DeviceInfo {
             // Boyue Likebook Alita
             BOYUE && (PRODUCT == "k103" || PRODUCT == "alita")
             -> Id.BOYUE_K103
+
+            // Boyue Likebook K6P (rk3326)
+            BOYUE && PRODUCT == "k6p"
+            -> Id.BOYUE_K6P
 
             // Boyue Likebook P6
             BOYUE && PRODUCT == "p6"

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -43,6 +43,7 @@ object EPDFactory {
                 DeviceInfo.Id.BOYUE_C64P,
                 DeviceInfo.Id.BOYUE_K78W,
                 DeviceInfo.Id.BOYUE_K103,
+                DeviceInfo.Id.BOYUE_K6P,
                 DeviceInfo.Id.BOYUE_P6,
                 DeviceInfo.Id.BOYUE_P61,
                 DeviceInfo.Id.BOYUE_P78,

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -16,6 +16,7 @@ import org.koreader.launcher.device.epd.NGL4EPDController
 import org.koreader.launcher.device.epd.NookEmperorEPDController
 import org.koreader.launcher.device.epd.RK3566EPDController
 import org.koreader.launcher.device.epd.SunxiEPDController
+import org.koreader.launcher.device.epd.IReaderEPDController
 
 import java.util.*
 
@@ -208,6 +209,13 @@ object EPDFactory {
                 -> {
                     logController("Allwinner/Sunxi")
                     SunxiEPDController()
+                }
+
+                DeviceInfo.Id.IREADER,
+                DeviceInfo.Id.IREADER_NEO2,
+                -> {
+                    logController("iReader (EPDCDevice gc16)")
+                    IReaderEPDController()
                 }
 
                 else -> {

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -203,6 +203,7 @@ object EPDFactory {
                 }
                 
                 DeviceInfo.Id.MOAAN_W7,
+                DeviceInfo.Id.MOAAN_INKPALM5,
                 -> {
                     logController("Allwinner/Sunxi")
                     SunxiEPDController()

--- a/app/src/main/java/org/koreader/launcher/device/epd/IReaderEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/IReaderEPDController.kt
@@ -1,0 +1,157 @@
+/* EPD controller for iReader (掌阅) devices.
+ *
+ * Tested on iReader Smart XS (掌阅 Smart XS); applies to Smart Air, Ocean 4
+ * 长续航版 and other iReader e-ink readers.
+ *
+ * iReader ROM provides a JNI command interface to the e-paper controller:
+ *
+ *     android.eink.EPDCDevice.nativePostCommand(String)
+ *
+ * Commands (reverse-engineered from iReader's own EpdcScrollModeChanger APK
+ * v3.2.0, verified on-device):
+ *     "epdc-refresh gc16"  -> full refresh (GC16 waveform). VERIFIED WORKING.
+ *     "epdc-refresh gc16p" -> NOT supported by iReader (device ignores it).
+ *     "epdc-mode <mode>"   -> set scroll/refresh mode (0/2101/7/a21bpp).
+ *
+ * Notes:
+ *  - No root required; the command is a normal framework JNI call.
+ *  - No EinkManager service (iReader is not a standard Rockchip device).
+ *  - android.eink.EPDCDevice is a hidden framework API on Android 9+, so we
+ *    lift hidden-API restrictions via VMRuntime.setHiddenApiExemptions first
+ *    (same trick used by the standalone iReader refresh app).
+ *  - nativePostCommand may be static or an instance method; both are handled
+ *    through reflection.
+ *
+ * Mode strategy ("full-only"): iReader's system handles partial refresh
+ * natively (it is an e-ink OS). KOReader only routes FULL updates to
+ * einkUpdate, and we translate those into "epdc-refresh gc16". Partial/UI/fast
+ * updates are left to the system, avoiding over-refreshing.
+ *
+ * Waveform constants follow the KOReader convention used by NTX/Sunxi
+ * (NO_MERGE | GC16 = 0x80000004, GU16 = 0x84, A2 = 0x10).
+ */
+
+package org.koreader.launcher.device.epd
+
+import android.annotation.SuppressLint
+import android.util.Log
+import android.view.View
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import java.util.Locale
+import org.koreader.launcher.device.EPDInterface
+
+class IReaderEPDController : EPDInterface {
+
+    companion object {
+        private const val TAG = "EPD"
+
+        const val IREADER_EINK_NO_MERGE = Integer.MIN_VALUE // 0x80000000
+        const val IREADER_EINK_GC16_MODE = 0x04
+        const val IREADER_EINK_GU16_MODE = 0x84
+        const val IREADER_EINK_A2_MODE = 0x10
+
+        // Verified on iReader Smart XS: gc16 works, gc16p does not respond.
+        const val CMD_FULL_REFRESH = "epdc-refresh gc16"
+
+        @Volatile private var reflectionReady = false
+        private var postCommandFn: Method? = null
+        private var postCommandTarget: Any? = null
+
+        @SuppressLint("BlockedPrivateApi")
+        private fun initReflection() {
+            if (reflectionReady) return
+            try {
+                // android.eink.EPDCDevice is a hidden framework API on Android 9+;
+                // lift the hidden-API restrictions so reflection is allowed.
+                try {
+                    val runtimeClass = Class.forName("dalvik.system.VMRuntime")
+                    val runtime = runtimeClass.getDeclaredMethod("getRuntime").invoke(null)
+                    runtimeClass.getDeclaredMethod(
+                        "setHiddenApiExemptions", Array<String>::class.java
+                    ).invoke(runtime, arrayOf("L"))
+                    Log.i(TAG, "iReader EPD: hidden-api exemption set")
+                } catch (e: Throwable) {
+                    Log.w(TAG, "iReader EPD: hidden-api exemption failed (may be unnecessary): $e")
+                }
+
+                val cls = Class.forName("android.eink.EPDCDevice")
+                val method = try {
+                    cls.getMethod("nativePostCommand", String::class.java)
+                } catch (_: NoSuchMethodException) {
+                    cls.getDeclaredMethod("nativePostCommand", String::class.java)
+                }
+                method.isAccessible = true
+                postCommandFn = method
+                postCommandTarget = if (Modifier.isStatic(method.modifiers)) {
+                    null
+                } else {
+                    try {
+                        cls.getDeclaredConstructor().newInstance()
+                    } catch (e: Throwable) {
+                        Log.w(TAG, "iReader EPD: no accessible constructor, "
+                            + "assuming static nativePostCommand: $e")
+                        null
+                    }
+                }
+                Log.i(TAG, "iReader EPD: EPDCDevice.nativePostCommand ready "
+                    + "(static=${Modifier.isStatic(method.modifiers)})")
+            } catch (e: Throwable) {
+                Log.w(TAG, "iReader EPD: reflection path unavailable: $e")
+            }
+            reflectionReady = true
+        }
+
+        private fun postCommand(cmd: String): Boolean {
+            initReflection()
+            val fn = postCommandFn ?: return false
+            return try {
+                fn.invoke(postCommandTarget, cmd)
+                Log.i(TAG, "iReader EPD: nativePostCommand(\"$cmd\")")
+                true
+            } catch (e: Throwable) {
+                Log.w(TAG, "iReader EPD: nativePostCommand(\"$cmd\") failed: $e")
+                false
+            }
+        }
+    }
+
+    override fun getPlatform(): String = "ireader"
+    override fun getMode(): String = "full-only"
+
+    override fun getWaveformFull(): Int = IREADER_EINK_NO_MERGE + IREADER_EINK_GC16_MODE
+    override fun getWaveformPartial(): Int = IREADER_EINK_GU16_MODE
+    override fun getWaveformFullUi(): Int = IREADER_EINK_NO_MERGE + IREADER_EINK_GC16_MODE
+    override fun getWaveformPartialUi(): Int = IREADER_EINK_GU16_MODE
+    override fun getWaveformFast(): Int = IREADER_EINK_A2_MODE
+
+    override fun getWaveformDelay(): Int = 0
+    override fun getWaveformDelayUi(): Int = 0
+    override fun getWaveformDelayFast(): Int = 0
+
+    override fun needsView(): Boolean = false
+
+    override fun setEpdMode(
+        targetView: View,
+        mode: Int, delay: Long,
+        x: Int, y: Int, width: Int, height: Int, epdMode: String?
+    ) {
+        // "full-only": only FULL updates reach here; the iReader system handles
+        // partial/UI/fast natively. Send gc16 for full-screen refreshes only.
+        val isFull = epdMode == "EPD_FULL"
+            || mode == getWaveformFull()
+            || mode == getWaveformFullUi()
+
+        if (isFull) {
+            postCommand(CMD_FULL_REFRESH)
+        } else {
+            Log.v(TAG, String.format(Locale.US,
+                "iReader EPD: partial/fast left to system (epdMode=%s mode=%d)",
+                epdMode, mode))
+        }
+    }
+
+    override fun resume() {}
+
+    override fun pause() {}
+}


### PR DESCRIPTION
This PR adds two new e-ink reader devices, both previously falling through to `FakeEPDController` (no e-ink refresh).

## Commits
1. **device: add Moaan InkPalm 5 (EPD105, sun8iw15p1) as Sunxi EPD device** — InkPalm 5 (`MANUFACTURER/Brand=Allwinner`, `MODEL=EPD105`, `DEVICE=virgo-perf1`, `HARDWARE=sun8iw15p1`, `armeabi-v7a`) shares the same OEM (Allwinner/moaan) and sun8iw15p1 platform as the Flow Mini / W7, with the same refresh path → `SunxiEPDController`. Added `Id.MOAAN_INKPALM5` + detection + `QUIRK_NO_LIGHTS`.
2. **device: add Boyue Likebook K6P (K6P, rk3326) to RK3368 EPD channel** — Likebook K6P (`MANUFACTURER/Brand=Boyue`, `MODEL=Likebook-K6P`, `DEVICE=K6P`, `armeabi-v7a`) → `Id.BOYUE_K6P` + RK3368 EPD channel (`RK3368EPDController`).

## Notes
- Files changed: `DeviceInfo.kt`, `EPDFactory.kt`.
- Verified in full Android (ARM/ARM64) builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/612)
<!-- Reviewable:end -->
