### PR TITLE
Nook GL4 Plus: make warmth survive B&N's colour temperature service

### DIFF
--- a/app/src/main/java/org/koreader/launcher/device/lights/NookGL4plusController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/NookGL4plusController.kt
@@ -14,14 +14,8 @@ import org.koreader.launcher.device.LightsInterface
  *   Sends action_set_color_temperature (0-100 scale); the service rescales to 0-10 for
  *   the lm3630a_led hardware and calls PowerManager.setFrontlightBrightnessColor() using
  *   its own DEVICE_POWER privilege.
- *
- * The same service owns B&N's Color Temperature Management (CTM), which re-applies a
- * warmth value on every SCREEN_ON. Its mode lives only in the service's shared prefs
- * (ctm_preference.xml, key ctm_mode) and defaults to -1 (CTM_MODE_DISABLE) when that
- * key is missing -- which is what an unclean shutdown leaves behind. In mode -1 the
- * service forces COLD_LIGHT (0) after every unlock and drops our stored value, so
- * warmth silently resets to cold. Mode 0 (CTM_MODE_MANUAL) instead re-applies the
- * value we set, so we assert it once per process before the first warmth write.
+ * The service also re-applies warmth on every SCREEN_ON, forcing it to cold unless its
+ * CTM mode is manual, so we assert that mode before the first warmth write.
  * see https://github.com/koreader/koreader/issues/14574
  */
 class NookGL4plusController : LightsInterface {
@@ -88,19 +82,15 @@ class NookGL4plusController : LightsInterface {
             Log.w(TAG, "warmth value out of range: $warmth")
             return
         }
-        // Skip redundant writes -- but never on the first call of the process: asserting
-        // CTM mode makes the service re-apply its own stored value, so it must always be
-        // followed by a warmth write that seeds that value with ours.
+        // Never skip the first write: it seeds the value the service re-applies.
         if (ctmModeAsserted && warmth == getWarmth(activity)) return
         Log.v(TAG, "Setting warmth to $warmth of $WARMTH_MAX")
         assertManualCtmMode(activity)
         setWarmthViaService(activity, warmth)
     }
 
