### PR TITLE
Onyx: support BOOX all refresh mode

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,4 +138,5 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
     implementation "androidx.legacy:legacy-support-v4:$androidx_supportv4_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_plugin_version"
+    implementation "org.lsposed.hiddenapibypass:hiddenapibypass:4.3"
 }

--- a/app/src/main/java/org/koreader/launcher/MainApp.kt
+++ b/app/src/main/java/org/koreader/launcher/MainApp.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.os.Build
 import android.os.Environment
 import android.os.StrictMode
+import org.lsposed.hiddenapibypass.HiddenApiBypass
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
@@ -92,6 +93,11 @@ class MainApp : Application() {
     @Suppress("DEPRECATION")
     override fun onCreate() {
         super.onCreate()
+        // Match the official BOOX demo: allow reflection of android.onyx APIs
+        // before the EPD controller resolves ViewUpdateHelper.debouncer.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            HiddenApiBypass.addHiddenApiExemptions("")
+        }
         assets_path = filesDir.absolutePath
         storage_path = Environment.getExternalStorageDirectory().absolutePath
         app_storage_path = String.format("%s%s%s", storage_path, File.separator, NAME.lowercase())

--- a/app/src/main/java/org/koreader/launcher/MainApp.kt
+++ b/app/src/main/java/org/koreader/launcher/MainApp.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.os.Build
 import android.os.Environment
 import android.os.StrictMode
-import org.lsposed.hiddenapibypass.HiddenApiBypass
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
@@ -93,11 +92,6 @@ class MainApp : Application() {
     @Suppress("DEPRECATION")
     override fun onCreate() {
         super.onCreate()
-        // Match the official BOOX demo: allow reflection of android.onyx APIs
-        // before the EPD controller resolves ViewUpdateHelper.debouncer.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            HiddenApiBypass.addHiddenApiExemptions("")
-        }
         assets_path = filesDir.absolutePath
         storage_path = Environment.getExternalStorageDirectory().absolutePath
         app_storage_path = String.format("%s%s%s", storage_path, File.separator, NAME.lowercase())

--- a/app/src/main/java/org/koreader/launcher/device/epd/OnyxEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/OnyxEPDController.kt
@@ -3,7 +3,6 @@
 package org.koreader.launcher.device.epd
 
 import android.util.Log
-import org.koreader.launcher.BuildConfig
 import org.koreader.launcher.device.EPDInterface
 import org.koreader.launcher.device.epd.qualcomm.QualcommEPDController
 
@@ -36,17 +35,20 @@ class OnyxEPDController : QualcommEPDController(), EPDInterface {
 
     private fun resumeBooxSystemRefresh(): Boolean {
         return try {
-            // The firmware restores the configured SF debouncer through this
-            // internal OnyxEpdBypassManager method, rather than fixed values.
-            val managerClass = Class.forName("android.onyx.optimization.OnyxEpdBypassManager")
-            val manager = managerClass.getMethod("sharedInstance").invoke(null)
-            managerClass.getDeclaredMethod("resumeSFDebouncer", String::class.java).apply {
-                isAccessible = true
-            }.invoke(manager, BuildConfig.APPLICATION_ID)
-            Log.i(TAG, "called OnyxEpdBypassManager.resumeSFDebouncer(${BuildConfig.APPLICATION_ID})")
+            // Ask BOOX's EInkHelper to reapply the current debouncer setting.
+            val helperClass = Class.forName("android.onyx.optimization.EInkHelper")
+            val duration = (helperClass.getMethod("getAnimationDuration")
+                .invoke(null) as Number).toInt()
+            if (duration < 0) {
+                Log.w(TAG, "BOOX E-Ink service is not ready")
+                return false
+            }
+            helperClass.getMethod("setAnimationDuration", Integer.TYPE)
+                .invoke(null, duration)
+            Log.i(TAG, "reapplied BOOX debouncer setting (animationDuration=$duration)")
             true
         } catch (e: Exception) {
-            Log.e(TAG, "OnyxEpdBypassManager.resumeSFDebouncer reflection failed: ${e.message}", e)
+            Log.e(TAG, "EInkHelper debouncer restore failed: ${e.message}", e)
             false
         }
     }

--- a/app/src/main/java/org/koreader/launcher/device/epd/OnyxEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/OnyxEPDController.kt
@@ -2,19 +2,39 @@
 
 package org.koreader.launcher.device.epd
 
+import android.os.Build
 import android.util.Log
 import org.koreader.launcher.device.EPDInterface
 import org.koreader.launcher.device.epd.qualcomm.QualcommEPDController
+import org.lsposed.hiddenapibypass.HiddenApiBypass
 
 class OnyxEPDController : QualcommEPDController(), EPDInterface {
 
     private companion object {
         const val TAG = "EPD"
+
+        private val hiddenApiAccess: Boolean by lazy {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+                true
+            } else {
+                runCatching {
+                    HiddenApiBypass.addHiddenApiExemptions(
+                        "Landroid/onyx/ViewUpdateHelper;",
+                        "Landroid/onyx/optimization/EInkHelper;",
+                    )
+                }.onFailure { error ->
+                    Log.e(TAG, "BOOX EPD hidden API exemption failed", error)
+                }.getOrDefault(false)
+            }
+        }
     }
 
     private var debouncerPrevented = false
 
     private fun preventBooxSystemRefresh(): Boolean {
+        if (!hiddenApiAccess) {
+            return false
+        }
         return try {
             // Official BOOX API: ViewUpdateHelper.debouncer(false, 0, 0, 0, 0).
             Class.forName("android.onyx.ViewUpdateHelper").getMethod(
@@ -34,6 +54,9 @@ class OnyxEPDController : QualcommEPDController(), EPDInterface {
     }
 
     private fun resumeBooxSystemRefresh(): Boolean {
+        if (!hiddenApiAccess) {
+            return false
+        }
         return try {
             // Ask BOOX's EInkHelper to reapply the current debouncer setting.
             val helperClass = Class.forName("android.onyx.optimization.EInkHelper")

--- a/app/src/main/java/org/koreader/launcher/device/epd/OnyxEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/OnyxEPDController.kt
@@ -2,17 +2,61 @@
 
 package org.koreader.launcher.device.epd
 
+import android.util.Log
+import org.koreader.launcher.BuildConfig
 import org.koreader.launcher.device.EPDInterface
 import org.koreader.launcher.device.epd.qualcomm.QualcommEPDController
 
 class OnyxEPDController : QualcommEPDController(), EPDInterface {
+
+    private companion object {
+        const val TAG = "EPD"
+    }
+
+    private var debouncerPrevented = false
+
+    private fun preventBooxSystemRefresh(): Boolean {
+        return try {
+            // Official BOOX API: ViewUpdateHelper.debouncer(false, 0, 0, 0, 0).
+            Class.forName("android.onyx.ViewUpdateHelper").getMethod(
+                "debouncer",
+                Boolean::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType
+            ).invoke(null, false, 0, 0, 0, 0)
+            Log.i(TAG, "called ViewUpdateHelper.debouncer(false, 0, 0, 0, 0)")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "ViewUpdateHelper.debouncer reflection failed: ${e.message}", e)
+            false
+        }
+    }
+
+    private fun resumeBooxSystemRefresh(): Boolean {
+        return try {
+            // The firmware restores the configured SF debouncer through this
+            // internal OnyxEpdBypassManager method, rather than fixed values.
+            val managerClass = Class.forName("android.onyx.optimization.OnyxEpdBypassManager")
+            val manager = managerClass.getMethod("sharedInstance").invoke(null)
+            managerClass.getDeclaredMethod("resumeSFDebouncer", String::class.java).apply {
+                isAccessible = true
+            }.invoke(manager, BuildConfig.APPLICATION_ID)
+            Log.i(TAG, "called OnyxEpdBypassManager.resumeSFDebouncer(${BuildConfig.APPLICATION_ID})")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "OnyxEpdBypassManager.resumeSFDebouncer reflection failed: ${e.message}", e)
+            false
+        }
+    }
 
     override fun getPlatform(): String {
         return "qualcomm"
     }
 
     override fun getMode(): String {
-        return "full-only"
+        return "all"
     }
 
     override fun getWaveformFull(): Int {
@@ -55,9 +99,21 @@ class OnyxEPDController : QualcommEPDController(), EPDInterface {
                             mode: Int, delay: Long,
                             x: Int, y: Int, width: Int, height: Int, epdMode: String?)
     {
-        requestEpdMode(targetView, mode, delay, x, y, width, height)
+        if (!debouncerPrevented) {
+            debouncerPrevented = preventBooxSystemRefresh()
+        }
+        // KOReader passes right/bottom, while current Onyx firmware expects width/height.
+        requestEpdMode(targetView, mode, delay, x, y, width - x, height - y)
     }
 
-    override fun resume() {}
-    override fun pause() {}
+    override fun resume() {
+        if (getMode() == "all") {
+            debouncerPrevented = false
+        }
+    }
+    override fun pause() {
+        if (getMode() == "all") {
+            debouncerPrevented = false
+        }
+    }
 }

--- a/app/src/main/java/org/koreader/launcher/device/epd/qualcomm/QualcommEPDController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/epd/qualcomm/QualcommEPDController.kt
@@ -39,10 +39,6 @@ abstract class QualcommEPDController {
                                 x: Int, y: Int, width: Int, height: Int) : Boolean
         {
             return try {
-                // We need to always call this, not sure why, if it's not called before
-                // system will refresh after us, it'll refresh anyway if user set
-                // Normal mode, or Regal mode works flawlessly otherwise
-                preventSystemRefresh()
                 // EpdController.refreshScreenRegion in onyxsdk
                 val refreshScreen = Class.forName("android.view.View").getMethod("refreshScreen",
                                         Integer.TYPE,


### PR DESCRIPTION
# Onyx: support BOOX all refresh mode

This changes `OnyxEPDController` from `full-only` to `all` mode.

BOOX may issue a delayed system refresh after an application refresh, which causes a second flash. Before KOReader sends its explicit refresh, the Onyx controller calls `ViewUpdateHelper.debouncer(false, 0, 0, 0, 0)`. This is an internal BOOX method, so `HiddenApiBypass` is needed on Android R and newer to allow the reflection call. `resumeBooxSystemRefresh()` is kept as a future hook for restoring the debouncer state, but it is not used yet.

The coordinate conversion follows the official BOOX SDK definition of `BaseDevice.refreshScreenRegion(View, left, top, width, height, UpdateMode)` ([onyxsdk-device 1.3.5.2](https://repo.boox.com/repository/maven-public/com/onyx/android/sdk/onyxsdk-device/1.3.5.2/onyxsdk-device-1.3.5.2.aar)). KOReader starts with `x, y, width, height`, but its Android framebuffer bridge sends `x, y, x + width, y + height`, and `MainActivity` forwards those values unchanged. The Onyx controller therefore converts the received right and bottom coordinates back to width and height with `width - x` and `height - y` before calling the region refresh method.

The BOOX-specific changes stay in `OnyxEPDController`; the shared Qualcomm controller is not used to handle the BOOX debouncer.

References:

- [BOOX OnyxAndroidDemo](https://github.com/onyx-intl/OnyxAndroidDemo)
- [BOOX EPD screen update documentation](https://github.com/onyx-intl/OnyxAndroidDemo/blob/master/doc/EPD-Screen-Update.md)  
- [BOOX EPD update modes](https://github.com/onyx-intl/OnyxAndroidDemo/blob/master/doc/EPD-Update-Mode.md)
- [AndroidHiddenApiBypass](https://github.com/LSPosed/AndroidHiddenApiBypass)

The `debouncer` method is not described in the public SDK. It was recovered from the BOOX T10C Plus firmware by decompiling `/system/framework/framework.jar` (`classes2.dex`), class `android.onyx.ViewUpdateHelper` (`ViewUpdateHelper.java`). The decompiled method has the signature `debouncer(boolean, int, int, int, int)` and writes its five arguments to the SurfaceFlinger debouncer transaction.

Tested on a BOOX device with EPUB documents.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/614)
<!-- Reviewable:end -->
