### PR TITLE
Add Onyx Boox Go 6 Gen 2 support

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -97,6 +97,7 @@ object DeviceInfo {
         ONYX_GO_103,
         ONYX_GO_COLOR7,
         ONYX_GO6,
+        ONYX_GO6GEN2,
         ONYX_GO7,
         ONYX_GO7GEN2,
         ONYX_JDREAD,
@@ -459,6 +460,10 @@ object DeviceInfo {
             // Onyx Boox Go 6
             BRAND == "onyx" && MODEL == "go6"
             -> Id.ONYX_GO6
+
+            // Onyx Boox Go 6 Gen II
+            BRAND == "onyx" && MODEL == "go6_2"
+            -> Id.ONYX_GO6GEN2
 
             // Onyx Boox Go 7
             BRAND == "onyx" && MODEL == "go7"

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -116,6 +116,7 @@ object EPDFactory {
                 DeviceInfo.Id.ONYX_GALILEO2,
                 DeviceInfo.Id.ONYX_GO_103,
                 DeviceInfo.Id.ONYX_GO6,
+                DeviceInfo.Id.ONYX_GO6GEN2,
                 DeviceInfo.Id.ONYX_GO7,
                 DeviceInfo.Id.ONYX_GO7GEN2,
                 DeviceInfo.Id.ONYX_KON_TIKI2,

--- a/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/LightsFactory.kt
@@ -22,6 +22,7 @@ object LightsFactory {
                 DeviceInfo.Id.ONYX_GALILEO2,
                 DeviceInfo.Id.ONYX_GO_COLOR7,
                 DeviceInfo.Id.ONYX_GO6,
+                DeviceInfo.Id.ONYX_GO6GEN2,
                 DeviceInfo.Id.ONYX_GO7GEN2,
                 DeviceInfo.Id.ONYX_NOTE_AIR_3,
                 DeviceInfo.Id.ONYX_NOTE_AIR_3C,


### PR DESCRIPTION
Adds support for the Onyx Boox Go 6 Gen 2.

The device reports `MODEL=go6_2`. `DeviceInfo.kt` already has `go6` for the Gen 1,
but the match is exact equality, so the Gen 2 falls through to the Generic lights
driver and frontlight control silently does nothing. This follows the existing
`gocolor7_2` -> `ONYX_GO7GEN2` handling for the Color 7 Gen 2.

### Verified on device

Both drivers confirmed with the built-in compatibility test (Developer options ->
Start compatibility test), not assumed from the Gen 1:

| test | driver | result |
|---|---|---|
| lights | `Onyx ADB (lights)` | brightness and warmth both working |
| e-ink | `Onyx/Qualcomm` | full refresh working |

`hidden_api_policy` was set to `1` per the wiki, as the Onyx ADB driver requires.

### Device info

```
Manufacturer: onyx
Brand: onyx
Model: go6_2
Device: boox
Product: boox
Hardware: qcom
Platform: bengal
Android 11 (API 30)
```

### Notes

The Go 6 is monochrome, so it is deliberately not added to `HAS_COLOR_SCREEN` —
only the *Color* 7 Gen 2 belongs there. No quirks were observed, so it is not
added to any `QUIRK_*` list either.

Reported at koreader/koreader#8482 (https://github.com/koreader/koreader/issues/8482#issuecomment-5462902909).

I have the device on hand and can test any changes.

### One caveat on the EPD side

`QualcommEPDController.preventSystemRefresh()` fails on this firmware:

```
E/EPD: java.lang.NoSuchMethodException: android.view.View.setWaveformAndScheme [int, int, int]
I/EPD: requested eink refresh, type: 98 x:0 y:0 w:1072 h:1365
```

`android.view.View.setWaveformAndScheme` does not exist here, so that call throws and
is swallowed by its own `catch`. The actual `refreshScreen(...)` reflection succeeds
and the refresh happens — the full refresh was confirmed visually on the device.

Per the comment in `requestEpdMode`, the consequence is that the system may also
refresh after us. I did not notice any problem in normal reading, but flagging it in
case you would rather I split the EPD part out and land only the lights change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/616)
<!-- Reviewable:end -->