-    /* Put B&N's Color Temperature Management into manual mode, so that the value written
-     * by setWarmthViaService() survives the next SCREEN_ON instead of being forced to cold.
-     * GlowLightService is an IntentService, so this is handled before the warmth intent
-     * that follows it. Idempotent, and a no-op cost after the first call. */
+    /* GlowLightService is an IntentService, so this is handled before the warmth intent
+     * that follows it. */
     private fun assertManualCtmMode(activity: Activity) {
         if (ctmModeAsserted) return
         try {

--- a/app/src/main/java/org/koreader/launcher/device/lights/NookGL4plusController.kt
+++ b/app/src/main/java/org/koreader/launcher/device/lights/NookGL4plusController.kt
@@ -14,6 +14,14 @@ import org.koreader.launcher.device.LightsInterface
  *   Sends action_set_color_temperature (0-100 scale); the service rescales to 0-10 for
  *   the lm3630a_led hardware and calls PowerManager.setFrontlightBrightnessColor() using
  *   its own DEVICE_POWER privilege.
+ *
+ * The same service owns B&N's Color Temperature Management (CTM), which re-applies a
+ * warmth value on every SCREEN_ON. Its mode lives only in the service's shared prefs
+ * (ctm_preference.xml, key ctm_mode) and defaults to -1 (CTM_MODE_DISABLE) when that
+ * key is missing -- which is what an unclean shutdown leaves behind. In mode -1 the
+ * service forces COLD_LIGHT (0) after every unlock and drops our stored value, so
+ * warmth silently resets to cold. Mode 0 (CTM_MODE_MANUAL) instead re-applies the
+ * value we set, so we assert it once per process before the first warmth write.
  * see https://github.com/koreader/koreader/issues/14574
  */
 class NookGL4plusController : LightsInterface {
@@ -27,9 +35,13 @@ class NookGL4plusController : LightsInterface {
         private const val GLOWLIGHT_SERVICE = "com.nook.partner.service.GlowLightService"
         private const val ACTION_SET_COLOR_TEMPERATURE = "action_set_color_temperature"
         private const val EXTRA_COLOR_TEMPERATURE = "extra_color_temperature"
+        private const val ACTION_SET_CTM_MODE = "action_set_ctm_mode"
+        private const val EXTRA_CTM_MODE = "extra_ctm_mode"
+        private const val CTM_MODE_MANUAL = 0
     }
 
     @Volatile private var currentWarmth: Int = MIN
+    @Volatile private var ctmModeAsserted: Boolean = false
 
     override fun getPlatform(): String = "nook"
     override fun hasFallback(): Boolean = false
@@ -76,9 +88,35 @@ class NookGL4plusController : LightsInterface {
             Log.w(TAG, "warmth value out of range: $warmth")
             return
         }
-        if (warmth == getWarmth(activity)) return
+        // Skip redundant writes -- but never on the first call of the process: asserting
+        // CTM mode makes the service re-apply its own stored value, so it must always be
+        // followed by a warmth write that seeds that value with ours.
+        if (ctmModeAsserted && warmth == getWarmth(activity)) return
         Log.v(TAG, "Setting warmth to $warmth of $WARMTH_MAX")
+        assertManualCtmMode(activity)
         setWarmthViaService(activity, warmth)
+    }
+
+    /* Put B&N's Color Temperature Management into manual mode, so that the value written
+     * by setWarmthViaService() survives the next SCREEN_ON instead of being forced to cold.
+     * GlowLightService is an IntentService, so this is handled before the warmth intent
+     * that follows it. Idempotent, and a no-op cost after the first call. */
+    private fun assertManualCtmMode(activity: Activity) {
+        if (ctmModeAsserted) return
+        try {
+            val intent = Intent(ACTION_SET_CTM_MODE).apply {
+                component = ComponentName(GLOWLIGHT_PACKAGE, GLOWLIGHT_SERVICE)
+                putExtra(EXTRA_CTM_MODE, CTM_MODE_MANUAL)
+            }
+            if (activity.startService(intent) != null) {
+                ctmModeAsserted = true
+                Log.v(TAG, "CTM mode set to manual")
+            } else {
+                Log.w(TAG, "GlowLightService unavailable, cannot set CTM mode")
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "setting CTM mode failed: $e")
+        }
     }
 
     private fun setWarmthViaService(activity: Activity, warmth: Int): Boolean {


### PR DESCRIPTION
## The symptom

On a Nook Glowlight 4 Plus (BNRV1300), frontlight warmth resets to cold on **every unlock**. Moving the warmth slider works until the screen goes off; on the next wake the light is cold again, and no amount of re-adjusting makes it stick. The device I hit this on lost its warmth after an unclean shutdown and never recovered it.

## Cause

`GlowLightService` — the service this controller already uses for warmth — also hosts B&N's Color Temperature Management (CTM), which re-applies a warmth value on **every `SCREEN_ON`**, after the framework has restored `screen_brightness_color`. So it wins over anything we write.

CTM's mode is persisted only in the service's own shared prefs (`ctm_preference.xml`, key `ctm_mode`), and `getCTMMode()` returns `-1` (`CTM_MODE_DISABLE`) when that key is missing. An unclean shutdown loses the file; the service then recreates it containing only `color_temperature` — with **no `ctm_mode` key at all**. In mode `-1`, `setupCTM()` forces `COLD_LIGHT` (0 on Emperor), and `action_set_color_temperature` does not persist either, because `saveColorTemperature()` routes to a `ScheduleMode` whose save is a no-op with null sunrise/sunset.

Reproduced end to end — both by killing the service with the prefs file removed, and by a real reboot:

```
CTMService: setupCTM:-1
LightsService: kk-1-brightness(color):0
```

Removing just that key reproduces the symptom exactly, and nothing in the system ever restores it.

## The fix

Assert `CTM_MODE_MANUAL` once per process, immediately before the first warmth write. In manual mode the same warmth intent also writes `manual_color_temperature`, so the value we set is the one re-applied at the next unlock.

The mode intent must always be followed by a warmth write — asserting the mode makes the service re-apply its *own* stored value — which is why the first call deliberately skips the redundant-write early return.

After the change:

```
Lights  : Setting warmth to 10 of 10
Lights  : CTM mode set to manual
CTMService: setupCTM:0
LightsService: kk-1-brightness(color):10
```

## Verified on hardware (BNRV1300)

- Repairs a genuinely broken device; `ctm_mode=0` reappears in the prefs.
- Survives a screen cycle and a full reboot.
- The assert fires exactly once per process — subsequent slider steps log no further mode intent.

## Notes for review

- **Why the assert is unconditional.** Running KOReader on this device requires disabling `bn.ereader`, which otherwise takes over the whole device. CTM's AUTO and SCHEDULE modes source their schedule from `bn.ereader`'s location service, so with it disabled they cannot compute anything and degrade to re-applying the stored value — behaviourally identical to manual. I measured that: in modes 1 and 2 a warmth write survives a screen cycle exactly as it does in mode 0. Only mode `-1` is broken.
- **One visible transient.** Asserting the mode makes the service re-apply its stored value ~40 ms before ours lands, so there is a brief flash to the old warmth on the first write. On a device in the broken state that stored value is 0, so it reads as a momentary cold flicker at startup.
- `ctmModeAsserted` is a plain `@Volatile` flag rather than an `AtomicBoolean`. Two threads racing it would send a duplicate mode intent, which is idempotent — happy to switch it if you'd prefer.
- On its own this makes a warmth write *stick*; it does not restore warmth by itself, because nothing calls `setWarmth()` at startup. Its companion is koreader/koreader#16004, which does exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/android-luajit-launcher/620)
<!-- Reviewable:end -->
