### PR TITLE
Onyx Boox Go 10.3 Gen II (Lumi)

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -95,6 +95,7 @@ object DeviceInfo {
         ONYX_FAUST3,
         ONYX_GALILEO2,
         ONYX_GO_103,
+        ONYX_GO_103_2,
         ONYX_GO_COLOR7,
         ONYX_GO6,
         ONYX_GO7,
@@ -447,6 +448,10 @@ object DeviceInfo {
             // Onyx Boox Go 10.3
             BRAND == "onyx" && MODEL == "go103"
             -> Id.ONYX_GO_103
+
+            // Onyx Boox Go 10.3 Gen II ("Lumi")
+            BRAND == "onyx" && MODEL == "go103_2lumi"
+            -> Id.ONYX_GO_103_2
 
             // Onyx Boox Go Color 7
             BRAND == "onyx" && MODEL == "gocolor7"

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -115,6 +115,7 @@ object EPDFactory {
                 DeviceInfo.Id.ONYX_FARADAY2,
                 DeviceInfo.Id.ONYX_GALILEO2,
                 DeviceInfo.Id.ONYX_GO_103,
+                DeviceInfo.Id.ONYX_GO_103_2,
                 DeviceInfo.Id.ONYX_GO6,
                 DeviceInfo.Id.ONYX_GO7,
                 DeviceInfo.Id.ONYX_GO7GEN2,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -20,6 +20,7 @@ object LightsFactory {
                     LenovoSmartPaperLightsController()
                 }
                 DeviceInfo.Id.ONYX_GALILEO2,
+                DeviceInfo.Id.ONYX_GO_103_2,
                 DeviceInfo.Id.ONYX_GO_COLOR7,
                 DeviceInfo.Id.ONYX_GO6,
                 DeviceInfo.Id.ONYX_GO7GEN2,


### PR DESCRIPTION
Adds device support for the Onyx Boox Go 10.3 Gen II (model `go103_2lumi`, brand `onyx`), a 10.3" B&W device on Android 15/Qualcomm.

Unlike the Gen I Go 10.3, the Gen II has a warm+cold CTM frontlight, so it is wired to `OnyxAdbLightsController`. Verified on hardware via the same `DeviceController` calls the controller uses: `checkCTM()` = true, max brightness/warmth 32/32, `setLightValue()` works. EPD goes through `OnyxEPDController` like the Gen I.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WECBEeokK3o1g3JPtyBPm

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/613)
<!-- Reviewable:end -->
