### PR TITLE
Add e-ink refresh support for Topjoy E602.

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -165,6 +165,7 @@ object DeviceInfo {
         TOLINO_VISION4,
         TOLINO_VISION5,
         TOLINO_VISION6,
+        TOPJOY_E602,
         XIAOMI_READER,
     }
 
@@ -732,6 +733,10 @@ object DeviceInfo {
             BRAND == STR_TOLINO && MODEL == "imx50_rdp"
             || MODEL == STR_TOLINO && (DEVICE == "tolino_vision2" || DEVICE == STR_NTX)
             -> Id.TOLINO
+
+            //Topjoy
+	        MANUFACTURER == "topjoy" && MODEL == "e602"
+	        -> Id.TOPJOY_E602
 
             // Xiaomi
             MANUFACTURER == "xiaomi" && BRAND == "xiaomi" && MODEL == "xiaomi_reader" && DEVICE == "rk3566_eink" && HARDWARE == "rk30board"

--- a/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
+++ b/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
@@ -734,7 +734,7 @@ object DeviceInfo {
             || MODEL == STR_TOLINO && (DEVICE == "tolino_vision2" || DEVICE == STR_NTX)
             -> Id.TOLINO
 
-            //Topjoy
+            // Topjoy
 	        MANUFACTURER == "topjoy" && MODEL == "e602"
 	        -> Id.TOPJOY_E602
 

--- a/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
+++ b/app/src/main/java/org/koreader/launcher/device/EPDFactory.kt
@@ -35,6 +35,7 @@ object EPDFactory {
                 DeviceInfo.Id.ONYX_C67,
                 DeviceInfo.Id.ONYX_MAGICBOOK,
                 DeviceInfo.Id.ONYX_MONTECRISTO3,
+                DeviceInfo.Id.TOPJOY_E602,
                 -> {
                     logController("Rockchip RK3026")
                     RK3026EPDController()


### PR DESCRIPTION
Hi everyone!

This PR adds e-ink refresh support for the Topjoy E602 e-reader.

**The Problem:**
Previously, KOReader did not recognize the Topjoy E602, so the e-ink screen couldn't perform a full page refresh.

**The Solution:**
I added the Topjoy E602 hardware identifiers and routing to the following files to enable the custom screen refresh drivers:
app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt
app/src/main/java/org/koreader/launcher/device/EPDFactory.kt

**Testing:**
Compiled a 32-bit (arm) debug APK.
Installed and tested on a physical Topjoy E602 device.
Verified that the "Full refresh rate" setting now appears in the E-ink settings menu and works perfectly on page turns without ghosting.

Note: This is my first time contributing (and my first time ever compiling an application!), so please let me know if I need to adjust formatting or anything else. Thank you for building such an incredible app!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/618)
<!-- Reviewable:end -->
